### PR TITLE
Spec: Invitations, AllowlistIdentifier, BlocklistIdentifier, RedirectUrls, InstanceSettings

### DIFF
--- a/components/schemas/AllowlistIdentifier.yaml
+++ b/components/schemas/AllowlistIdentifier.yaml
@@ -1,0 +1,41 @@
+type: object
+description: |
+  A pattern allowed to sign up while the environment is in
+  `restricted` mode. The `identifier` is either a literal email
+  address / phone number or a wildcard pattern (`*@example.com`,
+  `*@*.example.com`).
+
+  When a sign-up identifier matches a row here, the user is allowed
+  through; when `notify: true`, the row is also used as a
+  to-be-notified seed for the relevant email template.
+required:
+  - id
+  - object
+  - identifier
+  - notify
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: allowlist_identifier
+  identifier:
+    type: string
+    description: |
+      Literal email/phone or a wildcard pattern. Wildcard syntax:
+      `*@example.com` (any local part), `*@*.example.com` (any
+      subdomain). Phone numbers are E.164.
+    examples: ["jane@acme.com", "*@acme.com", "*@*.acme.com", "+15551234567"]
+  notify:
+    type: boolean
+    default: false
+    description: |
+      Send a "you've been invited" email when this row is added (only
+      meaningful for literal email addresses).
+  created_at:
+    $ref: ./Timestamp.yaml
+  updated_at:
+    $ref: ./Timestamp.yaml

--- a/components/schemas/AttributeSetting.yaml
+++ b/components/schemas/AttributeSetting.yaml
@@ -1,0 +1,34 @@
+type: object
+description: |
+  Per-attribute policy embedded in `InstanceSettings.attribute_settings`.
+  `verifications[]` lists the strategies the environment will accept
+  for this attribute (e.g. `["email_code"]`).
+additionalProperties: false
+properties:
+  enabled:
+    type: boolean
+    default: true
+    description: When `false`, the attribute is ignored at sign-up entirely.
+  required:
+    type: boolean
+    default: false
+    description: Sign-up cannot complete without this attribute.
+  used_for_first_factor:
+    type: boolean
+    default: false
+  used_for_second_factor:
+    type: boolean
+    default: false
+  verifications:
+    type: array
+    items:
+      type: string
+    description: Strategies accepted for verifying this attribute.
+    examples: [["email_code"], []]
+  verify_at_sign_up:
+    type: boolean
+    default: false
+    description: |
+      When `true`, sign-up cannot complete until this attribute is
+      verified. When `false`, the attribute can be added unverified
+      and verified later via `/v1/me/email_addresses/{id}`.

--- a/components/schemas/BlocklistIdentifier.yaml
+++ b/components/schemas/BlocklistIdentifier.yaml
@@ -1,0 +1,26 @@
+type: object
+description: |
+  A pattern that is refused at sign-up. Wildcard syntax matches
+  `AllowlistIdentifier`. When both lists match an identifier, the
+  blocklist wins.
+required:
+  - id
+  - object
+  - identifier
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: blocklist_identifier
+  identifier:
+    type: string
+    description: Literal email/phone or a wildcard pattern.
+    examples: ["spammer@acme.com", "*@disposable-mailbox.test"]
+  created_at:
+    $ref: ./Timestamp.yaml
+  updated_at:
+    $ref: ./Timestamp.yaml

