### PR TITLE
Spec: FAPI client + sign_ins + sign_ups + sessions + me

### DIFF
--- a/components/schemas/Client.yaml
+++ b/components/schemas/Client.yaml
@@ -1,0 +1,46 @@
+type: object
+description: |
+  Per-device state container on the FAPI side. Identified by the
+  `__client` cookie (or `__authn_db_jwt` query param in cross-origin
+  dev). Carries the in-progress sign-in / sign-up state machines and
+  the list of authenticated sessions on this device.
+required:
+  - id
+  - object
+  - sessions
+  - sign_in
+  - sign_up
+  - last_active_session_id
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: client
+  sessions:
+    type: array
+    description: Active + recent sessions on this device.
+    items:
+      $ref: ./Session.yaml
+  sign_in:
+    description: Current in-progress sign-in attempt, if any.
+    oneOf:
+      - $ref: ./SignIn.yaml
+      - type: "null"
+  sign_up:
+    description: Current in-progress sign-up attempt, if any.
+    oneOf:
+      - $ref: ./SignUp.yaml
+      - type: "null"
+  last_active_session_id:
+    type: [string, "null"]
+    description: |
+      ID of the session the SDK should treat as "current" by default.
+      Updated on every `touch`. `null` when there are no sessions.
+  created_at:
+    $ref: ./Timestamp.yaml
+  updated_at:
+    $ref: ./Timestamp.yaml

--- a/components/schemas/ClientResponseEnvelope.yaml
+++ b/components/schemas/ClientResponseEnvelope.yaml
@@ -1,0 +1,20 @@
+type: object
+description: |
+  Standard envelope returned by every FAPI **write** operation. The
+  `response` field is the resource the operation logically returns
+  (e.g. a `SignIn` after `attempt_first_factor`); the `client` field
+  is the full updated `Client` so the SDK can refresh its local
+  device-state cache atomically — no follow-up `GET /v1/client` is
+  required.
+required: [response, client]
+additionalProperties: false
+properties:
+  response:
+    description: |
+      The primary resource for the operation (`SignIn`, `SignUp`,
+      `Session`, `User`, `EmailAddress`, …) — schema varies per
+      operation.
+    type: object
+    additionalProperties: true
+  client:
+    $ref: ./Client.yaml

--- a/components/schemas/Environment.yaml
+++ b/components/schemas/Environment.yaml
@@ -1,0 +1,159 @@
+type: object
+description: |
+  Public bootstrap configuration returned by `GET /v1/environment`. The
+  SDK fetches this once at boot and uses it to render the right sign-in
+  flow, branding, and locale set. No authentication required.
+required:
+  - auth_config
+  - display_config
+  - user_settings
+  - organization_settings
+  - commerce_settings
+  - captcha
+  - localization
+  - oauth_providers
+additionalProperties: false
+properties:
+  auth_config:
+    type: object
+    description: |
+      Allowed authentication strategies and identifier requirements.
+      v0.1 returns the password + email-code subset; broader provider
+      lists ship in v0.4.
+    additionalProperties: false
+    properties:
+      first_factors:
+        type: array
+        items:
+          type: string
+        examples: [["password", "email_code", "reset_password_email_code", "ticket"]]
+      second_factors:
+        type: array
+        items:
+          type: string
+        description: Empty in v0.1 (MFA ships v0.3).
+      identifier_requirements:
+        type: object
+        additionalProperties: false
+        properties:
+          email_address:
+            type: string
+            enum: [required, used_for_first_factor, off]
+          phone_number:
+            type: string
+            enum: [required, used_for_first_factor, off]
+            default: off
+          username:
+            type: string
+            enum: [required, used_for_first_factor, off]
+            default: off
+      sign_up_modes:
+        type: array
+        items:
+          type: string
+          enum: [public, restricted, waitlist]
+  display_config:
+    type: object
+    description: Branding + post-auth redirect targets shown in the Account Portal.
+    additionalProperties: false
+    properties:
+      application_name:
+        type: string
+      home_url:
+        type: [string, "null"]
+        format: uri
+      logo_url:
+        type: [string, "null"]
+        format: uri
+      favicon_url:
+        type: [string, "null"]
+        format: uri
+      support_email:
+        type: [string, "null"]
+        format: email
+      preferred_sign_in_strategy:
+        type: string
+        enum: [password, otp]
+        default: password
+      sign_in_url:
+        type: string
+        format: uri
+      sign_up_url:
+        type: string
+        format: uri
+      after_sign_in_url:
+        type: string
+        format: uri
+      after_sign_up_url:
+        type: string
+        format: uri
+      branded:
+        type: boolean
+        description: '`true` for the free tier (shows "powered by authn.sh").'
+        default: false
+      theme:
+        type: object
+        description: Hex colors / radii. Free-form in v0.1.
+        additionalProperties: true
+  user_settings:
+    type: object
+    description: |
+      Per-attribute write/verify flags mirrored from the dashboard.
+      Flat in v0.1; richer per-attribute matrix lands in v0.5.
+    additionalProperties: true
+  organization_settings:
+    type: object
+    description: |
+      Placeholder for organization-aware flows. Always `enabled: false`
+      in v0.1.
+    additionalProperties: true
+    properties:
+      enabled:
+        type: boolean
+        default: false
+  commerce_settings:
+    type: object
+    description: |
+      Placeholder for billing-aware flows. Always `enabled: false` in v0.1.
+    additionalProperties: true
+    properties:
+      enabled:
+        type: boolean
+        default: false
+  captcha:
+    type: object
+    description: |
+      Per-environment CAPTCHA. `provider: none` disables it client-side.
+      Fields are the public credentials the SDK needs to render the widget.
+    additionalProperties: false
+    properties:
+      provider:
+        type: string
+        enum: [none, hcaptcha, turnstile]
+        default: none
+      widget_type:
+        type: string
+        enum: [smart, invisible, managed]
+        default: smart
+      public_key:
+        type: [string, "null"]
+  localization:
+    type: object
+    additionalProperties: false
+    properties:
+      default_locale:
+        type: string
+        examples: ["en-US"]
+      supported_locales:
+        type: array
+        items:
+          type: string
+        examples: [["en-US", "pt-BR", "fr-FR"]]
+  oauth_providers:
+    type: array
+    description: |
+      Configured OAuth connections. Always `[]` in v0.1; populated when
+      providers ship in v0.4.
+    items:
+      type: object
+      additionalProperties: true

