### PR TITLE
Spec: Users, EmailAddresses, Verifications

### DIFF
--- a/components/parameters/IdempotencyKeyHeader.yaml
+++ b/components/parameters/IdempotencyKeyHeader.yaml
@@ -1,0 +1,11 @@
+name: Idempotency-Key
+in: header
+description: |
+  Caller-supplied UUID for `POST` mutations. The server caches the response
+  for 24 hours; replays with the same key return the cached response without
+  re-executing. A different request body under the same key returns `409`.
+required: false
+schema:
+  type: string
+  minLength: 1
+  maxLength: 255

--- a/components/parameters/LimitParam.yaml
+++ b/components/parameters/LimitParam.yaml
@@ -1,0 +1,9 @@
+name: limit
+in: query
+description: Maximum rows to return. Default `10`, maximum `500`.
+required: false
+schema:
+  type: integer
+  minimum: 1
+  maximum: 500
+  default: 10

--- a/components/parameters/OffsetParam.yaml
+++ b/components/parameters/OffsetParam.yaml
@@ -1,0 +1,8 @@
+name: offset
+in: query
+description: Rows to skip before returning results.
+required: false
+schema:
+  type: integer
+  minimum: 0
+  default: 0

--- a/components/parameters/OrderByParam.yaml
+++ b/components/parameters/OrderByParam.yaml
@@ -1,0 +1,9 @@
+name: order_by
+in: query
+description: |
+  Sort key prefixed with `+` (ascending) or `-` (descending). Per-resource
+  endpoints document the allowed keys.
+required: false
+schema:
+  type: string
+  examples: ["+created_at", "-last_active_at"]

--- a/components/responses/BadRequest.yaml
+++ b/components/responses/BadRequest.yaml
@@ -1,0 +1,5 @@
+description: Validation or shape error.
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/ErrorResponse.yaml

--- a/components/responses/Conflict.yaml
+++ b/components/responses/Conflict.yaml
@@ -1,0 +1,5 @@
+description: State conflict — e.g. an `Idempotency-Key` reuse with a different request body.
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/ErrorResponse.yaml

--- a/components/responses/Forbidden.yaml
+++ b/components/responses/Forbidden.yaml
@@ -1,0 +1,5 @@
+description: Authenticated but not authorized for the action.
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/ErrorResponse.yaml

--- a/components/responses/NotFound.yaml
+++ b/components/responses/NotFound.yaml
@@ -1,0 +1,5 @@
+description: Resource does not exist (or is not visible to the caller).
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/ErrorResponse.yaml

--- a/components/responses/TooManyRequests.yaml
+++ b/components/responses/TooManyRequests.yaml
@@ -1,0 +1,10 @@
+description: Rate limit exhausted; consult `Retry-After`.
+headers:
+  Retry-After:
+    schema:
+      type: integer
+    description: Seconds until the next token in the bucket.
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/ErrorResponse.yaml

--- a/components/responses/Unauthorized.yaml
+++ b/components/responses/Unauthorized.yaml
@@ -1,0 +1,5 @@
+description: Missing or invalid credential.
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/ErrorResponse.yaml

--- a/components/responses/UnprocessableEntity.yaml
+++ b/components/responses/UnprocessableEntity.yaml
@@ -1,0 +1,5 @@
+description: Domain-level validation failure.
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/ErrorResponse.yaml

--- a/components/schemas/EmailAddress.yaml
+++ b/components/schemas/EmailAddress.yaml
@@ -1,0 +1,60 @@
+type: object
+description: |
+  An email identifier owned by a `User`. A user may have many email
+  addresses; exactly one is the primary (referenced by
+  `User.primary_email_address_id`). A new address starts unverified
+  and becomes a usable sign-in identifier once `verification.status`
+  reaches `verified`.
+required:
+  - id
+  - object
+  - email_address
+  - verification
+  - linked_to
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: "./Id.yaml"
+  object:
+    type: string
+    const: email_address
+  email_address:
+    type: string
+    format: email
+    maxLength: 254
+    description: The address itself, lower-cased and trimmed by the server.
+  verification:
+    description: |
+      Current verification challenge for this address, or `null` if the
+      address was created server-side already verified (e.g. via BAPI
+      with `verified: true`).
+    oneOf:
+      - $ref: "./Verification.yaml"
+      - type: "null"
+  linked_to:
+    type: array
+    description: |
+      External / enterprise account links that surfaced this address.
+      Empty in v0.1; populated as connections land.
+    items:
+      type: object
+      required: [id, type]
+      additionalProperties: false
+      properties:
+        id:
+          $ref: "./Id.yaml"
+        type:
+          type: string
+          description: Account type (e.g. `oauth_google`, `enterprise_account`).
+  reserved:
+    type: boolean
+    default: false
+    description: |
+      `true` when the address is held by an `AllowlistIdentifier` /
+      `Invitation` and is not yet attached to a user account.
+  created_at:
+    $ref: "./Timestamp.yaml"
+  updated_at:
+    $ref: "./Timestamp.yaml"

--- a/components/schemas/EmailAddressCreateRequest.yaml
+++ b/components/schemas/EmailAddressCreateRequest.yaml
@@ -1,0 +1,24 @@
+type: object
+description: Body for `POST /v1/email_addresses`.
+required: [user_id, email_address]
+additionalProperties: false
+properties:
+  user_id:
+    type: string
+    description: ID of the `User` that will own this address.
+  email_address:
+    type: string
+    format: email
+    maxLength: 254
+  verified:
+    type: boolean
+    default: false
+    description: |
+      When `true`, the address is created with
+      `verification.status = "verified"` and no challenge is issued.
+  primary:
+    type: boolean
+    default: false
+    description: |
+      When `true` (and the address is verified), make it the user's
+      primary email address.

--- a/components/schemas/EmailAddressUpdateRequest.yaml
+++ b/components/schemas/EmailAddressUpdateRequest.yaml
@@ -1,0 +1,14 @@
+type: object
+description: Body for `PATCH /v1/email_addresses/{email_address_id}`.
+additionalProperties: false
+properties:
+  verified:
+    type: boolean
+    description: |
+      Set to `true` to mark the address verified server-side without
+      issuing a challenge. Idempotent.
+  primary:
+    type: boolean
+    description: |
+      When `true` (and the address is verified), make it the owning
+      user's primary email address.

--- a/components/schemas/Error.yaml
+++ b/components/schemas/Error.yaml
@@ -1,0 +1,22 @@
+type: object
+required: [code, message, long_message]
+additionalProperties: false
+properties:
+  code:
+    type: string
+    description: |
+      Stable machine-readable code. SDKs match on this string; never
+      parse `message` or `long_message`.
+    examples: [form_password_incorrect, verification_expired, rate_limit_exceeded]
+  message:
+    type: string
+    description: Short, human-readable summary.
+  long_message:
+    type: string
+    description: |
+      Long-form, end-user-friendly message including next-step guidance.
+      Safe to render in the UI.
+  meta:
+    type: object
+    additionalProperties: true
+    description: Per-code structured context (param name, attempt count, retry-after, …).