--- a/components/schemas/InstanceSettings.yaml
+++ b/components/schemas/InstanceSettings.yaml
@@ -1,0 +1,224 @@
+type: object
+description: |
+  Composite read shape returned by `GET /v1/instance`. Covers every
+  per-environment knob exposed via BAPI today.
+
+  Read-only: `private_metadata` and any secret credential field
+  (notably `captcha.secret_key`, `attack_protection.brute_force.secret`)
+  are write-only — they're accepted on `PATCH` but **never** returned
+  in `GET` responses, so they never reach the dashboard or any audit
+  log unless the caller already supplied them.
+required:
+  - object
+  - sign_up_modes
+  - attribute_settings
+  - restrictions
+  - attack_protection
+  - sessions
+  - paths
+  - test_mode
+  - signing_keys
+  - organizations
+  - audit_log_retention_days
+additionalProperties: false
+properties:
+  object:
+    type: string
+    const: instance_settings
+  support_email:
+    type: [string, "null"]
+    format: email
+  enhanced_email_deliverability:
+    type: boolean
+    default: false
+    description: |
+      When `true`, the instance uses dedicated IPs / DKIM signing for
+      outbound mail. v0.1 surfaces the flag but always returns `false`.
+  sign_up_modes:
+    type: array
+    items:
+      type: string
+      enum: [public, restricted, waitlist]
+    description: |
+      Allowed sign-up modes. `public` is no-allowlist; `restricted`
+      requires an `AllowlistIdentifier` match; `waitlist` defers
+      account creation until the operator approves (post-v0.1).
+  attribute_settings:
+    type: object
+    description: Per-attribute write/verify policy for sign-ups.
+    additionalProperties: false
+    properties:
+      email_address:    { $ref: ./AttributeSetting.yaml }
+      phone_number:     { $ref: ./AttributeSetting.yaml }
+      username:         { $ref: ./AttributeSetting.yaml }
+      first_name:       { $ref: ./AttributeSetting.yaml }
+      last_name:        { $ref: ./AttributeSetting.yaml }
+      password:         { $ref: ./AttributeSetting.yaml }
+  restrictions:
+    type: object
+    additionalProperties: false
+    properties:
+      allowlist_enabled:
+        type: boolean
+        default: false
+      blocklist_enabled:
+        type: boolean
+        default: false
+      block_email_subaddresses:
+        type: boolean
+        default: false
+        description: |
+          When `true`, refuse `local+tag@domain` style addresses to
+          stop a single inbox from creating many accounts.
+      block_disposable_email_domains:
+        type: boolean
+        default: false
+        description: |
+          When `true`, refuse addresses on the maintained
+          disposable-domain list (mailinator, tempmail, etc.).
+      ignore_dots_for_gmail_addresses:
+        type: boolean
+        default: true
+        description: |
+          When `true`, `j.doe@gmail.com` and `jdoe@gmail.com` are
+          treated as the same address for uniqueness.
+  attack_protection:
+    type: object
+    description: Throttles + WAF-ish toggles. Secret credentials are write-only.
+    additionalProperties: false
+    properties:
+      captcha:
+        type: object
+        additionalProperties: false
+        properties:
+          provider:
+            type: string
+            enum: [none, hcaptcha, turnstile]
+            default: none
+          widget_type:
+            type: string
+            enum: [smart, invisible, managed]
+            default: smart
+          public_key:
+            type: [string, "null"]
+            description: Surfaced to the SDK; safe to read.
+      brute_force:
+        type: object
+        additionalProperties: false
+        properties:
+          enabled:
+            type: boolean
+            default: true
+          max_attempts:
+            type: integer
+            minimum: 1
+            default: 100
+          lockout_duration_seconds:
+            type: integer
+            minimum: 0
+            default: 3600
+      device_tracking:
+        type: object
+        additionalProperties: false
+        properties:
+          enabled:
+            type: boolean
+            default: false
+          require_device_trust:
+            type: boolean
+            default: false
+            description: |
+              When `true`, sign-in pauses for an out-of-band device
+              trust check before the session activates.
+  sessions:
+    type: object
+    additionalProperties: false
+    properties:
+      lifetime_seconds:
+        type: integer
+        minimum: 60
+        default: 604800
+        description: Hard ceiling on a session's age.
+      inactivity_timeout_seconds:
+        type: [integer, "null"]
+        minimum: 60
+        description: Sliding-window expiry. `null` to disable.
+      multi_session:
+        type: boolean
+        default: true
+        description: When `false`, signing in on a new device ends every other session for the user.
+      max_concurrent_sessions_per_client:
+        type: integer
+        minimum: 1
+        default: 10
+      url_based_session_syncing:
+        type: boolean
+        default: false
+        description: |
+          When `true`, the SDK wires up cross-tab sync via the URL bar
+          (used for environments that can't share cookies between
+          subdomains).
+      session_token_template:
+        type: [string, "null"]
+        description: |
+          Default JWT template used by `getSessionToken`. v0.1 ignores
+          this and always issues the built-in template.
+  paths:
+    type: object
+    additionalProperties: false
+    properties:
+      sign_in_url:                     { type: string, format: uri }
+      sign_up_url:                     { type: string, format: uri }
+      after_sign_in_url:               { type: string, format: uri }
+      after_sign_up_url:               { type: string, format: uri }
+      unauthorized_sign_in_url:        { type: string, format: uri }
+      user_profile_url:                { type: string, format: uri }
+      create_organization_url:         { type: [string, "null"], format: uri }
+      organization_profile_url:        { type: [string, "null"], format: uri }
+      after_leave_organization_url:    { type: [string, "null"], format: uri }
+      after_create_organization_url:   { type: [string, "null"], format: uri }
+      home_url:                        { type: [string, "null"], format: uri }
+  test_mode:
+    type: string
+    enum: [enabled, disabled, rejected]
+    description: |
+      `enabled` — `*_test_*` identifiers + the magic `424242` code work
+      end-to-end without sending real emails. `disabled` — test
+      affordances are off. `rejected` — sign-ins/sign-ups using the
+      magic identifiers are refused (production hardening).
+  signing_keys:
+    type: object
+    additionalProperties: false
+    properties:
+      rotation_cadence_days:
+        type: integer
+        minimum: 1
+        default: 90
+      pre_publish_window_seconds:
+        type: integer
+        minimum: 0
+        default: 86400
+        description: |
+          How long a new key sits in JWKS before becoming the active
+          signing key. Lets caches warm up.
+      retire_window_seconds:
+        type: integer
+        minimum: 0
+        default: 604800
+        description: |
+          How long a retired key stays in JWKS before being deleted.
+  organizations:
+    type: object
+    description: |
+      Placeholder for organization-level settings. Always
+      `enabled: false` in v0.1 — full schema lands in v0.2.
+    additionalProperties: true
+    properties:
+      enabled:
+        type: boolean
+        default: false
+  audit_log_retention_days:
+    type: integer
+    minimum: 1
+    maximum: 3650
+    default: 90