--- a/components/schemas/Session.yaml
+++ b/components/schemas/Session.yaml
@@ -1,0 +1,72 @@
+type: object
+description: |
+  An authenticated session for one `User` on one `Client` (device).
+  Lifecycle:
+
+  - `pending` — the SignIn flow created the session but the user hasn't
+    completed all factors yet.
+  - `active` — usable.
+  - `expired` — past `expire_at`.
+  - `ended` — user signed out on this device (`POST /sessions/{id}/end`).
+  - `removed` — administratively removed.
+  - `replaced` — a new session for the same user/device superseded this one.
+  - `revoked` — admin revoked.
+  - `abandoned` — never reached `active` and `abandon_at` passed.
+required:
+  - id
+  - object
+  - client_id
+  - user_id
+  - status
+  - last_active_at
+  - expire_at
+  - abandon_at
+  - latest_activity
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: session
+  client_id:
+    $ref: ./Id.yaml
+  user_id:
+    $ref: ./Id.yaml
+  status:
+    type: string
+    enum:
+      - pending
+      - active
+      - expired
+      - ended
+      - removed
+      - replaced
+      - revoked
+      - abandoned
+  last_active_at:
+    $ref: ./Timestamp.yaml
+  last_active_organization_id:
+    type: [string, "null"]
+    description: |
+      Set by `POST /v1/client/sessions/{id}/touch`. Populated once
+      organizations land in v0.2.
+  expire_at:
+    $ref: ./Timestamp.yaml
+  abandon_at:
+    $ref: ./Timestamp.yaml
+  actor:
+    type: ["object", "null"]
+    additionalProperties: true
+    description: |
+      Impersonation chain. `null` for end-user sessions; populated when a
+      privileged actor (e.g. dashboard support seat) signs in as another
+      user. Carries `iss`, `sub`, `sid` of the actor's session.
+  latest_activity:
+    $ref: ./SessionActivity.yaml
+  created_at:
+    $ref: ./Timestamp.yaml
+  updated_at:
+    $ref: ./Timestamp.yaml

--- a/components/schemas/SessionActivity.yaml
+++ b/components/schemas/SessionActivity.yaml
@@ -1,0 +1,39 @@
+type: object
+description: |
+  Latest device fingerprint observed on a `Session`. Populated each time
+  the SDK calls `touch`. Coarse-grained on purpose — no PII beyond the
+  IP address, which is hashed when stored.
+required:
+  - id
+  - object
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: session_activity
+  device_type:
+    type: [string, "null"]
+    enum:
+      - desktop
+      - mobile
+      - tablet
+      - smart_tv
+      - bot
+      - null
+  is_mobile:
+    type: boolean
+    default: false
+  browser_name:
+    type: [string, "null"]
+  browser_version:
+    type: [string, "null"]
+  ip_address:
+    type: [string, "null"]
+    description: Caller IP, redacted to /24 (IPv4) or /48 (IPv6) at rest.
+  city:
+    type: [string, "null"]
+  country:
+    type: [string, "null"]
+    description: ISO 3166-1 alpha-2 country code.

--- a/components/schemas/SignIn.yaml
+++ b/components/schemas/SignIn.yaml
@@ -1,0 +1,105 @@
+type: object
+description: |
+  In-progress sign-in attempt. The client drives a tiny state machine:
+  identify the user → prepare a first factor → attempt that factor →
+  (optionally) prepare/attempt a second factor → `complete`.
+
+  v0.1 ships `password` + `email_code` + `reset_password_email_code`
+  + `ticket`. OAuth/SAML/passkey/TOTP land in later milestones.
+required:
+  - id
+  - object
+  - status
+  - supported_identifiers
+  - supported_first_factors
+  - supported_second_factors
+  - first_factor_verification
+  - second_factor_verification
+  - identifier
+  - user_data
+  - created_session_id
+  - abandon_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: sign_in_attempt
+  status:
+    type: string
+    enum:
+      - needs_identifier
+      - needs_first_factor
+      - needs_second_factor
+      - needs_new_password
+      - needs_client_trust
+      - complete
+      - abandoned
+    description: |
+      - `needs_identifier` — caller must supply email/phone/username.
+      - `needs_first_factor` — caller must call `prepare_first_factor` then
+        `attempt_first_factor`.
+      - `needs_second_factor` — first factor passed; second pending. v0.3+.
+      - `needs_new_password` — email-code reset succeeded; caller must
+        `POST /reset_password` with the new password.
+      - `needs_client_trust` — environment requires the device pass an
+        out-of-band trust check (geolocation/WAF/captcha).
+      - `complete` — `created_session_id` is set; SDK can stop driving.
+      - `abandoned` — `abandon_at` passed; create a new sign-in.
+  supported_identifiers:
+    type: array
+    items:
+      type: string
+      enum: [email_address, phone_number, username]
+    description: Identifier kinds the environment accepts at this step.
+  supported_first_factors:
+    type: array
+    items:
+      type: object
+      required: [strategy]
+      additionalProperties: true
+      properties:
+        strategy:
+          type: string
+        email_address_id:
+          type: string
+        phone_number_id:
+          type: string
+        safe_identifier:
+          type: string
+          description: Redacted hint shown in UI (e.g. `j***@a***`).
+    description: Concrete first factors that can be prepared.
+  supported_second_factors:
+    type: array
+    items:
+      type: object
+      additionalProperties: true
+    description: Empty in v0.1 (MFA ships in v0.3).
+  first_factor_verification:
+    description: Verification challenge for the chosen first factor, if started.
+    oneOf:
+      - $ref: ./Verification.yaml
+      - type: "null"
+  second_factor_verification:
+    description: Verification challenge for the second factor, if started.
+    oneOf:
+      - $ref: ./Verification.yaml
+      - type: "null"
+  identifier:
+    type: [string, "null"]
+    description: Identifier the caller submitted, normalized.
+  user_data:
+    type: object
+    description: |
+      Public-safe profile preview the client can render before the user
+      finishes auth. Keys mirror `User`'s `first_name`, `last_name`,
+      `image_url`, `has_image`. May be `{}` until the identifier resolves.
+    additionalProperties: true
+  created_session_id:
+    type: [string, "null"]
+    description: |
+      Set when `status` reaches `complete`. The new `Session` is also
+      visible in the enclosing `Client.sessions[]`.
+  abandon_at:
+    $ref: ./Timestamp.yaml