--- a/components/schemas/ErrorResponse.yaml
+++ b/components/schemas/ErrorResponse.yaml
@@ -1,0 +1,16 @@
+type: object
+required: [errors]
+additionalProperties: false
+properties:
+  errors:
+    type: array
+    minItems: 1
+    items:
+      $ref: ./Error.yaml
+  trace_id:
+    type: [string, "null"]
+    description: |
+      Server-generated request id. Same value goes into the audit log and
+      into the `X-Authn-Request-Id` response header, so customers can
+      paste it back to support.
+    examples: [req_01HKX9SY9V7H7TF8C8K7J9X4ZD]

--- a/components/schemas/Id.yaml
+++ b/components/schemas/Id.yaml
@@ -1,0 +1,9 @@
+type: string
+pattern: "^[a-z][a-z0-9_]{0,9}_[0-9A-HJKMNP-TV-Z]{26}$"
+description: |
+  A prefixed ULID. The prefix indicates the resource type
+  (`user_`, `org_`, `sess_`, `env_`, …); the suffix is a 26-character
+  Crockford-base32 ULID.
+examples:
+  - user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+  - sess_01HKX9SY9V7H7TF8C8K7J9X4ZC

--- a/components/schemas/Metadata.yaml
+++ b/components/schemas/Metadata.yaml
@@ -1,0 +1,13 @@
+type: object
+additionalProperties: true
+description: |
+  Free-form JSON object attached to a resource.
+
+  Three flavours exist:
+
+  - `public_metadata` — readable everywhere; writable only via BAPI.
+  - `private_metadata` — readable only via BAPI; never returned to FAPI;
+    never logged or embedded in JWT claims unless an explicit
+    `JwtTemplate` references it (post-v0.7).
+  - `unsafe_metadata` — readable everywhere; writable from FAPI by the
+    end user themselves.

--- a/components/schemas/PaginatedList.yaml
+++ b/components/schemas/PaginatedList.yaml
@@ -1,0 +1,14 @@
+type: object
+required: [data, total_count]
+properties:
+  data:
+    type: array
+    items: {}
+  total_count:
+    type: integer
+    format: int64
+    minimum: 0
+    description: Total number of rows matching the filter, ignoring `limit`/`offset`.
+description: |
+  Wrapper for paginated list endpoints. Concrete responses use `allOf` to
+  narrow `data[]` to the specific resource schema.

--- a/components/schemas/Timestamp.yaml
+++ b/components/schemas/Timestamp.yaml
@@ -1,0 +1,4 @@
+type: integer
+format: int64
+minimum: 0
+description: Unix timestamp in milliseconds.

--- a/components/schemas/User.yaml
+++ b/components/schemas/User.yaml
@@ -1,0 +1,178 @@
+type: object
+description: |
+  An end-user identity within an `Environment`. Carries the canonical
+  identifier set (email addresses, phone numbers, external accounts,
+  passkeys), the auth-state flags (password, MFA), the moderation state
+  (banned, locked), the lifecycle timestamps, and the three flavours of
+  metadata.
+
+  Phone numbers, external accounts, enterprise accounts, and passkeys
+  are present in the shape today (as empty arrays in v0.1) so SDKs can
+  generate stable types up front; the corresponding endpoints land in
+  later milestones (v0.4 / v0.5 / v0.6).
+required:
+  - id
+  - object
+  - email_addresses
+  - phone_numbers
+  - external_accounts
+  - enterprise_accounts
+  - passkeys
+  - has_image
+  - password_enabled
+  - two_factor_enabled
+  - totp_enabled
+  - backup_code_enabled
+  - banned
+  - locked
+  - delete_self_enabled
+  - public_metadata
+  - private_metadata
+  - unsafe_metadata
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: "./Id.yaml"
+  object:
+    type: string
+    const: user
+  external_id:
+    type: [string, "null"]
+    maxLength: 255
+    description: |
+      Caller-supplied stable identifier. Indexed and unique within the
+      environment. Useful for migrating users from another system.
+  username:
+    type: [string, "null"]
+    minLength: 4
+    maxLength: 64
+  first_name:
+    type: [string, "null"]
+    maxLength: 256
+  last_name:
+    type: [string, "null"]
+    maxLength: 256
+  image_url:
+    type: [string, "null"]
+    format: uri
+    description: |
+      Cached CDN URL for the user's profile image. `null` when
+      `has_image` is `false`.
+  has_image:
+    type: boolean
+    description: |
+      Convenience flag derived from `image_url`. SDKs hide UI affordances
+      that depend on a real avatar based on this field.
+  primary_email_address_id:
+    type: [string, "null"]
+    description: |
+      Pointer into `email_addresses[]`. `null` for users created with no
+      verified email (e.g. username-only).
+  primary_phone_number_id:
+    type: [string, "null"]
+    description: |
+      Pointer into `phone_numbers[]`. v0.1 always returns `null` (phone
+      identifiers ship in v0.4).
+  email_addresses:
+    type: array
+    items:
+      $ref: "./EmailAddress.yaml"
+  phone_numbers:
+    type: array
+    description: |
+      Reserved for v0.4. Always returned as `[]` in v0.1.
+    items:
+      type: object
+      additionalProperties: true
+  external_accounts:
+    type: array
+    description: |
+      Reserved for v0.4 (OAuth connections). Always `[]` in v0.1.
+    items:
+      type: object
+      additionalProperties: true
+  enterprise_accounts:
+    type: array
+    description: |
+      Reserved for v0.6 (enterprise SSO). Always `[]` in v0.1.
+    items:
+      type: object
+      additionalProperties: true
+  passkeys:
+    type: array
+    description: |
+      Reserved for v0.5 (WebAuthn). Always `[]` in v0.1.
+    items:
+      type: object
+      additionalProperties: true
+  password_enabled:
+    type: boolean
+    description: |
+      `true` when the user has a stored password digest. Resetting via
+      "forgot password" flips this to `true` after the new password is set.
+  two_factor_enabled:
+    type: boolean
+    description: |
+      `true` when at least one second factor is active. Always `false` in
+      v0.1 (MFA ships in v0.3).
+  totp_enabled:
+    type: boolean
+    description: Always `false` in v0.1 (TOTP ships in v0.3).
+  backup_code_enabled:
+    type: boolean
+    description: Always `false` in v0.1 (backup codes ship in v0.3).
+  mfa_enabled_at:
+    type: [integer, "null"]
+    format: int64
+    minimum: 0
+    description: When MFA was first enabled. `null` until v0.3.
+  mfa_disabled_at:
+    type: [integer, "null"]
+    format: int64
+    minimum: 0
+    description: When MFA was last disabled. `null` until v0.3.
+  banned:
+    type: boolean
+    description: |
+      `true` when the user is permanently blocked from authenticating.
+      Toggle via `POST /v1/users/{id}/ban` and `/unban`.
+  locked:
+    type: boolean
+    description: |
+      `true` when the user is temporarily locked out (e.g. brute-force
+      protection). Toggle via `POST /v1/users/{id}/lock` and `/unlock`.
+  lockout_expires_at:
+    type: [integer, "null"]
+    format: int64
+    minimum: 0
+    description: |
+      Unix ms after which a `locked` user is automatically unlocked.
+      `null` when not locked or the lock is indefinite.
+  last_sign_in_at:
+    type: [integer, "null"]
+    format: int64
+    minimum: 0
+  last_active_at:
+    type: [integer, "null"]
+    format: int64
+    minimum: 0
+  delete_self_enabled:
+    type: boolean
+    description: |
+      Mirrors the environment-level setting at the time of read; tells
+      the FAPI whether the user can call `DELETE /v1/me`.
+  locale:
+    type: [string, "null"]
+    description: BCP-47 tag (e.g. `en-US`). Used to localize emails sent to the user.
+  public_metadata:
+    $ref: "./Metadata.yaml"
+  private_metadata:
+    $ref: "./Metadata.yaml"
+  unsafe_metadata:
+    $ref: "./Metadata.yaml"
+  created_at:
+    $ref: "./Timestamp.yaml"
+  updated_at:
+    $ref: "./Timestamp.yaml"