--- a/components/schemas/InstanceUpdateRequest.yaml
+++ b/components/schemas/InstanceUpdateRequest.yaml
@@ -1,0 +1,50 @@
+type: object
+description: |
+  Body for `PATCH /v1/instance`. Top-level toggles + writable nested
+  groups. Every field is optional; unspecified groups are left
+  untouched.
+
+  Secret credentials (e.g. `attack_protection.captcha.secret_key`,
+  `attack_protection.brute_force.secret`) are accepted here but **never**
+  returned by `GET /v1/instance` (write-only).
+additionalProperties: false
+properties:
+  support_email:
+    type: [string, "null"]
+    format: email
+  enhanced_email_deliverability:
+    type: boolean
+  sign_up_modes:
+    type: array
+    items:
+      type: string
+      enum: [public, restricted, waitlist]
+  test_mode:
+    type: string
+    enum: [enabled, disabled, rejected]
+  paths:
+    type: object
+    additionalProperties: true
+  attribute_settings:
+    type: object
+    description: |
+      Same shape as `InstanceSettings.attribute_settings`; you can
+      patch any subset of attributes.
+    additionalProperties: true
+  attack_protection:
+    type: object
+    description: |
+      Patch any nested toggle. Setting `captcha.secret_key` rotates the
+      provider secret; the new value never appears in subsequent `GET`s.
+    additionalProperties: true
+  sessions:
+    type: object
+    description: Same shape as `InstanceSettings.sessions`.
+    additionalProperties: true
+  signing_keys:
+    type: object
+    additionalProperties: true
+  audit_log_retention_days:
+    type: integer
+    minimum: 1
+    maximum: 3650

--- a/components/schemas/Invitation.yaml
+++ b/components/schemas/Invitation.yaml
@@ -1,0 +1,61 @@
+type: object
+description: |
+  Application-level (non-organization) invitation. Each invitation
+  carries a single-use ticket — the recipient clicks `url`, lands on
+  the Account Portal pre-fill page, and either signs up (transferring
+  the ticket into a new `User`) or signs in (linking the address to
+  the existing `User`).
+required:
+  - id
+  - object
+  - email_address
+  - status
+  - revoked
+  - url
+  - public_metadata
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: invitation
+  email_address:
+    type: string
+    format: email
+    maxLength: 254
+  redirect_url:
+    type: [string, "null"]
+    format: uri
+    description: |
+      Where the Account Portal returns the user after they accept. Must
+      be on the redirect-URL allowlist.
+  public_metadata:
+    $ref: ./Metadata.yaml
+  status:
+    type: string
+    enum: [pending, accepted, revoked, expired]
+  revoked:
+    type: boolean
+    default: false
+  url:
+    type: string
+    format: uri
+    description: |
+      Click-through URL. Includes the ticket and the
+      `__authn_status=sign_up` (or `sign_in`) query so the SDK knows
+      which flow to start. The full v0.1 query convention lives in
+      PLAN §9.7.
+    examples:
+      - "https://acme.authn.sh/v1/client/handshake?__authn_ticket=tkt_01HKX9SY9V7H7TF8C8K7J9X4ZG&__authn_status=sign_up&redirect_url=https%3A%2F%2Fapp.acme.com%2Fwelcome"
+  expires_at:
+    type: [integer, "null"]
+    format: int64
+    minimum: 0
+    description: Unix ms; `null` for invitations that don't expire.
+  created_at:
+    $ref: ./Timestamp.yaml
+  updated_at:
+    $ref: ./Timestamp.yaml

--- a/components/schemas/InvitationBulkCreateRequest.yaml
+++ b/components/schemas/InvitationBulkCreateRequest.yaml
@@ -1,0 +1,14 @@
+type: object
+description: |
+  Body for `POST /v1/invitations/bulk`. Atomic across the whole batch:
+  if any single invitation fails validation, the entire request is
+  rejected and no rows are inserted.
+required: [invitations]
+additionalProperties: false
+properties:
+  invitations:
+    type: array
+    minItems: 1
+    maxItems: 500
+    items:
+      $ref: ./InvitationCreateRequest.yaml