--- a/components/schemas/SignUp.yaml
+++ b/components/schemas/SignUp.yaml
@@ -1,0 +1,107 @@
+type: object
+description: |
+  In-progress sign-up attempt. Tracks which fields the environment
+  requires, which the caller has already supplied, which still need
+  verification, and the per-attribute verification challenges.
+
+  v0.1 supports email + password sign-ups; phone, OAuth, SAML, and
+  passkey sign-ups ship in later milestones.
+required:
+  - id
+  - object
+  - status
+  - required_fields
+  - optional_fields
+  - missing_fields
+  - unverified_fields
+  - verifications
+  - password_enabled
+  - unsafe_metadata
+  - public_metadata
+  - created_session_id
+  - created_user_id
+  - abandon_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: sign_up_attempt
+  status:
+    type: string
+    enum:
+      - missing_requirements
+      - complete
+      - transferable
+      - abandoned
+    description: |
+      - `missing_requirements` — `missing_fields` or `unverified_fields`
+        is non-empty; caller must `PATCH` to fill / `attempt_verification`
+        to verify.
+      - `complete` — `created_user_id` and `created_session_id` are set;
+        SDK can stop driving.
+      - `transferable` — an OAuth identity matched but no local user
+        exists; the caller can transfer to sign-up. (v0.4.)
+      - `abandoned` — `abandon_at` passed.
+  required_fields:
+    type: array
+    items: { type: string }
+    description: Fields the environment requires for sign-up to complete.
+  optional_fields:
+    type: array
+    items: { type: string }
+  missing_fields:
+    type: array
+    items: { type: string }
+    description: |
+      Subset of `required_fields` not yet supplied. When non-empty,
+      `status` stays `missing_requirements`.
+  unverified_fields:
+    type: array
+    items: { type: string }
+    description: |
+      Fields the caller supplied but that need a verification challenge
+      (`email_address`, `phone_number`).
+  verifications:
+    type: object
+    description: |
+      Map of attribute name → `Verification`. Populated by
+      `prepare_verification` and updated by `attempt_verification`.
+    additionalProperties:
+      oneOf:
+        - $ref: ./Verification.yaml
+        - type: "null"
+    examples:
+      - email_address:
+          status: unverified
+          strategy: email_code
+          attempts: 0
+          expire_at: 1714724000000
+          external_verification_redirect_url: null
+          nonce: null
+          error: null
+  username:
+    type: [string, "null"]
+  email_address:
+    type: [string, "null"]
+    format: email
+  phone_number:
+    type: [string, "null"]
+  first_name:
+    type: [string, "null"]
+  last_name:
+    type: [string, "null"]
+  password_enabled:
+    type: boolean
+    description: '`true` once the caller has set a password on this attempt.'
+  unsafe_metadata:
+    $ref: ./Metadata.yaml
+  public_metadata:
+    $ref: ./Metadata.yaml
+  created_session_id:
+    type: [string, "null"]
+  created_user_id:
+    type: [string, "null"]
+  abandon_at:
+    $ref: ./Timestamp.yaml

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -110,6 +110,69 @@ paths:
   /v1/email_addresses/{email_address_id}:
     $ref: ./paths/email-address.yaml
 
+  # Frontend API (FAPI) — per-environment host. SDKs target the second
+  # `servers:` entry; `client_cookie` / `dev_browser_jwt` security applies.
+  /v1/environment:
+    $ref: ./paths/environment.yaml
+  /v1/client:
+    $ref: ./paths/client.yaml
+  /v1/client/handshake:
+    $ref: ./paths/client-handshake.yaml
+  /v1/client/sign_ins:
+    $ref: ./paths/sign-ins.yaml
+  /v1/client/sign_ins/{sign_in_id}:
+    $ref: ./paths/sign-in.yaml
+  /v1/client/sign_ins/{sign_in_id}/prepare_first_factor:
+    $ref: ./paths/sign-in-prepare-first-factor.yaml
+  /v1/client/sign_ins/{sign_in_id}/attempt_first_factor:
+    $ref: ./paths/sign-in-attempt-first-factor.yaml
+  /v1/client/sign_ins/{sign_in_id}/prepare_second_factor:
+    $ref: ./paths/sign-in-prepare-second-factor.yaml
+  /v1/client/sign_ins/{sign_in_id}/attempt_second_factor:
+    $ref: ./paths/sign-in-attempt-second-factor.yaml
+  /v1/client/sign_ins/{sign_in_id}/reset_password:
+    $ref: ./paths/sign-in-reset-password.yaml
+  /v1/client/sign_ups:
+    $ref: ./paths/sign-ups.yaml
+  /v1/client/sign_ups/{sign_up_id}:
+    $ref: ./paths/sign-up.yaml
+  /v1/client/sign_ups/{sign_up_id}/prepare_verification:
+    $ref: ./paths/sign-up-prepare-verification.yaml
+  /v1/client/sign_ups/{sign_up_id}/attempt_verification:
+    $ref: ./paths/sign-up-attempt-verification.yaml
+  /v1/client/sessions/{session_id}:
+    $ref: ./paths/client-session.yaml
+  /v1/client/sessions/{session_id}/end:
+    $ref: ./paths/client-session-end.yaml
+  /v1/client/sessions/{session_id}/remove:
+    $ref: ./paths/client-session-remove.yaml
+  /v1/client/sessions/{session_id}/touch:
+    $ref: ./paths/client-session-touch.yaml
+  /v1/client/sessions/{session_id}/tokens:
+    $ref: ./paths/client-session-tokens.yaml
+  /v1/client/sessions/{session_id}/tokens/{template_name}:
+    $ref: ./paths/client-session-tokens-template.yaml
+  /v1/me:
+    $ref: ./paths/me.yaml
+  /v1/me/profile_image:
+    $ref: ./paths/me-profile-image.yaml
+  /v1/me/email_addresses:
+    $ref: ./paths/me-email-addresses.yaml
+  /v1/me/email_addresses/{email_address_id}:
+    $ref: ./paths/me-email-address.yaml
+  /v1/me/email_addresses/{email_address_id}/prepare_verification:
+    $ref: ./paths/me-email-prepare-verification.yaml
+  /v1/me/email_addresses/{email_address_id}/attempt_verification:
+    $ref: ./paths/me-email-attempt-verification.yaml
+  /v1/me/sessions:
+    $ref: ./paths/me-sessions.yaml
+  /v1/me/change_password:
+    $ref: ./paths/me-change-password.yaml
+  /v1/me/password:
+    $ref: ./paths/me-password.yaml
+  /v1/me/delete_self:
+    $ref: ./paths/me-delete-self.yaml
+
 components:
   securitySchemes:
     bearer_secret_key:
@@ -154,6 +217,13 @@ components:
     UserUpdateRequest:         { $ref: ./components/schemas/UserUpdateRequest.yaml }
     EmailAddressCreateRequest: { $ref: ./components/schemas/EmailAddressCreateRequest.yaml }
     EmailAddressUpdateRequest: { $ref: ./components/schemas/EmailAddressUpdateRequest.yaml }
+    Client:                    { $ref: ./components/schemas/Client.yaml }
+    ClientResponseEnvelope:    { $ref: ./components/schemas/ClientResponseEnvelope.yaml }
+    Environment:               { $ref: ./components/schemas/Environment.yaml }
+    Session:                   { $ref: ./components/schemas/Session.yaml }
+    SessionActivity:           { $ref: ./components/schemas/SessionActivity.yaml }
+    SignIn:                    { $ref: ./components/schemas/SignIn.yaml }
+    SignUp:                    { $ref: ./components/schemas/SignUp.yaml }
 
   responses:
     BadRequest:           { $ref: ./components/responses/BadRequest.yaml }

--- a/paths/client-handshake.yaml
+++ b/paths/client-handshake.yaml
@@ -1,0 +1,37 @@
+get:
+  operationId: clientHandshake
+  summary: Server-side handshake
+  description: |
+    SSR handshake endpoint. The server-side renderer calls this with the
+    incoming request's cookies; the response carries the
+    `Set-Cookie: __client=…` header so the SSR proxy can set it on the
+    outgoing HTML response.
+  tags: [Client]
+  security: []
+  parameters:
+    - name: redirect_url
+      in: query
+      description: Caller URL the SDK should bounce back to after the handshake.
+      required: false
+      schema:
+        type: string
+        format: uri
+  responses:
+    "200":
+      description: |
+        Handshake confirmation. Carries the `Set-Cookie: __client=…`
+        header.
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            required: [object, redirect_url]
+            properties:
+              object:
+                type: string
+                const: client_handshake
+              redirect_url:
+                type: [string, "null"]
+                format: uri
+    "404": { $ref: ../components/responses/NotFound.yaml }

--- a/paths/client-session-end.yaml
+++ b/paths/client-session-end.yaml
@@ -1,0 +1,25 @@
+parameters:
+  - name: session_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+post:
+  operationId: endSession
+  summary: End a session (sign out on this device)
+  description: |
+    Marks the session `ended` and invalidates its tokens. The session
+    stays in `Client.sessions[]` for ~1 minute so the SDK can finish
+    flushing analytics, then drops out.
+  tags: [Sessions]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: The ended session, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }

--- a/paths/client-session-remove.yaml
+++ b/paths/client-session-remove.yaml
@@ -1,0 +1,25 @@
+parameters:
+  - name: session_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+post:
+  operationId: removeSession
+  summary: Remove a session immediately
+  description: |
+    Like `end`, but drops the session from `Client.sessions[]` straight
+    away. Used when the SDK wants to forget about it (e.g. user clicked
+    "Remove this device" in the user profile).
+  tags: [Sessions]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: The removed session, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }

--- a/paths/client-session-tokens-template.yaml
+++ b/paths/client-session-tokens-template.yaml
@@ -1,0 +1,38 @@
+parameters:
+  - name: session_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+  - name: template_name
+    in: path
+    required: true
+    schema:
+      type: string
+      pattern: "^[A-Za-z0-9_-]{1,64}$"
+    description: Name of the JWT template configured on the environment.
+
+post:
+  operationId: getSessionTokenWithTemplate
+  summary: Mint a session JWT with a custom template (v0.7)
+  description: |
+    Issue a JWT shaped by the named template. Always returns
+    `404 jwt_template_not_found` in v0.1; the templating layer ships in
+    v0.7 alongside the IdP role.
+  tags: [Sessions]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: The minted token.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [object, jwt]
+            additionalProperties: false
+            properties:
+              object: { type: string, const: token }
+              jwt:    { type: string }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }

--- a/paths/client-session-tokens.yaml
+++ b/paths/client-session-tokens.yaml
@@ -1,0 +1,40 @@
+parameters:
+  - name: session_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+post:
+  operationId: getSessionToken
+  summary: Mint a session JWT
+  description: |
+    Mint a short-lived RS256 JWT for the session. Use the templated
+    sibling endpoint (`/tokens/{template_name}`) once JWT templates
+    ship in v0.7.
+  tags: [Sessions]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: The minted token.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [object, jwt]
+            additionalProperties: false
+            properties:
+              object:
+                type: string
+                const: token
+              jwt:
+                type: string
+          examples:
+            token:
+              value:
+                object: token
+                jwt: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImpfMTIifQ.eyJzdWIiOiJ1c2VyXzE…"
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }
+    "429": { $ref: ../components/responses/TooManyRequests.yaml }

--- a/paths/client-session-touch.yaml
+++ b/paths/client-session-touch.yaml
@@ -1,0 +1,38 @@
+parameters:
+  - name: session_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+post:
+  operationId: touchSession
+  summary: Touch a session
+  description: |
+    Update `last_active_at` and (optionally) the active organization.
+    The SDK calls this on every page view so the dashboard "active
+    sessions" view is fresh.
+  tags: [Sessions]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: false
+    content:
+      application/json:
+        schema:
+          type: object
+          additionalProperties: false
+          properties:
+            active_organization_id:
+              type: [string, "null"]
+              description: |
+                Switch the active organization. Always `null` in v0.1
+                since organizations land in v0.2.
+  responses:
+    "200":
+      description: The touched session, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }

--- a/paths/client-session.yaml
+++ b/paths/client-session.yaml
@@ -1,0 +1,47 @@
+parameters:
+  - name: session_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+get:
+  operationId: getSession
+  summary: Get a session
+  description: Fetch a single `Session` by ID; returns the current status, expiry, and last activity.
+  tags: [Sessions]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: The session.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/Session.yaml }
+          examples:
+            active:
+              value:
+                id: sess_01HKX9SY9V7H7TF8C8K7J9X4ZC
+                object: session
+                client_id: clt_01HKX9SY9V7H7TF8C8K7J9X4ZA
+                user_id: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+                status: active
+                last_active_at: 1714895999000
+                last_active_organization_id: null
+                expire_at: 1717487999000
+                abandon_at: 1717487999000
+                actor: null
+                latest_activity:
+                  id: sa_01HKX9SY9V7H7TF8C8K7J9X4ZF
+                  object: session_activity
+                  device_type: desktop
+                  is_mobile: false
+                  browser_name: Chrome
+                  browser_version: "124.0"
+                  ip_address: "203.0.113.0"
+                  city: Berlin
+                  country: DE
+                created_at: 1714723200000
+                updated_at: 1714895999000
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }

--- a/paths/client.yaml
+++ b/paths/client.yaml
@@ -1,0 +1,51 @@
+get:
+  operationId: getClient
+  summary: Get the current client
+  description: |
+    Returns the device-scoped `Client`. Lazily creates one and sets the
+    `__client` cookie if the request didn't already carry one.
+  tags: [Client]
+  security: []
+  responses:
+    "200":
+      description: The current client.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/Client.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }
+
+put:
+  operationId: createClient
+  summary: Create / re-create the current client
+  description: |
+    Force a fresh `Client` and `__client` cookie. Used by the SDK after
+    a sign-out-everywhere to obtain a clean device identity.
+  tags: [Client]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: The freshly-issued client, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+
+delete:
+  operationId: destroyClient
+  summary: Destroy the current client
+  description: |
+    Revokes every session on this device and clears the `__client`
+    cookie. The next request gets a fresh client via `GET /v1/client`.
+  tags: [Client]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: Confirmation envelope (response is the destroyed client).
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }

--- a/paths/environment.yaml
+++ b/paths/environment.yaml
@@ -1,0 +1,15 @@
+get:
+  operationId: getEnvironment
+  summary: Get environment bootstrap config
+  description: |
+    Public, unauthenticated. Returned at SDK boot to drive flow rendering,
+    branding, and locale selection. Cacheable for ~30 seconds.
+  tags: [Environment]
+  security: []
+  responses:
+    "200":
+      description: Environment configuration.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/Environment.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }

--- a/paths/me-change-password.yaml
+++ b/paths/me-change-password.yaml
@@ -1,0 +1,37 @@
+post:
+  operationId: changeMyPassword
+  summary: Change my password
+  description: |
+    Replace the user's password. Always requires the current password
+    when one is set; the `new_password` is validated against the
+    environment's strength policy.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [new_password]
+          additionalProperties: false
+          properties:
+            current_password:
+              type: string
+              description: Required if the user already has a password.
+            new_password:
+              type: string
+              minLength: 8
+            sign_out_of_other_sessions:
+              type: boolean
+              default: true
+  responses:
+    "200":
+      description: The user with `password_enabled = true`, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }

--- a/paths/me-delete-self.yaml
+++ b/paths/me-delete-self.yaml
@@ -1,0 +1,19 @@
+post:
+  operationId: deleteMyself
+  summary: Delete my account
+  description: |
+    Permanently destroy the current user (and every session, identifier,
+    and metadata). Requires the environment's `delete_self_enabled`
+    setting to be `true`.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: The destroyed user, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "403": { $ref: ../components/responses/Forbidden.yaml }

--- a/paths/me-email-address.yaml
+++ b/paths/me-email-address.yaml
@@ -1,0 +1,70 @@
+parameters:
+  - name: email_address_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+get:
+  operationId: getMyEmailAddress
+  summary: Get one of my email addresses
+  description: Fetch a single email address attached to the current user, by ID.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: The email address.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/EmailAddress.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }
+
+patch:
+  operationId: updateMyEmailAddress
+  summary: Promote one of my email addresses to primary
+  description: Only verified addresses can be made primary.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          additionalProperties: false
+          properties:
+            primary: { type: boolean }
+  responses:
+    "200":
+      description: The updated address, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }
+
+delete:
+  operationId: deleteMyEmailAddress
+  summary: Remove one of my email addresses
+  description: |
+    Detach the address from the current user. The user must have at
+    least one other identifier remaining; deleting the last one returns
+    `422`.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: The deleted address, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }

--- a/paths/me-email-addresses.yaml
+++ b/paths/me-email-addresses.yaml
@@ -1,0 +1,53 @@
+get:
+  operationId: listMyEmailAddresses
+  summary: List my email addresses
+  description: Every email address attached to the current user, with verification state.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: My email addresses.
+      content:
+        application/json:
+          schema:
+            type: array
+            items: { $ref: ../components/schemas/EmailAddress.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+
+post:
+  operationId: createMyEmailAddress
+  summary: Add an email address to my account
+  description: |
+    Attach a new email to the current user. Always created unverified;
+    follow up with `prepare_verification` + `attempt_verification`.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [email_address]
+          additionalProperties: false
+          properties:
+            email_address:
+              type: string
+              format: email
+              maxLength: 254
+        examples:
+          add:
+            value: { email_address: jane.alt@acme.com }
+  responses:
+    "200":
+      description: The new email address, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "409": { $ref: ../components/responses/Conflict.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }

--- a/paths/me-email-attempt-verification.yaml
+++ b/paths/me-email-attempt-verification.yaml
@@ -1,0 +1,37 @@
+parameters:
+  - name: email_address_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+post:
+  operationId: attemptMyEmailVerification
+  summary: Attempt email verification
+  description: Submit the code received in email; flips the address to `verified` on match.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [code]
+          additionalProperties: false
+          properties:
+            code:
+              type: string
+              minLength: 4
+              maxLength: 12
+  responses:
+    "200":
+      description: The (now-verified) address, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }
+    "429": { $ref: ../components/responses/TooManyRequests.yaml }

--- a/paths/me-email-prepare-verification.yaml
+++ b/paths/me-email-prepare-verification.yaml
@@ -1,0 +1,39 @@
+parameters:
+  - name: email_address_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+post:
+  operationId: prepareMyEmailVerification
+  summary: Prepare email verification
+  description: Issue a fresh email-code challenge for one of my unverified addresses.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [strategy]
+          additionalProperties: false
+          properties:
+            strategy:
+              type: string
+              enum: [email_code]
+        examples:
+          basic:
+            value: { strategy: email_code }
+  responses:
+    "200":
+      description: The address with the new verification, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }
+    "429": { $ref: ../components/responses/TooManyRequests.yaml }

--- a/paths/me-password.yaml
+++ b/paths/me-password.yaml
@@ -1,0 +1,30 @@
+delete:
+  operationId: removeMyPassword
+  summary: Remove my password
+  description: |
+    Clear the user's password digest, leaving them with whatever other
+    factors are configured (e.g. magic link). Returns `422` when the
+    environment requires a password.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [current_password]
+          additionalProperties: false
+          properties:
+            current_password:
+              type: string
+  responses:
+    "200":
+      description: The user with `password_enabled = false`, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }

--- a/paths/me-profile-image.yaml
+++ b/paths/me-profile-image.yaml
@@ -1,0 +1,56 @@
+post:
+  operationId: uploadMyProfileImage
+  summary: Upload my profile image
+  description: |
+    Upload a new profile image. Replaces the existing image, if any.
+    Maximum 10 MiB; allowed content types: `image/png`, `image/jpeg`,
+    `image/webp`, `image/gif`.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      multipart/form-data:
+        schema:
+          type: object
+          required: [file]
+          additionalProperties: false
+          properties:
+            file:
+              type: string
+              format: binary
+  responses:
+    "200":
+      description: The user with the new `image_url`, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "413":
+      description: Image too large.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ErrorResponse.yaml }
+    "415":
+      description: Unsupported image type.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ErrorResponse.yaml }
+
+delete:
+  operationId: deleteMyProfileImage
+  summary: Delete my profile image
+  description: Remove the profile image and clear `image_url`. Idempotent.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: The user with `image_url = null`, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }

--- a/paths/me-sessions.yaml
+++ b/paths/me-sessions.yaml
@@ -1,0 +1,19 @@
+get:
+  operationId: listMySessions
+  summary: List my active sessions
+  description: |
+    All non-ended sessions for the current user across every device.
+    Powers the "active sessions" panel in the user profile.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: My sessions.
+      content:
+        application/json:
+          schema:
+            type: array
+            items: { $ref: ../components/schemas/Session.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }

--- a/paths/me.yaml
+++ b/paths/me.yaml
@@ -1,0 +1,108 @@
+get:
+  operationId: getMe
+  summary: Get the current user
+  description: |
+    Return the authenticated user. Works on any active session; the SDK
+    uses this to hydrate `useUser()` / `currentUser` in the framework
+    bindings.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: The user.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/User.yaml }
+          examples:
+            me:
+              summary: A signed-in user
+              value:
+                id: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+                object: user
+                external_id: null
+                username: jane
+                first_name: Jane
+                last_name: Doe
+                image_url: null
+                has_image: false
+                primary_email_address_id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE
+                primary_phone_number_id: null
+                email_addresses: []
+                phone_numbers: []
+                external_accounts: []
+                enterprise_accounts: []
+                passkeys: []
+                password_enabled: true
+                two_factor_enabled: false
+                totp_enabled: false
+                backup_code_enabled: false
+                mfa_enabled_at: null
+                mfa_disabled_at: null
+                banned: false
+                locked: false
+                lockout_expires_at: null
+                last_sign_in_at: 1714809600000
+                last_active_at: 1714895999000
+                delete_self_enabled: true
+                locale: en-US
+                public_metadata: { plan: pro }
+                private_metadata: {}
+                unsafe_metadata: {}
+                created_at: 1714723200000
+                updated_at: 1714895999000
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+
+patch:
+  operationId: updateMe
+  summary: Update the current user
+  description: |
+    Partial update over the FAPI-writable subset (display name fields,
+    `unsafe_metadata`, `locale`). Privileged fields (`public_metadata`,
+    `private_metadata`, `external_id`, password lifecycle) live on
+    BAPI's `PATCH /v1/users/{id}`.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          additionalProperties: false
+          properties:
+            username:        { type: [string, "null"] }
+            first_name:      { type: [string, "null"] }
+            last_name:       { type: [string, "null"] }
+            unsafe_metadata: { $ref: ../components/schemas/Metadata.yaml }
+            locale:          { type: [string, "null"] }
+  responses:
+    "200":
+      description: The updated user, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }
+
+delete:
+  operationId: deleteMe
+  summary: Delete the current user (alias for delete_self)
+  description: |
+    Convenience wrapper around `POST /v1/me/delete_self`. Subject to
+    the environment's `delete_self_enabled` setting.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: The destroyed user, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "403": { $ref: ../components/responses/Forbidden.yaml }

--- a/paths/sign-in-attempt-first-factor.yaml
+++ b/paths/sign-in-attempt-first-factor.yaml
@@ -1,0 +1,55 @@
+parameters:
+  - name: sign_in_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+post:
+  operationId: attemptFirstFactor
+  summary: Attempt first-factor verification
+  description: |
+    Submit the user's answer to the first-factor challenge. Strategies:
+
+    - `password` — body `{strategy: "password", password: "…"}`.
+    - `email_code` — body `{strategy: "email_code", code: "123456"}`.
+    - `reset_password_email_code` — body
+      `{strategy: "reset_password_email_code", code: "…"}` — on success
+      the sign-in transitions to `needs_new_password`.
+    - `ticket` — body `{strategy: "ticket", ticket: "…"}`.
+  tags: [Sign-Ins]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [strategy]
+          additionalProperties: false
+          properties:
+            strategy:
+              type: string
+              enum: [password, email_code, reset_password_email_code, ticket]
+            password: { type: string }
+            code:     { type: string }
+            ticket:   { type: string }
+            signature:
+              type: string
+              description: Reserved for v0.5 (passkey).
+        examples:
+          password:
+            value: { strategy: password, password: "correct horse battery staple" }
+          email_code:
+            value: { strategy: email_code, code: "542178" }
+  responses:
+    "200":
+      description: Sign-in transitioned (possibly to `complete`), wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }
+    "429": { $ref: ../components/responses/TooManyRequests.yaml }

--- a/paths/sign-in-attempt-second-factor.yaml
+++ b/paths/sign-in-attempt-second-factor.yaml
@@ -1,0 +1,34 @@
+parameters:
+  - name: sign_in_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+post:
+  operationId: attemptSecondFactor
+  summary: Attempt second-factor verification (v0.3+)
+  description: |
+    Placeholder. v0.1 always returns `422 mfa_not_enabled`. The full
+    surface ships in v0.3.
+  tags: [Sign-Ins]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [strategy]
+          additionalProperties: true
+          properties:
+            strategy:
+              type: string
+  responses:
+    "200":
+      description: Sign-in transitioned, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }

--- a/paths/sign-in-prepare-first-factor.yaml
+++ b/paths/sign-in-prepare-first-factor.yaml
@@ -1,0 +1,48 @@
+parameters:
+  - name: sign_in_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+post:
+  operationId: prepareFirstFactor
+  summary: Prepare first-factor verification
+  description: |
+    Issue a first-factor challenge (e.g. send the email code) without
+    yet evaluating an answer. The next step is `attempt_first_factor`.
+  tags: [Sign-Ins]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [strategy]
+          additionalProperties: false
+          properties:
+            strategy:
+              type: string
+              enum: [email_code, reset_password_email_code]
+            email_address_id:
+              type: string
+            phone_number_id:
+              type: string
+            redirect_url:
+              type: string
+              format: uri
+        examples:
+          email_code:
+            value: { strategy: email_code, email_address_id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE }
+  responses:
+    "200":
+      description: Sign-in with the new `first_factor_verification`, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }
+    "429": { $ref: ../components/responses/TooManyRequests.yaml }

--- a/paths/sign-in-prepare-second-factor.yaml
+++ b/paths/sign-in-prepare-second-factor.yaml
@@ -1,0 +1,34 @@
+parameters:
+  - name: sign_in_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+post:
+  operationId: prepareSecondFactor
+  summary: Prepare second-factor verification (v0.3+)
+  description: |
+    Placeholder. v0.1 always returns `422 mfa_not_enabled`. The full
+    surface ships in v0.3.
+  tags: [Sign-Ins]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [strategy]
+          additionalProperties: true
+          properties:
+            strategy:
+              type: string
+  responses:
+    "200":
+      description: Sign-in with the new `second_factor_verification`, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }

--- a/paths/sign-in-reset-password.yaml
+++ b/paths/sign-in-reset-password.yaml
@@ -1,0 +1,46 @@
+parameters:
+  - name: sign_in_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+post:
+  operationId: resetPassword
+  summary: Reset password during sign-in
+  description: |
+    Called after `attemptFirstFactor` with `reset_password_email_code`
+    succeeded — i.e. the sign-in is in `needs_new_password`. Sets the
+    new password, then transitions the sign-in to `complete`. When
+    `sign_out_of_other_sessions: true`, every other active session for
+    the user is revoked.
+  tags: [Sign-Ins]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [password]
+          additionalProperties: false
+          properties:
+            password:
+              type: string
+              minLength: 8
+            sign_out_of_other_sessions:
+              type: boolean
+              default: true
+        examples:
+          basic:
+            value: { password: "tr0ub4dor &3", sign_out_of_other_sessions: true }
+  responses:
+    "200":
+      description: The completed sign-in, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }

--- a/paths/sign-in.yaml
+++ b/paths/sign-in.yaml
@@ -1,0 +1,22 @@
+parameters:
+  - name: sign_in_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+get:
+  operationId: getSignIn
+  summary: Get a sign-in attempt
+  description: Fetch the current state of an in-progress sign-in attempt by ID.
+  tags: [Sign-Ins]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: The sign-in attempt.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/SignIn.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }

--- a/paths/sign-ins.yaml
+++ b/paths/sign-ins.yaml
@@ -1,0 +1,67 @@
+post:
+  operationId: createSignIn
+  summary: Create a sign-in attempt
+  description: |
+    Start a sign-in flow. The caller may supply only the identifier (in
+    which case the response carries `supported_first_factors` so the
+    SDK can pick one), or supply an identifier + strategy (and password
+    when applicable) to fold the first attempt into the create call.
+  tags: [Sign-Ins]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          additionalProperties: false
+          properties:
+            identifier:
+              type: string
+              description: Email, phone (E.164), or username.
+            strategy:
+              type: string
+              enum: [password, email_code, reset_password_email_code, ticket]
+            password:
+              type: string
+              minLength: 1
+            redirect_url:
+              type: string
+              format: uri
+              description: Used by strategies that need a callback URL.
+            ticket:
+              type: string
+              description: Single-use ticket from an invitation or magic link.
+            transfer:
+              type: boolean
+              default: false
+            captcha_token:        { type: string }
+            captcha_widget_type:  { type: string, enum: [smart, invisible, managed] }
+            captcha_error:        { type: string }
+        examples:
+          identify_only:
+            summary: Identify and let the SDK pick the next factor
+            value:
+              identifier: jane@acme.com
+          password_first_attempt:
+            summary: Identify + first-factor password in one call
+            value:
+              identifier: jane@acme.com
+              strategy: password
+              password: "correct horse battery staple"
+          email_code:
+            summary: Identify + start an email code
+            value:
+              identifier: jane@acme.com
+              strategy: email_code
+  responses:
+    "200":
+      description: New (or transitioned) sign-in attempt, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }
+    "429": { $ref: ../components/responses/TooManyRequests.yaml }

--- a/paths/sign-up-attempt-verification.yaml
+++ b/paths/sign-up-attempt-verification.yaml
@@ -1,0 +1,46 @@
+parameters:
+  - name: sign_up_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+post:
+  operationId: attemptVerification
+  summary: Attempt sign-up verification
+  description: |
+    Submit the user's answer to a sign-up challenge (the email code in
+    v0.1). On success the matching attribute moves out of
+    `unverified_fields` and — if no other requirements remain — the
+    sign-up transitions to `complete` (sets `created_user_id` and
+    `created_session_id`).
+  tags: [Sign-Ups]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [strategy]
+          additionalProperties: false
+          properties:
+            strategy:
+              type: string
+              enum: [email_code]
+            code:      { type: string }
+            signature: { type: string, description: Reserved for v0.5 (passkey). }
+        examples:
+          email_code:
+            value: { strategy: email_code, code: "542178" }
+  responses:
+    "200":
+      description: Sign-up transitioned (possibly to `complete`), wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }
+    "429": { $ref: ../components/responses/TooManyRequests.yaml }

--- a/paths/sign-up-prepare-verification.yaml
+++ b/paths/sign-up-prepare-verification.yaml
@@ -1,0 +1,45 @@
+parameters:
+  - name: sign_up_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+post:
+  operationId: prepareVerification
+  summary: Prepare sign-up verification
+  description: |
+    Issue a verification challenge for one of the unverified attributes
+    on the sign-up (e.g. send the email code). v0.1 supports
+    `email_code`.
+  tags: [Sign-Ups]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [strategy]
+          additionalProperties: false
+          properties:
+            strategy:
+              type: string
+              enum: [email_code]
+            redirect_url:
+              type: string
+              format: uri
+        examples:
+          email_code:
+            value: { strategy: email_code }
+  responses:
+    "200":
+      description: Sign-up with the new verification populated, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }
+    "429": { $ref: ../components/responses/TooManyRequests.yaml }