--- a/components/schemas/UserCreateRequest.yaml
+++ b/components/schemas/UserCreateRequest.yaml
@@ -1,0 +1,82 @@
+type: object
+description: |
+  Body for `POST /v1/users`. All fields are optional, but the resulting
+  user must be addressable: at least one of `email_address`,
+  `phone_number`, `username`, or `external_id` is required by the
+  server.
+additionalProperties: false
+properties:
+  external_id:
+    type: string
+    maxLength: 255
+    description: Caller-supplied stable identifier. Must be unique in the environment.
+  username:
+    type: string
+    minLength: 4
+    maxLength: 64
+  first_name:
+    type: string
+    maxLength: 256
+  last_name:
+    type: string
+    maxLength: 256
+  email_address:
+    type: array
+    description: |
+      Initial email addresses for the user. Each is created with
+      `verification.status = "verified"` (BAPI is privileged).
+    items:
+      type: string
+      format: email
+      maxLength: 254
+    minItems: 1
+  phone_number:
+    type: array
+    description: Reserved for v0.4. Rejected with HTTP 422 in v0.1.
+    items:
+      type: string
+  password:
+    type: string
+    minLength: 8
+    description: |
+      Plaintext password. Server hashes with the configured `password_hasher`
+      before storing. Mutually exclusive with `password_digest`.
+  password_digest:
+    type: string
+    description: |
+      Pre-hashed password (for migrations). Format determined by
+      `password_hasher`. Mutually exclusive with `password`.
+  password_hasher:
+    type: string
+    enum: [bcrypt, scrypt, argon2id, pbkdf2_sha256, md5, sha256]
+    description: |
+      Identifies the algorithm that produced `password_digest`. Required
+      whenever `password_digest` is set.
+  skip_password_checks:
+    type: boolean
+    default: false
+    description: |
+      When `true`, accept a password that doesn't satisfy the environment's
+      strength policy. Useful for migrations.
+  skip_password_requirement:
+    type: boolean
+    default: false
+    description: |
+      When `true`, allow the user to be created with no password even if
+      the environment requires one.
+  public_metadata:
+    $ref: "./Metadata.yaml"
+  private_metadata:
+    $ref: "./Metadata.yaml"
+  unsafe_metadata:
+    $ref: "./Metadata.yaml"
+  locale:
+    type: string
+    description: BCP-47 tag.
+  created_at:
+    type: integer
+    format: int64
+    minimum: 0
+    description: |
+      Override the user's creation timestamp. Only honored when the
+      caller is migrating users from another system.

--- a/components/schemas/UserUpdateRequest.yaml
+++ b/components/schemas/UserUpdateRequest.yaml
@@ -1,0 +1,55 @@
+type: object
+description: |
+  Body for `PATCH /v1/users/{user_id}`. Every field is optional;
+  unspecified fields are left untouched. Sending `null` clears a
+  nullable field.
+additionalProperties: false
+properties:
+  external_id:
+    type: [string, "null"]
+    maxLength: 255
+  username:
+    type: [string, "null"]
+    minLength: 4
+    maxLength: 64
+  first_name:
+    type: [string, "null"]
+    maxLength: 256
+  last_name:
+    type: [string, "null"]
+    maxLength: 256
+  primary_email_address_id:
+    type: [string, "null"]
+    description: |
+      Must reference an `email_address_id` already attached to this user
+      and verified.
+  primary_phone_number_id:
+    type: [string, "null"]
+    description: Reserved for v0.4. Rejected with HTTP 422 in v0.1.
+  password:
+    type: string
+    minLength: 8
+    description: |
+      Replace the user's password. Mutually exclusive with `password_digest`.
+  password_digest:
+    type: string
+  password_hasher:
+    type: string
+    enum: [bcrypt, scrypt, argon2id, pbkdf2_sha256, md5, sha256]
+  skip_password_checks:
+    type: boolean
+    default: false
+  sign_out_of_other_sessions:
+    type: boolean
+    default: false
+    description: |
+      When `true` and `password` (or `password_digest`) is also provided,
+      revoke every active session except (optionally) the caller's own.
+  public_metadata:
+    $ref: "./Metadata.yaml"
+  private_metadata:
+    $ref: "./Metadata.yaml"
+  unsafe_metadata:
+    $ref: "./Metadata.yaml"
+  locale:
+    type: [string, "null"]

--- a/components/schemas/Verification.yaml
+++ b/components/schemas/Verification.yaml
@@ -1,0 +1,71 @@
+type: object
+description: |
+  The state of a verification challenge attached to an identifier
+  (`EmailAddress`, eventually `PhoneNumber`, …) or an in-progress
+  `SignInAttempt` / `SignUpAttempt` factor.
+
+  `status` is the consumer-visible lifecycle. `strategy` records
+  *how* the challenge is being completed; the set of allowed strategies
+  grows with each milestone.
+required: [status, strategy, attempts]
+additionalProperties: false
+properties:
+  status:
+    type: string
+    enum:
+      - unverified
+      - verified
+      - transferable
+      - failed
+      - expired
+    description: |
+      - `unverified` — challenge created, no successful attempt yet.
+      - `verified` — challenge succeeded; the parent identifier is now trusted.
+      - `transferable` — succeeded against an OAuth provider but the local
+        account doesn't exist yet (used during sign-up).
+      - `failed` — too many wrong attempts; the challenge can no longer be retried.
+      - `expired` — `expire_at` is in the past; the challenge must be re-issued.
+  strategy:
+    type: string
+    description: |
+      How this verification is being completed. v0.1 issues `email_code`,
+      `reset_password_email_code`, `ticket`, `password`, and `transfer`;
+      OAuth, phone, passkeys, and TOTP land in later milestones.
+    examples:
+      - email_code
+      - reset_password_email_code
+      - password
+      - ticket
+      - transfer
+      - oauth_google
+      - phone_code
+      - passkey
+      - totp
+      - backup_code
+  attempts:
+    type: integer
+    minimum: 0
+    description: Number of confirm attempts made against this challenge.
+  expire_at:
+    type: [integer, "null"]
+    format: int64
+    minimum: 0
+    description: |
+      Unix ms after which the challenge can no longer be confirmed. `null`
+      for strategies that don't expire (e.g. a `password` factor).
+  external_verification_redirect_url:
+    type: [string, "null"]
+    format: uri
+    description: |
+      For redirect-based strategies (OAuth, magic-link), the URL the
+      browser should hand off to. `null` otherwise.
+  nonce:
+    type: [string, "null"]
+    description: |
+      Strategy-specific opaque blob. For OAuth this is the state nonce;
+      for passkey it's the authenticator challenge.
+  error:
+    description: Last error returned by the strategy, if any.
+    oneOf:
+      - $ref: "./Error.yaml"
+      - type: "null"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -84,7 +84,31 @@ tags:
 security:
   - bearer_secret_key: []
 