--- a/components/schemas/InvitationCreateRequest.yaml
+++ b/components/schemas/InvitationCreateRequest.yaml
@@ -1,0 +1,40 @@
+type: object
+description: Body for `POST /v1/invitations`.
+required: [email_address]
+additionalProperties: false
+properties:
+  email_address:
+    type: string
+    format: email
+    maxLength: 254
+  redirect_url:
+    type: string
+    format: uri
+    description: Must match the redirect-URL allowlist.
+  public_metadata:
+    $ref: ./Metadata.yaml
+  notify:
+    type: boolean
+    default: true
+    description: |
+      When `true`, send the invitation email immediately. Set to `false`
+      to mint the ticket without sending email (caller will deliver it
+      via their own channel).
+  expires_in_days:
+    type: [integer, "null"]
+    minimum: 1
+    maximum: 365
+    description: Days until `expires_at`. `null` for invitations that don't expire.
+  template_slug:
+    type: string
+    description: |
+      Reference an alternative invitation email template by slug.
+      Templates ship in v0.5; v0.1 always uses the default template
+      and ignores this field.
+  ignore_existing:
+    type: boolean
+    default: false
+    description: |
+      When `true`, allow creating an invitation for an email address
+      that's already attached to a `User`. Default `false` returns
+      `422 invitation_for_existing_user`.

--- a/components/schemas/OrganizationSettingsUpdateRequest.yaml
+++ b/components/schemas/OrganizationSettingsUpdateRequest.yaml
@@ -1,0 +1,11 @@
+type: object
+description: |
+  Placeholder body for `PATCH /v1/instance/organization_settings`.
+  v0.1 only accepts `enabled: false`; the full schema lands in v0.2.
+additionalProperties: true
+properties:
+  enabled:
+    type: boolean
+    description: |
+      Always validated as `false` in v0.1. Setting it to `true` returns
+      `422 organizations_not_available`.

--- a/components/schemas/RedirectUrl.yaml
+++ b/components/schemas/RedirectUrl.yaml
@@ -1,0 +1,30 @@
+type: object
+description: |
+  An HTTPS URL allowed as a post-flow redirect target. The Account
+  Portal and FAPI `redirect_url` parameters are validated against this
+  list to prevent open-redirect abuse.
+required:
+  - id
+  - object
+  - url
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: redirect_url
+  url:
+    type: string
+    format: uri
+    description: |
+      Origin-and-path URL. Trailing slashes are normalized away. Match
+      semantics: exact origin + path-prefix; query and fragment are
+      ignored.
+    examples: ["https://app.acme.com/welcome", "http://localhost:3000/sign-in"]
+  created_at:
+    $ref: ./Timestamp.yaml
+  updated_at:
+    $ref: ./Timestamp.yaml

--- a/components/schemas/RestrictionsUpdateRequest.yaml
+++ b/components/schemas/RestrictionsUpdateRequest.yaml
@@ -1,0 +1,9 @@
+type: object
+description: Body for `PATCH /v1/instance/restrictions`. Same shape as `InstanceSettings.restrictions`.
+additionalProperties: false
+properties:
+  allowlist_enabled:                  { type: boolean }
+  blocklist_enabled:                  { type: boolean }
+  block_email_subaddresses:           { type: boolean }
+  block_disposable_email_domains:     { type: boolean }
+  ignore_dots_for_gmail_addresses:    { type: boolean }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -173,6 +173,32 @@ paths:
   /v1/me/delete_self:
     $ref: ./paths/me-delete-self.yaml
 
+  # BAPI: invitations + restrictions + redirect URLs + instance settings.
+  /v1/invitations:
+    $ref: ./paths/invitations.yaml
+  /v1/invitations/bulk:
+    $ref: ./paths/invitations-bulk.yaml
+  /v1/invitations/{invitation_id}/revoke:
+    $ref: ./paths/invitation-revoke.yaml
+  /v1/allowlist_identifiers:
+    $ref: ./paths/allowlist-identifiers.yaml
+  /v1/allowlist_identifiers/{identifier_id}:
+    $ref: ./paths/allowlist-identifier.yaml
+  /v1/blocklist_identifiers:
+    $ref: ./paths/blocklist-identifiers.yaml
+  /v1/blocklist_identifiers/{identifier_id}:
+    $ref: ./paths/blocklist-identifier.yaml
+  /v1/redirect_urls:
+    $ref: ./paths/redirect-urls.yaml
+  /v1/redirect_urls/{redirect_url_id}:
+    $ref: ./paths/redirect-url.yaml
+  /v1/instance:
+    $ref: ./paths/instance.yaml
+  /v1/instance/restrictions:
+    $ref: ./paths/instance-restrictions.yaml
+  /v1/instance/organization_settings:
+    $ref: ./paths/instance-organization-settings.yaml
+
 components:
   securitySchemes:
     bearer_secret_key:
@@ -224,6 +250,17 @@ components:
     SessionActivity:           { $ref: ./components/schemas/SessionActivity.yaml }
     SignIn:                    { $ref: ./components/schemas/SignIn.yaml }
     SignUp:                    { $ref: ./components/schemas/SignUp.yaml }