--- a/paths/sign-up.yaml
+++ b/paths/sign-up.yaml
@@ -1,0 +1,60 @@
+parameters:
+  - name: sign_up_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+get:
+  operationId: getSignUp
+  summary: Get a sign-up attempt
+  description: Fetch the current state of an in-progress sign-up attempt by ID.
+  tags: [Sign-Ups]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: The sign-up attempt.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/SignUp.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }
+
+patch:
+  operationId: updateSignUp
+  summary: Patch missing sign-up fields
+  description: |
+    Fill in fields that were missing in the create call. Sending the
+    same field twice transparently overwrites the previous value.
+  tags: [Sign-Ups]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          additionalProperties: false
+          properties:
+            email_address: { type: string, format: email }
+            phone_number:  { type: string }
+            username:      { type: string }
+            first_name:    { type: string }
+            last_name:     { type: string }
+            password:
+              type: string
+              minLength: 8
+            unsafe_metadata: { $ref: ../components/schemas/Metadata.yaml }
+            legal_accepted:  { type: boolean }
+  responses:
+    "200":
+      description: The transitioned sign-up, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }

--- a/paths/sign-ups.yaml
+++ b/paths/sign-ups.yaml
@@ -1,0 +1,52 @@
+post:
+  operationId: createSignUp
+  summary: Create a sign-up attempt
+  description: |
+    Start a sign-up flow. Any subset of the supported fields may be
+    supplied; whatever's missing is reported in the response's
+    `missing_fields[]`.
+  tags: [Sign-Ups]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          additionalProperties: false
+          properties:
+            email_address: { type: string, format: email }
+            phone_number:  { type: string }
+            username:      { type: string }
+            first_name:    { type: string }
+            last_name:     { type: string }
+            password:
+              type: string
+              minLength: 8
+            unsafe_metadata: { $ref: ../components/schemas/Metadata.yaml }
+            redirect_url:    { type: string, format: uri }
+            ticket:          { type: string }
+            transfer:        { type: boolean, default: false }
+            legal_accepted:  { type: boolean }
+            captcha_token:        { type: string }
+            captcha_widget_type:  { type: string, enum: [smart, invisible, managed] }
+            captcha_error:        { type: string }
+        examples:
+          email_password:
+            summary: Email + password sign-up
+            value:
+              email_address: jane@acme.com
+              password: "correct horse battery staple"
+              first_name: Jane
+              last_name: Doe
+  responses:
+    "200":
+      description: The new sign-up attempt, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }
+    "429": { $ref: ../components/responses/TooManyRequests.yaml }


### PR DESCRIPTION
## Summary

Implements [OA-3](https://github.com/authn-sh/openapi/issues/3) — the Frontend API surface that browsers and embeddable components talk to. Drives the entire Account Portal and the `@authn.sh/sdk-react` component library.

### Schemas (`components/schemas/`) — 7 new

- **`Client`** — per-device state container (`sessions[]` + `sign_in` + `sign_up` + `last_active_session_id`).
- **`Environment`** — public bootstrap config (`auth_config`, `display_config`, `user_settings`, `organization_settings` + `commerce_settings` v0.x placeholders, `captcha`, `localization`, `oauth_providers` placeholder).
- **`Session`** — `id`/`object`/`client_id`/`user_id`/`status` (`pending|active|expired|ended|removed|replaced|revoked|abandoned`)/`last_active_at`/`expire_at`/`abandon_at`/`last_active_organization_id`/`actor`/`latest_activity` (`SessionActivity`) + timestamps.
- **`SessionActivity`** — device fingerprint last seen on a session.
- **`SignIn`** — state machine: `needs_identifier|needs_first_factor|needs_second_factor|needs_new_password|needs_client_trust|complete|abandoned`. Carries `supported_*_factors`, `*_factor_verification` (refs `Verification` from OA-2), `identifier`, `user_data` preview, `created_session_id`, `abandon_at`.
- **`SignUp`** — state machine: `missing_requirements|complete|transferable|abandoned`. Carries `required_fields`/`optional_fields`/`missing_fields`/`unverified_fields`, `verifications` map, identifier + name fields, `password_enabled`, `*_metadata`, `created_user_id`, `created_session_id`.
- **`ClientResponseEnvelope`** — every FAPI write returns `{ response, client }` so the SDK refreshes device state atomically.

### Paths (`paths/`) — 30 new path items / 39 new operations

- `/v1/environment` GET (public): `getEnvironment`.
- `/v1/client` GET/PUT/DELETE: `getClient` (no auth) + `createClient` + `destroyClient`. `/v1/client/handshake` GET (no auth): `clientHandshake` (SSR).
- Sign-Ins: `createSignIn`, `getSignIn`, `prepareFirstFactor`, `attemptFirstFactor`, `prepareSecondFactor` / `attemptSecondFactor` (v0.3 placeholders), `resetPassword`.
- Sign-Ups: `createSignUp`, `getSignUp`, `updateSignUp`, `prepareVerification`, `attemptVerification`.
- Sessions (FAPI): `getSession` + `/end` + `/remove` + `/touch` + `/tokens` + `/tokens/{template_name}` (v0.7 placeholder).
- Me: `getMe`/`updateMe`/`deleteMe`, `uploadMyProfileImage` + `deleteMyProfileImage`, `listMyEmailAddresses`/`createMyEmailAddress`, `getMyEmailAddress`/`updateMyEmailAddress`/`deleteMyEmailAddress`, `prepareMyEmailVerification`/`attemptMyEmailVerification`, `listMySessions`, `changeMyPassword`, `removeMyPassword`, `deleteMyself`.

### Conventions

- All FAPI write operations respond with `ClientResponseEnvelope`.
- Read operations return the bare resource.
- Per-operation `security`: `{ client_cookie }`, `{ dev_browser_jwt }` for everything; `getEnvironment` / `getClient` / `clientHandshake` override to `security: []` (bootstrap).
- Strategy enums on `SignIn`/`SignUp` limited to the v0.1 subset (`password` / `email_code` / `reset_password_email_code` / `ticket`).
- Examples per the acceptance-criteria list: `createSignIn` (password + email_code variants), `attemptFirstFactor` (password + email_code), `createSignUp` (email + password), `attemptVerification` (email_code), `resetPassword`, `getSession`, `getSessionToken`, `getMe`, `createMyEmailAddress`, `prepareMyEmailVerification`.

### Test plan

- [x] `npm run lint` — clean
- [x] `npm run bundle` — **42 path items, 57 operations, 20 schemas**
- [x] `npm run stats` — sanity-checked
- [ ] `npm run preview` (visually verifies examples render — recommended local check)

Closes #3