-paths: {}
+paths:
+  /v1/users:
+    $ref: ./paths/users.yaml
+  /v1/users/count:
+    $ref: ./paths/users-count.yaml
+  /v1/users/{user_id}:
+    $ref: ./paths/user.yaml
+  /v1/users/{user_id}/ban:
+    $ref: ./paths/user-ban.yaml
+  /v1/users/{user_id}/unban:
+    $ref: ./paths/user-unban.yaml
+  /v1/users/{user_id}/lock:
+    $ref: ./paths/user-lock.yaml
+  /v1/users/{user_id}/unlock:
+    $ref: ./paths/user-unlock.yaml
+  /v1/users/{user_id}/profile_image:
+    $ref: ./paths/user-profile-image.yaml
+  /v1/users/{user_id}/metadata:
+    $ref: ./paths/user-metadata.yaml
+  /v1/users/{user_id}/verify_password:
+    $ref: ./paths/user-verify-password.yaml
+  /v1/email_addresses:
+    $ref: ./paths/email-addresses.yaml
+  /v1/email_addresses/{email_address_id}:
+    $ref: ./paths/email-address.yaml
 
 components:
   securitySchemes:
@@ -117,184 +141,31 @@ components:
         this.
 
   schemas:
-    Id:
-      type: string
-      pattern: "^[a-z][a-z0-9_]{0,9}_[0-9A-HJKMNP-TV-Z]{26}$"
-      description: |
-        A prefixed ULID. The prefix indicates the resource type
-        (`user_`, `org_`, `sess_`, `env_`, …); the suffix is a 26-character
-        Crockford-base32 ULID.
-      examples:
-        - user_01HKX9SY9V7H7TF8C8K7J9X4ZB
-        - sess_01HKX9SY9V7H7TF8C8K7J9X4ZC
-
-    Timestamp:
-      type: integer
-      format: int64
-      minimum: 0
-      description: Unix timestamp in milliseconds.
-
-    Metadata:
-      type: object
-      additionalProperties: true
-      description: |
-        Free-form JSON object attached to a resource.
-
-        Three flavours exist:
-
-        - `public_metadata` — readable everywhere; writable only via BAPI.
-        - `private_metadata` — readable only via BAPI; never returned to FAPI;
-          never logged or embedded in JWT claims unless an explicit
-          `JwtTemplate` references it (post-v0.7).
-        - `unsafe_metadata` — readable everywhere; writable from FAPI by the
-          end user themselves.
-
-    PaginatedList:
-      type: object
-      required: [data, total_count]
-      properties:
-        data:
-          type: array
-          items: {}
-        total_count:
-          type: integer
-          format: int64
-          minimum: 0
-          description: Total number of rows matching the filter, ignoring `limit`/`offset`.
-      description: |
-        Wrapper for paginated list endpoints. Concrete responses use `allOf` to
-        narrow `data[]` to the specific resource schema.
-
-    Error:
-      type: object
-      required: [code, message, long_message]
-      additionalProperties: false
-      properties:
-        code:
-          type: string
-          description: |
-            Stable machine-readable code. SDKs match on this string; never
-            parse `message` or `long_message`.
-          examples: [form_password_incorrect, verification_expired, rate_limit_exceeded]
-        message:
-          type: string
-          description: Short, human-readable summary.
-        long_message:
-          type: string
-          description: |
-            Long-form, end-user-friendly message including next-step guidance.
-            Safe to render in the UI.
-        meta:
-          type: object
-          additionalProperties: true
-          description: Per-code structured context (param name, attempt count, retry-after, …).
-
-    ErrorResponse:
-      type: object
-      required: [errors]
-      additionalProperties: false
-      properties:
-        errors:
-          type: array
-          minItems: 1
-          items:
-            $ref: "#/components/schemas/Error"
-        trace_id:
-          type: [string, "null"]
-          description: |
-            Server-generated request id. Same value goes into the audit log and
-            into the `X-Authn-Request-Id` response header, so customers can
-            paste it back to support.
-          examples: [req_01HKX9SY9V7H7TF8C8K7J9X4ZD]
+    Id:                        { $ref: ./components/schemas/Id.yaml }
+    Timestamp:                 { $ref: ./components/schemas/Timestamp.yaml }
+    Metadata:                  { $ref: ./components/schemas/Metadata.yaml }
+    PaginatedList:             { $ref: ./components/schemas/PaginatedList.yaml }
+    Error:                     { $ref: ./components/schemas/Error.yaml }
+    ErrorResponse:             { $ref: ./components/schemas/ErrorResponse.yaml }
+    Verification:              { $ref: ./components/schemas/Verification.yaml }
+    EmailAddress:              { $ref: ./components/schemas/EmailAddress.yaml }
+    User:                      { $ref: ./components/schemas/User.yaml }
+    UserCreateRequest:         { $ref: ./components/schemas/UserCreateRequest.yaml }
+    UserUpdateRequest:         { $ref: ./components/schemas/UserUpdateRequest.yaml }
+    EmailAddressCreateRequest: { $ref: ./components/schemas/EmailAddressCreateRequest.yaml }
+    EmailAddressUpdateRequest: { $ref: ./components/schemas/EmailAddressUpdateRequest.yaml }
 
   responses:
-    BadRequest:
-      description: Validation or shape error.
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorResponse"
-    Unauthorized:
-      description: Missing or invalid credential.
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorResponse"
-    Forbidden:
-      description: Authenticated but not authorized for the action.
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorResponse"
-    NotFound:
-      description: Resource does not exist (or is not visible to the caller).
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorResponse"
-    Conflict:
-      description: State conflict — e.g. an `Idempotency-Key` reuse with a different request body.
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorResponse"
-    UnprocessableEntity:
-      description: Domain-level validation failure.
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorResponse"
-    TooManyRequests:
-      description: Rate limit exhausted; consult `Retry-After`.
-      headers:
-        Retry-After:
-          schema:
-            type: integer
-          description: Seconds until the next token in the bucket.
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorResponse"
+    BadRequest:           { $ref: ./components/responses/BadRequest.yaml }
+    Unauthorized:         { $ref: ./components/responses/Unauthorized.yaml }
+    Forbidden:            { $ref: ./components/responses/Forbidden.yaml }
+    NotFound:             { $ref: ./components/responses/NotFound.yaml }
+    Conflict:             { $ref: ./components/responses/Conflict.yaml }
+    UnprocessableEntity:  { $ref: ./components/responses/UnprocessableEntity.yaml }
+    TooManyRequests:      { $ref: ./components/responses/TooManyRequests.yaml }
 
   parameters:
-    LimitParam:
-      name: limit
-      in: query
-      description: Maximum rows to return. Default `10`, maximum `500`.
-      required: false
-      schema:
-        type: integer
-        minimum: 1
-        maximum: 500
-        default: 10
-    OffsetParam:
-      name: offset
-      in: query
-      description: Rows to skip before returning results.
-      required: false
-      schema:
-        type: integer
-        minimum: 0
-        default: 0
-    OrderByParam:
-      name: order_by
-      in: query
-      description: |
-        Sort key prefixed with `+` (ascending) or `-` (descending). Per-resource
-        endpoints document the allowed keys.
-      required: false
-      schema:
-        type: string
-        examples: ["+created_at", "-last_active_at"]
-    IdempotencyKeyHeader:
-      name: Idempotency-Key
-      in: header
-      description: |
-        Caller-supplied UUID for `POST` mutations. The server caches the response
-        for 24 hours; replays with the same key return the cached response without
-        re-executing. A different request body under the same key returns `409`.
-      required: false
-      schema:
-        type: string
-        minLength: 1
-        maxLength: 255
+    LimitParam:           { $ref: ./components/parameters/LimitParam.yaml }
+    OffsetParam:          { $ref: ./components/parameters/OffsetParam.yaml }
+    OrderByParam:         { $ref: ./components/parameters/OrderByParam.yaml }
+    IdempotencyKeyHeader: { $ref: ./components/parameters/IdempotencyKeyHeader.yaml }

--- a/paths/email-address.yaml
+++ b/paths/email-address.yaml
@@ -1,0 +1,63 @@
+parameters:
+  - name: email_address_id
+    in: path
+    required: true
+    description: ID of the email address.
+    schema: { $ref: "../components/schemas/Id.yaml" }
+
+get:
+  operationId: getEmailAddress
+  summary: Get an email address
+  description: Fetch a single `EmailAddress` by ID.
+  tags: [Email Addresses]
+  responses:
+    "200":
+      description: The email address.
+      content:
+        application/json:
+          schema: { $ref: "../components/schemas/EmailAddress.yaml" }
+    "401": { $ref: "../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../components/responses/NotFound.yaml" }
+
+patch:
+  operationId: updateEmailAddress
+  summary: Update an email address
+  description: |
+    Mark the address verified server-side or promote it to the user's
+    primary address. Sending an empty body is a no-op.
+  tags: [Email Addresses]
+  parameters:
+    - $ref: "../components/parameters/IdempotencyKeyHeader.yaml"
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: "../components/schemas/EmailAddressUpdateRequest.yaml" }
+        examples:
+          promote:
+            summary: Mark verified and make primary
+            value: { verified: true, primary: true }
+  responses:
+    "200":
+      description: The updated email address.
+      content:
+        application/json:
+          schema: { $ref: "../components/schemas/EmailAddress.yaml" }
+    "401": { $ref: "../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../components/responses/NotFound.yaml" }
+    "422": { $ref: "../components/responses/UnprocessableEntity.yaml" }
+
+delete:
+  operationId: deleteEmailAddress
+  summary: Delete an email address
+  description: |
+    Permanently remove the address from the user. The owning user must
+    have at least one other identifier remaining; deleting the only
+    identifier returns `422`.
+  tags: [Email Addresses]
+  responses:
+    "204":
+      description: Deleted.
+    "401": { $ref: "../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../components/responses/NotFound.yaml" }
+    "422": { $ref: "../components/responses/UnprocessableEntity.yaml" }

--- a/paths/email-addresses.yaml
+++ b/paths/email-addresses.yaml
@@ -1,0 +1,58 @@
+post:
+  operationId: createEmailAddress
+  summary: Create an email address
+  description: |
+    Attach a new email address to a user. By default the address is
+    created unverified and a verification challenge is issued (email
+    code). Pass `verified: true` to skip the challenge — the BAPI is
+    privileged.
+  tags: [Email Addresses]
+  parameters:
+    - $ref: "../components/parameters/IdempotencyKeyHeader.yaml"
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: "../components/schemas/EmailAddressCreateRequest.yaml" }
+        examples:
+          self_serve:
+            summary: Add an unverified address (issues a code)
+            value:
+              user_id: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+              email_address: jane.alt@acme.com
+          server_verified:
+            summary: Add an already-verified address and make it primary
+            value:
+              user_id: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+              email_address: jane@acme.com
+              verified: true
+              primary: true
+  responses:
+    "201":
+      description: Email address created.
+      content:
+        application/json:
+          schema: { $ref: "../components/schemas/EmailAddress.yaml" }
+          examples:
+            unverified:
+              value:
+                id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE
+                object: email_address
+                email_address: jane.alt@acme.com
+                verification:
+                  status: unverified
+                  strategy: email_code
+                  attempts: 0
+                  expire_at: 1714724000000
+                  external_verification_redirect_url: null
+                  nonce: null
+                  error: null
+                linked_to: []
+                reserved: false
+                created_at: 1714723200000
+                updated_at: 1714723200000
+    "401": { $ref: "../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../components/responses/NotFound.yaml" }
+    "409": { $ref: "../components/responses/Conflict.yaml" }
+    "422": { $ref: "../components/responses/UnprocessableEntity.yaml" }
+    "429": { $ref: "../components/responses/TooManyRequests.yaml" }

--- a/paths/user-ban.yaml
+++ b/paths/user-ban.yaml
@@ -1,0 +1,21 @@
+parameters:
+  - name: user_id
+    in: path
+    required: true
+    schema: { $ref: "../components/schemas/Id.yaml" }
+
+post:
+  operationId: banUser
+  summary: Ban a user
+  description: |
+    Permanently block a user from authenticating. Existing sessions are
+    revoked. Idempotent: banning an already-banned user is a no-op.
+  tags: [Users]
+  responses:
+    "200":
+      description: The banned user.
+      content:
+        application/json:
+          schema: { $ref: "../components/schemas/User.yaml" }
+    "401": { $ref: "../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../components/responses/NotFound.yaml" }

--- a/paths/user-lock.yaml
+++ b/paths/user-lock.yaml
@@ -1,0 +1,21 @@
+parameters:
+  - name: user_id
+    in: path
+    required: true
+    schema: { $ref: "../components/schemas/Id.yaml" }
+
+post:
+  operationId: lockUser
+  summary: Lock a user
+  description: |
+    Temporarily prevent the user from authenticating. Honors the
+    environment-level `max_lockout_duration` setting.
+  tags: [Users]
+  responses:
+    "200":
+      description: The locked user.
+      content:
+        application/json:
+          schema: { $ref: "../components/schemas/User.yaml" }
+    "401": { $ref: "../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../components/responses/NotFound.yaml" }