+    Invitation:                       { $ref: ./components/schemas/Invitation.yaml }
+    InvitationCreateRequest:          { $ref: ./components/schemas/InvitationCreateRequest.yaml }
+    InvitationBulkCreateRequest:      { $ref: ./components/schemas/InvitationBulkCreateRequest.yaml }
+    AllowlistIdentifier:              { $ref: ./components/schemas/AllowlistIdentifier.yaml }
+    BlocklistIdentifier:              { $ref: ./components/schemas/BlocklistIdentifier.yaml }
+    RedirectUrl:                      { $ref: ./components/schemas/RedirectUrl.yaml }
+    InstanceSettings:                 { $ref: ./components/schemas/InstanceSettings.yaml }
+    AttributeSetting:                 { $ref: ./components/schemas/AttributeSetting.yaml }
+    InstanceUpdateRequest:            { $ref: ./components/schemas/InstanceUpdateRequest.yaml }
+    RestrictionsUpdateRequest:        { $ref: ./components/schemas/RestrictionsUpdateRequest.yaml }
+    OrganizationSettingsUpdateRequest: { $ref: ./components/schemas/OrganizationSettingsUpdateRequest.yaml }
 
   responses:
     BadRequest:           { $ref: ./components/responses/BadRequest.yaml }

--- a/paths/allowlist-identifier.yaml
+++ b/paths/allowlist-identifier.yaml
@@ -1,0 +1,16 @@
+parameters:
+  - name: identifier_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+delete:
+  operationId: deleteAllowlistIdentifier
+  summary: Delete an allowlist identifier
+  description: Idempotent removal of a single allowlist row.
+  tags: [Allowlist Identifiers]
+  responses:
+    "204":
+      description: Deleted.
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }

--- a/paths/allowlist-identifiers.yaml
+++ b/paths/allowlist-identifiers.yaml
@@ -1,0 +1,60 @@
+get:
+  operationId: listAllowlistIdentifiers
+  summary: List allowlist identifiers
+  description: Paginated list. The allowlist gates sign-ups while the environment is in `restricted` mode.
+  tags: [Allowlist Identifiers]
+  parameters:
+    - $ref: ../components/parameters/LimitParam.yaml
+    - $ref: ../components/parameters/OffsetParam.yaml
+  responses:
+    "200":
+      description: A page of allowlist identifiers.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: ../components/schemas/PaginatedList.yaml
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: ../components/schemas/AllowlistIdentifier.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+
+post:
+  operationId: createAllowlistIdentifier
+  summary: Create an allowlist identifier
+  description: Add a literal identifier or a wildcard pattern (`*@example.com`).
+  tags: [Allowlist Identifiers]
+  parameters:
+    - $ref: ../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [identifier]
+          additionalProperties: false
+          properties:
+            identifier:
+              type: string
+            notify:
+              type: boolean
+              default: false
+        examples:
+          literal:
+            summary: Literal email address
+            value: { identifier: jane@acme.com, notify: true }
+          wildcard:
+            summary: Anyone at the acme.com domain
+            value: { identifier: "*@acme.com" }
+  responses:
+    "201":
+      description: The created identifier.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/AllowlistIdentifier.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "409": { $ref: ../components/responses/Conflict.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }

--- a/paths/blocklist-identifier.yaml
+++ b/paths/blocklist-identifier.yaml
@@ -1,0 +1,16 @@
+parameters:
+  - name: identifier_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+delete:
+  operationId: deleteBlocklistIdentifier
+  summary: Delete a blocklist identifier
+  description: Idempotent removal of a single blocklist row.
+  tags: [Blocklist Identifiers]
+  responses:
+    "204":
+      description: Deleted.
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }

--- a/paths/blocklist-identifiers.yaml
+++ b/paths/blocklist-identifiers.yaml
@@ -1,0 +1,55 @@
+get:
+  operationId: listBlocklistIdentifiers
+  summary: List blocklist identifiers
+  description: Paginated list. Blocklist matches always refuse sign-up, even in `public` mode.
+  tags: [Blocklist Identifiers]
+  parameters:
+    - $ref: ../components/parameters/LimitParam.yaml
+    - $ref: ../components/parameters/OffsetParam.yaml
+  responses:
+    "200":
+      description: A page of blocklist identifiers.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: ../components/schemas/PaginatedList.yaml
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: ../components/schemas/BlocklistIdentifier.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+
+post:
+  operationId: createBlocklistIdentifier
+  summary: Create a blocklist identifier
+  description: Add a literal identifier or a wildcard pattern.
+  tags: [Blocklist Identifiers]
+  parameters:
+    - $ref: ../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [identifier]
+          additionalProperties: false
+          properties:
+            identifier:
+              type: string
+        examples:
+          literal:
+            value: { identifier: spammer@acme.com }
+          wildcard:
+            value: { identifier: "*@disposable-mailbox.test" }
+  responses:
+    "201":
+      description: The created identifier.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/BlocklistIdentifier.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "409": { $ref: ../components/responses/Conflict.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }

--- a/paths/instance-organization-settings.yaml
+++ b/paths/instance-organization-settings.yaml
@@ -1,0 +1,22 @@
+patch:
+  operationId: updateOrganizationSettings
+  summary: Patch organization settings (v0.2 placeholder)
+  description: |
+    v0.1 only accepts `enabled: false`. The full schema lands in v0.2
+    along with the organization API surface.
+  tags: [Instance]
+  parameters:
+    - $ref: ../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../components/schemas/OrganizationSettingsUpdateRequest.yaml }
+  responses:
+    "200":
+      description: The updated instance settings.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/InstanceSettings.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }

--- a/paths/instance-restrictions.yaml
+++ b/paths/instance-restrictions.yaml
@@ -1,0 +1,31 @@
+patch:
+  operationId: updateRestrictions
+  summary: Patch sign-up restrictions
+  description: |
+    Convenience endpoint that scopes the patch to the
+    `restrictions` group. Equivalent to `PATCH /v1/instance` with
+    `{ "restrictions": { … } }` but doesn't require sending the rest of
+    the settings tree.
+  tags: [Instance]
+  parameters:
+    - $ref: ../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../components/schemas/RestrictionsUpdateRequest.yaml }
+        examples:
+          turn_on_allowlist:
+            summary: Switch to allowlist mode and refuse disposable email domains
+            value:
+              allowlist_enabled: true
+              block_disposable_email_domains: true
+              block_email_subaddresses: false
+  responses:
+    "200":
+      description: The updated instance settings.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/InstanceSettings.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }

--- a/paths/instance.yaml
+++ b/paths/instance.yaml
@@ -1,0 +1,107 @@
+get:
+  operationId: getInstance
+  summary: Get instance settings
+  description: |
+    Returns the composite per-environment settings tree. Secret
+    credentials (`attack_protection.captcha.secret_key`,
+    `attack_protection.brute_force.secret`) and any `private_metadata`
+    are write-only and never appear here.
+  tags: [Instance]
+  responses:
+    "200":
+      description: Instance settings.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/InstanceSettings.yaml }
+          examples:
+            production:
+              summary: A typical production environment
+              value:
+                object: instance_settings
+                support_email: support@acme.com
+                enhanced_email_deliverability: false
+                sign_up_modes: [public]
+                attribute_settings:
+                  email_address:
+                    enabled: true
+                    required: true
+                    used_for_first_factor: true
+                    used_for_second_factor: false
+                    verifications: [email_code]
+                    verify_at_sign_up: true
+                  password:
+                    enabled: true
+                    required: true
+                    used_for_first_factor: true
+                    used_for_second_factor: false
+                    verifications: []
+                    verify_at_sign_up: false
+                restrictions:
+                  allowlist_enabled: false
+                  blocklist_enabled: false
+                  block_email_subaddresses: false
+                  block_disposable_email_domains: true
+                  ignore_dots_for_gmail_addresses: true
+                attack_protection:
+                  captcha:
+                    provider: turnstile
+                    widget_type: smart
+                    public_key: "0x4AAAAAAAAAAAAAAAAAAAAA"
+                  brute_force:
+                    enabled: true
+                    max_attempts: 100
+                    lockout_duration_seconds: 3600
+                  device_tracking:
+                    enabled: false
+                    require_device_trust: false
+                sessions:
+                  lifetime_seconds: 604800
+                  inactivity_timeout_seconds: null
+                  multi_session: true
+                  max_concurrent_sessions_per_client: 10
+                  url_based_session_syncing: false
+                  session_token_template: null
+                paths:
+                  sign_in_url: https://app.acme.com/sign-in
+                  sign_up_url: https://app.acme.com/sign-up
+                  after_sign_in_url: https://app.acme.com/dashboard
+                  after_sign_up_url: https://app.acme.com/welcome
+                  unauthorized_sign_in_url: https://app.acme.com/forbidden
+                  user_profile_url: https://app.acme.com/profile
+                  create_organization_url: null
+                  organization_profile_url: null
+                  after_leave_organization_url: null
+                  after_create_organization_url: null
+                  home_url: https://app.acme.com
+                test_mode: rejected
+                signing_keys:
+                  rotation_cadence_days: 90
+                  pre_publish_window_seconds: 86400
+                  retire_window_seconds: 604800
+                organizations:
+                  enabled: false
+                audit_log_retention_days: 365
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+
+patch:
+  operationId: updateInstance
+  summary: Patch instance settings
+  description: |
+    Update top-level toggles and the writable nested groups. Secret
+    credentials supplied here are stored but never returned by `GET`.
+  tags: [Instance]
+  parameters:
+    - $ref: ../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../components/schemas/InstanceUpdateRequest.yaml }
+  responses:
+    "200":
+      description: The updated instance settings.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/InstanceSettings.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }

--- a/paths/invitation-revoke.yaml
+++ b/paths/invitation-revoke.yaml
@@ -1,0 +1,35 @@
+parameters:
+  - name: invitation_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+post:
+  operationId: revokeInvitation
+  summary: Revoke an invitation
+  description: |
+    Mark the invitation `revoked` and invalidate its ticket. Idempotent:
+    revoking an already-revoked invitation is a no-op.
+  tags: [Invitations]
+  responses:
+    "200":
+      description: The revoked invitation.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/Invitation.yaml }
+          examples:
+            revoked:
+              value:
+                id: inv_01HKX9SY9V7H7TF8C8K7J9X4ZG
+                object: invitation
+                email_address: jane@acme.com
+                redirect_url: null
+                public_metadata: {}
+                status: revoked
+                revoked: true
+                url: "https://acme.authn.sh/v1/client/handshake?__authn_ticket=tkt_01HKX9SY9V7H7TF8C8K7J9X4ZG&__authn_status=sign_up"
+                expires_at: 1717487999000
+                created_at: 1714895999000
+                updated_at: 1714896200000
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }

--- a/paths/invitations-bulk.yaml
+++ b/paths/invitations-bulk.yaml
@@ -1,0 +1,43 @@
+post:
+  operationId: bulkCreateInvitations
+  summary: Bulk-create invitations
+  description: |
+    Atomic batch create. If any invitation fails validation the entire
+    request is rejected; the response describes the offending row(s).
+  tags: [Invitations]
+  parameters:
+    - $ref: ../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../components/schemas/InvitationBulkCreateRequest.yaml }
+        examples:
+          batch:
+            summary: Two invitations in one call
+            value:
+              invitations:
+                - email_address: jane@acme.com
+                  redirect_url: https://app.acme.com/welcome
+                - email_address: john@acme.com
+                  notify: false
+                  expires_in_days: 30
+  responses:
+    "201":
+      description: Created invitations.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [data, total_count]
+            additionalProperties: false
+            properties:
+              data:
+                type: array
+                items: { $ref: ../components/schemas/Invitation.yaml }
+              total_count:
+                type: integer
+                minimum: 0
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "409": { $ref: ../components/responses/Conflict.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }

--- a/paths/invitations.yaml
+++ b/paths/invitations.yaml
@@ -1,0 +1,87 @@
+get:
+  operationId: listInvitations
+  summary: List invitations
+  description: Paginated list of invitations, filterable by `status` and free-text `query`.
+  tags: [Invitations]
+  parameters:
+    - $ref: ../components/parameters/LimitParam.yaml
+    - $ref: ../components/parameters/OffsetParam.yaml
+    - $ref: ../components/parameters/OrderByParam.yaml
+    - name: status
+      in: query
+      required: false
+      schema:
+        type: string
+        enum: [pending, accepted, revoked, expired]
+    - name: query
+      in: query
+      description: Free-text match against `email_address`.
+      required: false
+      schema: { type: string }
+  responses:
+    "200":
+      description: A page of invitations.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: ../components/schemas/PaginatedList.yaml
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: ../components/schemas/Invitation.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }
+
+post:
+  operationId: createInvitation
+  summary: Create an invitation
+  description: |
+    Mint a single invitation. By default an email is sent immediately;
+    set `notify: false` to mint a ticket without sending.
+  tags: [Invitations]
+  parameters:
+    - $ref: ../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../components/schemas/InvitationCreateRequest.yaml }
+        examples:
+          basic:
+            summary: Email + redirect_url, default expiry
+            value:
+              email_address: jane@acme.com
+              redirect_url: https://app.acme.com/welcome
+              public_metadata: { plan: pro }
+          silent:
+            summary: Mint ticket only, no email
+            value:
+              email_address: jane@acme.com
+              notify: false
+              expires_in_days: 30
+  responses:
+    "201":
+      description: The new invitation.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/Invitation.yaml }
+          examples:
+            created:
+              value:
+                id: inv_01HKX9SY9V7H7TF8C8K7J9X4ZG
+                object: invitation
+                email_address: jane@acme.com
+                redirect_url: https://app.acme.com/welcome
+                public_metadata: { plan: pro }
+                status: pending
+                revoked: false
+                url: "https://acme.authn.sh/v1/client/handshake?__authn_ticket=tkt_01HKX9SY9V7H7TF8C8K7J9X4ZG&__authn_status=sign_up&redirect_url=https%3A%2F%2Fapp.acme.com%2Fwelcome"
+                expires_at: 1717487999000
+                created_at: 1714895999000
+                updated_at: 1714895999000
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "409": { $ref: ../components/responses/Conflict.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }
+    "429": { $ref: ../components/responses/TooManyRequests.yaml }

--- a/paths/redirect-url.yaml
+++ b/paths/redirect-url.yaml
@@ -1,0 +1,30 @@
+parameters:
+  - name: redirect_url_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+get:
+  operationId: getRedirectUrl
+  summary: Get a redirect URL
+  description: Fetch a single redirect URL by ID.
+  tags: [Redirect URLs]
+  responses:
+    "200":
+      description: The redirect URL.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/RedirectUrl.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }
+
+delete:
+  operationId: deleteRedirectUrl
+  summary: Delete a redirect URL
+  description: Idempotent removal.
+  tags: [Redirect URLs]
+  responses:
+    "204":
+      description: Deleted.
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }

--- a/paths/redirect-urls.yaml
+++ b/paths/redirect-urls.yaml
@@ -1,0 +1,58 @@
+get:
+  operationId: listRedirectUrls
+  summary: List redirect URLs
+  description: Paginated list of allowed post-flow redirect targets.
+  tags: [Redirect URLs]
+  parameters:
+    - $ref: ../components/parameters/LimitParam.yaml
+    - $ref: ../components/parameters/OffsetParam.yaml
+  responses:
+    "200":
+      description: A page of redirect URLs.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: ../components/schemas/PaginatedList.yaml
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: ../components/schemas/RedirectUrl.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+
+post:
+  operationId: createRedirectUrl
+  summary: Create a redirect URL
+  description: |
+    Add a URL to the allowlist. HTTPS required in production
+    environments; `http://localhost:*` is allowed in test environments.
+  tags: [Redirect URLs]
+  parameters:
+    - $ref: ../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [url]
+          additionalProperties: false
+          properties:
+            url:
+              type: string
+              format: uri
+        examples:
+          prod:
+            value: { url: "https://app.acme.com/welcome" }
+          dev:
+            value: { url: "http://localhost:3000/sign-in" }
+  responses:
+    "201":
+      description: The created redirect URL.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/RedirectUrl.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "409": { $ref: ../components/responses/Conflict.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }


### PR DESCRIPTION
## Summary

Implements [OA-4](https://github.com/authn-sh/openapi/issues/4) — closes the v0.1 BAPI surface (modulo webhook endpoints, which are OA-5): application invitations, allowlist/blocklist identifiers, redirect-URL allowlist, and instance-level settings.

### Schemas (`components/schemas/`) — 12 new

- **`Invitation`** — id/object/email_address/redirect_url/public_metadata/status (`pending|accepted|revoked|expired`)/revoked/`url` (with the `?__authn_ticket=…&__authn_status=sign_up&redirect_url=…` convention from PLAN §9.7 in the example)/expires_at/timestamps.
- **`InvitationCreateRequest`**, **`InvitationBulkCreateRequest`**.
- **`AllowlistIdentifier`** (literal + wildcard syntax + optional `notify`), **`BlocklistIdentifier`** (no `notify`), **`RedirectUrl`**.
- **`InstanceSettings`** — composite read shape covering `sign_up_modes`, `attribute_settings` (per-attribute via `AttributeSetting`), `restrictions`, `attack_protection` (captcha + brute_force + device_tracking), `sessions`, `paths`, `test_mode`, `signing_keys`, `organizations` placeholder, `audit_log_retention_days`. Documents that secret credentials (`captcha.secret_key`, `brute_force.secret`) and `private_metadata` are write-only and excluded from `GET` responses.
- **`AttributeSetting`** — per-attribute `enabled`/`required`/`used_for_*_factor`/`verifications`/`verify_at_sign_up`.
- **`InstanceUpdateRequest`**, **`RestrictionsUpdateRequest`**, **`OrganizationSettingsUpdateRequest`** patch shapes.

### Paths (`paths/`) — 12 new path items / 18 new operations

- `/v1/invitations` GET (`listInvitations`) + POST (`createInvitation`)
- `/v1/invitations/bulk` POST (`bulkCreateInvitations`, atomic batch)
- `/v1/invitations/{id}/revoke` POST (`revokeInvitation`)
- `/v1/allowlist_identifiers` GET/POST + `/{id}` DELETE
- `/v1/blocklist_identifiers` GET/POST + `/{id}` DELETE
- `/v1/redirect_urls` GET/POST + `/{id}` GET/DELETE
- `/v1/instance` GET (`getInstance`) + PATCH (`updateInstance`)
- `/v1/instance/restrictions` PATCH (`updateRestrictions`)
- `/v1/instance/organization_settings` PATCH (`updateOrganizationSettings`, v0.1 placeholder)

### Examples included

`createInvitation` (basic + silent), `bulkCreateInvitations`, `revokeInvitation`, `createAllowlistIdentifier` (literal + wildcard), `getInstance` (full production example), `updateRestrictions`. The `Invitation.url` example carries the full `?__authn_ticket=…&__authn_status=sign_up&redirect_url=…` query convention end-to-end.

### Test plan

- [x] `npm run lint` — clean
- [x] `npm run bundle` — **54 path items, 75 operations, 31 schemas**
- [x] `npm run stats` — sanity-checked

### Note on a pre-existing gap

The sdk-php BAPI client (SP-2) calls `/v1/sessions/*` endpoints (admin-side session list/get/revoke/tokens), but those aren't in the OA-2/OA-3/OA-4 scope — OA-3 covered the FAPI `/v1/client/sessions/*` only. A follow-up issue is needed for the BAPI sessions surface so the sdk-php contract test fully passes once activated.

Closes #4