--- a/paths/user-metadata.yaml
+++ b/paths/user-metadata.yaml
@@ -1,0 +1,42 @@
+parameters:
+  - name: user_id
+    in: path
+    required: true
+    schema: { $ref: "../components/schemas/Id.yaml" }
+
+patch:
+  operationId: updateUserMetadata
+  summary: Patch user metadata
+  description: |
+    Shallow-merge the supplied metadata buckets into the user. To clear
+    a key, send it with `null`. Top-level buckets you don't include are
+    left untouched.
+  tags: [Users]
+  parameters:
+    - $ref: "../components/parameters/IdempotencyKeyHeader.yaml"
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          additionalProperties: false
+          properties:
+            public_metadata:  { $ref: "../components/schemas/Metadata.yaml" }
+            private_metadata: { $ref: "../components/schemas/Metadata.yaml" }
+            unsafe_metadata:  { $ref: "../components/schemas/Metadata.yaml" }
+        examples:
+          set_plan:
+            summary: Promote the user to the enterprise plan
+            value:
+              public_metadata: { plan: enterprise }
+              private_metadata: { stripe_customer_id: cus_XXXXX }
+  responses:
+    "200":
+      description: The user with merged metadata.
+      content:
+        application/json:
+          schema: { $ref: "../components/schemas/User.yaml" }
+    "401": { $ref: "../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../components/responses/NotFound.yaml" }
+    "422": { $ref: "../components/responses/UnprocessableEntity.yaml" }

--- a/paths/user-profile-image.yaml
+++ b/paths/user-profile-image.yaml
@@ -1,0 +1,59 @@
+parameters:
+  - name: user_id
+    in: path
+    required: true
+    schema: { $ref: "../components/schemas/Id.yaml" }
+
+post:
+  operationId: uploadUserProfileImage
+  summary: Upload a profile image
+  description: |
+    Upload a new profile image for the user. Replaces the existing
+    image, if any. Maximum 10 MiB; allowed content types: `image/png`,
+    `image/jpeg`, `image/webp`, `image/gif`.
+  tags: [Users]
+  requestBody:
+    required: true
+    content:
+      multipart/form-data:
+        schema:
+          type: object
+          required: [file]
+          additionalProperties: false
+          properties:
+            file:
+              type: string
+              format: binary
+              description: Raw image bytes.
+  responses:
+    "200":
+      description: The user with the new `image_url` populated.
+      content:
+        application/json:
+          schema: { $ref: "../components/schemas/User.yaml" }
+    "401": { $ref: "../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../components/responses/NotFound.yaml" }
+    "413":
+      description: Image larger than the per-environment limit.
+      content:
+        application/json:
+          schema: { $ref: "../components/schemas/ErrorResponse.yaml" }
+    "415":
+      description: Unsupported image content type.
+      content:
+        application/json:
+          schema: { $ref: "../components/schemas/ErrorResponse.yaml" }
+
+delete:
+  operationId: deleteUserProfileImage
+  summary: Delete a profile image
+  description: Remove the profile image and clear `image_url`. Idempotent.
+  tags: [Users]
+  responses:
+    "200":
+      description: The user with `image_url = null`.
+      content:
+        application/json:
+          schema: { $ref: "../components/schemas/User.yaml" }
+    "401": { $ref: "../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../components/responses/NotFound.yaml" }

--- a/paths/user-unban.yaml
+++ b/paths/user-unban.yaml
@@ -1,0 +1,20 @@
+parameters:
+  - name: user_id
+    in: path
+    required: true
+    schema: { $ref: "../components/schemas/Id.yaml" }
+
+post:
+  operationId: unbanUser
+  summary: Unban a user
+  description: |
+    Lift a previous ban. Idempotent: unbanning a non-banned user is a no-op.
+  tags: [Users]
+  responses:
+    "200":
+      description: The unbanned user.
+      content:
+        application/json:
+          schema: { $ref: "../components/schemas/User.yaml" }
+    "401": { $ref: "../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../components/responses/NotFound.yaml" }

--- a/paths/user-unlock.yaml
+++ b/paths/user-unlock.yaml
@@ -1,0 +1,19 @@
+parameters:
+  - name: user_id
+    in: path
+    required: true
+    schema: { $ref: "../components/schemas/Id.yaml" }
+
+post:
+  operationId: unlockUser
+  summary: Unlock a user
+  description: Lift a temporary lockout. Idempotent.
+  tags: [Users]
+  responses:
+    "200":
+      description: The unlocked user.
+      content:
+        application/json:
+          schema: { $ref: "../components/schemas/User.yaml" }
+    "401": { $ref: "../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../components/responses/NotFound.yaml" }

--- a/paths/user-verify-password.yaml
+++ b/paths/user-verify-password.yaml
@@ -1,0 +1,48 @@
+parameters:
+  - name: user_id
+    in: path
+    required: true
+    schema: { $ref: "../components/schemas/Id.yaml" }
+
+post:
+  operationId: verifyPassword
+  summary: Verify a user's password
+  description: |
+    Server-side password check. Returns `200 { verified: true }` on
+    match, `200 { verified: false }` on mismatch. Subject to the
+    standard rate-limit bucket; repeated mismatches eventually return
+    `429`.
+  tags: [Users]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [password]
+          additionalProperties: false
+          properties:
+            password:
+              type: string
+              minLength: 1
+        examples:
+          basic:
+            value: { password: "correct horse battery staple" }
+  responses:
+    "200":
+      description: Verification result.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [verified]
+            additionalProperties: false
+            properties:
+              verified: { type: boolean }
+          examples:
+            ok:    { value: { verified: true } }
+            wrong: { value: { verified: false } }
+    "401": { $ref: "../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../components/responses/NotFound.yaml" }
+    "422": { $ref: "../components/responses/UnprocessableEntity.yaml" }
+    "429": { $ref: "../components/responses/TooManyRequests.yaml" }

--- a/paths/user.yaml
+++ b/paths/user.yaml
@@ -1,0 +1,121 @@
+parameters:
+  - name: user_id
+    in: path
+    required: true
+    description: ID of the user.
+    schema: { $ref: "../components/schemas/Id.yaml" }
+
+get:
+  operationId: getUser
+  summary: Get a user
+  description: Fetch a single `User` by ID.
+  tags: [Users]
+  responses:
+    "200":
+      description: The user.
+      content:
+        application/json:
+          schema: { $ref: "../components/schemas/User.yaml" }
+          examples:
+            user:
+              value:
+                id: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+                object: user
+                external_id: null
+                username: jane
+                first_name: Jane
+                last_name: Doe
+                image_url: null
+                has_image: false
+                primary_email_address_id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE
+                primary_phone_number_id: null
+                email_addresses:
+                  - id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE
+                    object: email_address
+                    email_address: jane@acme.com
+                    verification:
+                      status: verified
+                      strategy: email_code
+                      attempts: 1
+                      expire_at: null
+                      external_verification_redirect_url: null
+                      nonce: null
+                      error: null
+                    linked_to: []
+                    reserved: false
+                    created_at: 1714723200000
+                    updated_at: 1714723260000
+                phone_numbers: []
+                external_accounts: []
+                enterprise_accounts: []
+                passkeys: []
+                password_enabled: true
+                two_factor_enabled: false
+                totp_enabled: false
+                backup_code_enabled: false
+                mfa_enabled_at: null
+                mfa_disabled_at: null
+                banned: false
+                locked: false
+                lockout_expires_at: null
+                last_sign_in_at: 1714809600000
+                last_active_at: 1714895999000
+                delete_self_enabled: true
+                locale: en-US
+                public_metadata: { plan: pro }
+                private_metadata: {}
+                unsafe_metadata: {}
+                created_at: 1714723200000
+                updated_at: 1714895999000
+    "401": { $ref: "../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../components/responses/NotFound.yaml" }
+    "429": { $ref: "../components/responses/TooManyRequests.yaml" }
+
+patch:
+  operationId: updateUser
+  summary: Update a user
+  description: |
+    Partial update. Only the fields you send are touched; nullable
+    fields can be cleared by sending `null`.
+  tags: [Users]
+  parameters:
+    - $ref: "../components/parameters/IdempotencyKeyHeader.yaml"
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: "../components/schemas/UserUpdateRequest.yaml" }
+        examples:
+          rename:
+            summary: Rename + update public metadata
+            value:
+              first_name: Janet
+              public_metadata: { plan: enterprise }
+          rotate_password:
+            summary: Force a password rotation and revoke other sessions
+            value:
+              password: "tr0ub4dor &3"
+              sign_out_of_other_sessions: true
+  responses:
+    "200":
+      description: The updated user.
+      content:
+        application/json:
+          schema: { $ref: "../components/schemas/User.yaml" }
+    "401": { $ref: "../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../components/responses/NotFound.yaml" }
+    "409": { $ref: "../components/responses/Conflict.yaml" }
+    "422": { $ref: "../components/responses/UnprocessableEntity.yaml" }
+
+delete:
+  operationId: deleteUser
+  summary: Delete a user
+  description: |
+    Permanently delete the user, all their identifiers, sessions, and
+    metadata. Emits `user.deleted`.
+  tags: [Users]
+  responses:
+    "204":
+      description: Deleted.
+    "401": { $ref: "../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../components/responses/NotFound.yaml" }

--- a/paths/users-count.yaml
+++ b/paths/users-count.yaml
@@ -1,0 +1,88 @@
+get:
+  operationId: countUsers
+  summary: Count users
+  description: |
+    Return the total number of users matching the same filter set as
+    `listUsers`. Useful for pagination headers and dashboards.
+  tags: [Users]
+  parameters:
+    - name: email_address
+      in: query
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: array
+        items: { type: string, format: email }
+    - name: phone_number
+      in: query
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: array
+        items: { type: string }
+    - name: username
+      in: query
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: array
+        items: { type: string }
+    - name: user_id
+      in: query
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: array
+        items: { type: string }
+    - name: external_id
+      in: query
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: array
+        items: { type: string }
+    - name: query
+      in: query
+      required: false
+      schema: { type: string }
+    - name: last_active_at_since
+      in: query
+      required: false
+      schema: { type: integer, format: int64, minimum: 0 }
+    - name: created_at_after
+      in: query
+      required: false
+      schema: { type: integer, format: int64, minimum: 0 }
+    - name: created_at_before
+      in: query
+      required: false
+      schema: { type: integer, format: int64, minimum: 0 }
+  responses:
+    "200":
+      description: Total count.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [object, total_count]
+            additionalProperties: false
+            properties:
+              object:
+                type: string
+                const: total_count
+              total_count:
+                type: integer
+                format: int64
+                minimum: 0
+          examples:
+            count:
+              value:
+                object: total_count
+                total_count: 12_345
+    "401": { $ref: "../components/responses/Unauthorized.yaml" }
+    "422": { $ref: "../components/responses/UnprocessableEntity.yaml" }

--- a/paths/users.yaml
+++ b/paths/users.yaml
@@ -1,0 +1,258 @@
+get:
+  operationId: listUsers
+  summary: List users
+  description: |
+    Return a paginated list of users in the environment, filtered by
+    identifier and lifecycle predicates.
+  tags: [Users]
+  parameters:
+    - $ref: "../components/parameters/LimitParam.yaml"
+    - $ref: "../components/parameters/OffsetParam.yaml"
+    - name: order_by
+      in: query
+      description: |
+        Sort key prefixed with `+` (ascending, default) or `-` (descending).
+        Allowed: `created_at`, `updated_at`, `last_active_at`, `last_sign_in_at`.
+      required: false
+      schema:
+        type: string
+        examples: ["+created_at", "-last_active_at"]
+    - name: email_address
+      in: query
+      description: |
+        Filter by email address. Repeat the parameter for OR semantics.
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: array
+        items: { type: string, format: email }
+    - name: phone_number
+      in: query
+      description: |
+        Filter by phone number (E.164). v0.1 always returns an empty
+        list since phone identifiers ship in v0.4.
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: array
+        items: { type: string }
+    - name: username
+      in: query
+      description: Filter by username. Repeat for OR semantics.
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: array
+        items: { type: string }
+    - name: user_id
+      in: query
+      description: Filter by `User.id`. Repeat for OR semantics.
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: array
+        items: { type: string }
+    - name: external_id
+      in: query
+      description: Filter by `User.external_id`. Repeat for OR semantics.
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: array
+        items: { type: string }
+    - name: query
+      in: query
+      description: |
+        Free-text search across email addresses, usernames, first
+        name, last name. Case-insensitive substring match.
+      required: false
+      schema: { type: string }
+    - name: last_active_at_since
+      in: query
+      description: Unix ms; only return users active at or after this instant.
+      required: false
+      schema: { type: integer, format: int64, minimum: 0 }
+    - name: created_at_after
+      in: query
+      description: Unix ms; only return users created strictly after this instant.
+      required: false
+      schema: { type: integer, format: int64, minimum: 0 }
+    - name: created_at_before
+      in: query
+      description: Unix ms; only return users created strictly before this instant.
+      required: false
+      schema: { type: integer, format: int64, minimum: 0 }
+  responses:
+    "200":
+      description: A page of users.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../components/schemas/PaginatedList.yaml"
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: "../components/schemas/User.yaml" }
+          examples:
+            page:
+              summary: First page, two users
+              value:
+                data:
+                  - id: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+                    object: user
+                    external_id: null
+                    username: jane
+                    first_name: Jane
+                    last_name: Doe
+                    image_url: null
+                    has_image: false
+                    primary_email_address_id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE
+                    primary_phone_number_id: null
+                    email_addresses:
+                      - id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE
+                        object: email_address
+                        email_address: jane@acme.com
+                        verification:
+                          status: verified
+                          strategy: email_code
+                          attempts: 1
+                          expire_at: null
+                          external_verification_redirect_url: null
+                          nonce: null
+                          error: null
+                        linked_to: []
+                        reserved: false
+                        created_at: 1714723200000
+                        updated_at: 1714723260000
+                    phone_numbers: []
+                    external_accounts: []
+                    enterprise_accounts: []
+                    passkeys: []
+                    password_enabled: true
+                    two_factor_enabled: false
+                    totp_enabled: false
+                    backup_code_enabled: false
+                    mfa_enabled_at: null
+                    mfa_disabled_at: null
+                    banned: false
+                    locked: false
+                    lockout_expires_at: null
+                    last_sign_in_at: 1714809600000
+                    last_active_at: 1714895999000
+                    delete_self_enabled: true
+                    locale: en-US
+                    public_metadata: { plan: pro }
+                    private_metadata: {}
+                    unsafe_metadata: {}
+                    created_at: 1714723200000
+                    updated_at: 1714895999000
+                total_count: 1
+    "401": { $ref: "../components/responses/Unauthorized.yaml" }
+    "403": { $ref: "../components/responses/Forbidden.yaml" }
+    "422": { $ref: "../components/responses/UnprocessableEntity.yaml" }
+    "429": { $ref: "../components/responses/TooManyRequests.yaml" }
+
+post:
+  operationId: createUser
+  summary: Create a user
+  description: |
+    Create a `User`. The BAPI is privileged: identifiers passed in
+    `email_address[]` are created already verified, and `password`
+    bypasses the user-flow verification step. At least one of
+    `email_address`, `phone_number`, `username`, or `external_id`
+    must be supplied.
+  tags: [Users]
+  parameters:
+    - $ref: "../components/parameters/IdempotencyKeyHeader.yaml"
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: "../components/schemas/UserCreateRequest.yaml" }
+        examples:
+          basic:
+            summary: Create with email + password
+            value:
+              email_address: ["jane@acme.com"]
+              password: "correct horse battery staple"
+              first_name: Jane
+              last_name: Doe
+              public_metadata: { plan: pro }
+          migration:
+            summary: Migrate a pre-hashed password
+            value:
+              external_id: legacy-user-42
+              email_address: ["jane@acme.com"]
+              password_digest: "$2a$10$N9qo8uLOickgx2ZMRZoMye…"
+              password_hasher: bcrypt
+              created_at: 1577836800000
+  responses:
+    "201":
+      description: User created.
+      content:
+        application/json:
+          schema: { $ref: "../components/schemas/User.yaml" }
+          examples:
+            created:
+              summary: Newly-created user
+              value:
+                id: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+                object: user
+                external_id: null
+                username: null
+                first_name: Jane
+                last_name: Doe
+                image_url: null
+                has_image: false
+                primary_email_address_id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE
+                primary_phone_number_id: null
+                email_addresses:
+                  - id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE
+                    object: email_address
+                    email_address: jane@acme.com
+                    verification:
+                      status: verified
+                      strategy: email_code
+                      attempts: 0
+                      expire_at: null
+                      external_verification_redirect_url: null
+                      nonce: null
+                      error: null
+                    linked_to: []
+                    reserved: false
+                    created_at: 1714723200000
+                    updated_at: 1714723200000
+                phone_numbers: []
+                external_accounts: []
+                enterprise_accounts: []
+                passkeys: []
+                password_enabled: true
+                two_factor_enabled: false
+                totp_enabled: false
+                backup_code_enabled: false
+                mfa_enabled_at: null
+                mfa_disabled_at: null
+                banned: false
+                locked: false
+                lockout_expires_at: null
+                last_sign_in_at: null
+                last_active_at: null
+                delete_self_enabled: true
+                locale: null
+                public_metadata: { plan: pro }
+                private_metadata: {}
+                unsafe_metadata: {}
+                created_at: 1714723200000
+                updated_at: 1714723200000
+    "401": { $ref: "../components/responses/Unauthorized.yaml" }
+    "403": { $ref: "../components/responses/Forbidden.yaml" }
+    "409": { $ref: "../components/responses/Conflict.yaml" }
+    "422": { $ref: "../components/responses/UnprocessableEntity.yaml" }
+    "429": { $ref: "../components/responses/TooManyRequests.yaml" }


### PR DESCRIPTION
## Summary

Implements [OA-2](https://github.com/authn-sh/openapi/issues/2) — first content drop into the spec. Defines the canonical shape of the three core end-user identity resources (`User`, `EmailAddress`, `Verification`) and their BAPI endpoints. Every other spec issue and every SDK that touches user data references these types.

### Schemas (`components/schemas/`)

- **`User`** — full BAPI shape: identifier set (`email_addresses`, `phone_numbers`, `external_accounts`, `enterprise_accounts`, `passkeys`), auth-state flags (`password_enabled`, `*_factor_*`), moderation state (`banned`, `locked`, `lockout_expires_at`), lifecycle timestamps, three metadata flavours.
- **`EmailAddress`** — `id`/`object`/`email_address`/`verification`/`linked_to`/`reserved`/timestamps.
- **`Verification`** — `status` (`unverified|verified|transferable|failed|expired`) + open-ended `strategy`, `attempts`, `expire_at`, redirect URL, `nonce`, `error`.
- **`UserCreateRequest`**, **`UserUpdateRequest`** with the privileged write surface (`password`/`password_digest`/`*_metadata`/...).
- **`EmailAddressCreateRequest`**, **`EmailAddressUpdateRequest`**.

### Paths (`paths/`) — **12 path items, 18 operations**

- `/v1/users` — `listUsers`, `createUser`
- `/v1/users/count` — `countUsers`
- `/v1/users/{user_id}` — `getUser`, `updateUser`, `deleteUser`
- `/v1/users/{user_id}/ban` + `/unban` + `/lock` + `/unlock` — 4 moderation POSTs
- `/v1/users/{user_id}/profile_image` — `uploadUserProfileImage` (multipart) + `deleteUserProfileImage`
- `/v1/users/{user_id}/metadata` — `updateUserMetadata`
- `/v1/users/{user_id}/verify_password` — `verifyPassword`
- `/v1/email_addresses` — `createEmailAddress`
- `/v1/email_addresses/{email_address_id}` — `getEmailAddress`, `updateEmailAddress`, `deleteEmailAddress`

Examples for `createUser`, `listUsers`, `getUser`, `updateUser`, `createEmailAddress` per the acceptance criteria. All schemas declare `additionalProperties: false` except free-form `Metadata`.

### Repo layout

OA-1 kept the shared components inline in `openapi.yaml`. The redocly linter only resolves cross-file refs by relative path, so once external schema/path files reference `Id`/`Error`/`Metadata`/etc. the inline shape stops working. This PR extracts every shared component (`Id`, `Timestamp`, `Metadata`, `PaginatedList`, `Error`, `ErrorResponse`, the standard responses, the common parameters) into per-file YAMLs under `components/`; `openapi.yaml` now glues components and paths together via `$ref` one-liners.

### Test plan

- [x] `npm run lint` — clean
- [x] `npm run bundle` — 12 path items, 18 operations, 13 schemas
- [x] `npm run stats` — sanity-checked
- [ ] `npm run preview` (visually verifies examples render — recommended local check)

Closes #2