### PR TITLE
Spec: Webhook envelope + v0.1 event types + endpoints CRUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,40 @@ SDK repos pull `dist/openapi.bundled.json` from this repo's CI artifacts (or fro
 
 Pin the spec version in each SDK's `package.json` / `composer.json` / `go.mod` to the openapi tag you want to track.
 
+## Webhook signature contract
+
+Every delivery `POST`s a JSON `WebhookEvent` body and three headers:
+
+| Header           | Meaning                                                                 |
+|------------------|-------------------------------------------------------------------------|
+| `svix-id`        | Stable message ID (also `WebhookDelivery.id`).                          |
+| `svix-timestamp` | Unix-second epoch when authn.sh signed the body.                        |
+| `svix-signature` | Space-separated list of `v1,<base64>` entries (multi-value on rotation).|
+
+The signature is `HMAC-SHA256` of `"{svix-id}.{svix-timestamp}.{raw_request_body}"` keyed by the **decoded** signing secret (the `whsec_<base64>` prefix is stripped and the suffix base64-decoded into the raw key bytes). Verifiers must:
+
+1. Reject the request if any of the three headers is missing or empty.
+2. Reject the request if `|now − svix-timestamp| > 300` seconds (replay window).
+3. Iterate every `v1,<base64>` entry in `svix-signature` and constant-time compare its base64 value against the locally-computed signature; accept on first match. (Multi-value headers occur during a `rotateWebhookEndpointSecret` overlap window.)
+
+### Worked example
+
+```text
+secret             = whsec_dGVzdC1zZWNyZXQtZG8tbm90LXJldXNlLXRoaXM=
+decoded            = "test-secret-do-not-reuse-this"
+
+svix-id            = whd_01HKX9SY9V7H7TF8C8K7J9X4ZK
+svix-timestamp     = 1714896500
+raw_body           = {"id":"whd_01HKX9SY9V7H7TF8C8K7J9X4ZK","object":"event","type":"user.created","timestamp":1714896500000,"instance_id":"env_acme_test","data":{"id":"user_01HKX9SY9V7H7TF8C8K7J9X4ZB","object":"user"}}
+
+signed_payload     = "whd_01HKX9SY9V7H7TF8C8K7J9X4ZK.1714896500.{raw_body}"
+signature_bytes    = HMAC-SHA256(decoded, signed_payload)
+svix-signature     = "v1," + base64(signature_bytes)
+                   = "v1,JG2qiInfP2EnVN6nq+S6XKhSGq9D+TlMkRkn2g4tBgI="
+```
+
+Reference verifier implementations: PHP — [`Authn\Sdk\Webhooks\SignatureVerifier`](https://github.com/authn-sh/sdk-php/blob/main/src/Webhooks/SignatureVerifier.php); JavaScript — `@authn.sh/sdk-js` (post-v0.1).
+
 ## Versioning
 
 Pre-1.0 the spec changes freely. Once we tag `v0.1.0` in coordination with the rest of v0.1, breaking changes require a major bump and a migration note in this README.

--- a/components/schemas/WebhookDelivery.yaml
+++ b/components/schemas/WebhookDelivery.yaml
@@ -1,0 +1,57 @@
+type: object
+description: |
+  One attempt at delivering one event to one endpoint. The dispatcher
+  retries with exponential backoff on transient failures; each retry
+  produces a new `WebhookDelivery` row sharing the `event_id` of the
+  first attempt.
+required:
+  - id
+  - object
+  - endpoint_id
+  - event_id
+  - event_type
+  - attempt
+  - succeeded
+  - created_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: webhook_delivery
+  endpoint_id:
+    type: string
+  event_id:
+    type: string
+    description: Stable across all retry attempts of the same event.
+  event_type:
+    type: string
+    description: Mirrors the `WebhookEvent.type` value being delivered.
+  attempt:
+    type: integer
+    minimum: 1
+    description: 1-based attempt counter; increments on every retry.
+  response_status:
+    type: [integer, "null"]
+    minimum: 100
+    maximum: 599
+    description: HTTP status returned by the endpoint, or `null` for connection failures.
+  response_body:
+    type: [string, "null"]
+    description: |
+      First 4 KiB of the endpoint's response body (UTF-8 best-effort).
+      Stored for debugging — never matched against in dispatcher logic.
+  next_retry_at:
+    type: [integer, "null"]
+    format: int64
+    minimum: 0
+    description: Unix ms; `null` when delivery succeeded or was given up on.
+  succeeded:
+    type: boolean
+    description: |
+      `true` once the endpoint returns 2xx. Permanent failures
+      (`succeeded: false` and `next_retry_at: null`) are kept for
+      audit but no longer retried.
+  created_at:
+    $ref: ./Timestamp.yaml

--- a/components/schemas/WebhookEndpoint.yaml
+++ b/components/schemas/WebhookEndpoint.yaml
@@ -1,0 +1,63 @@
+type: object
+description: |
+  A customer-controlled HTTPS endpoint the dispatcher delivers events
+  to. Each endpoint has its own `signing_secret` so customers can rotate
+  one without disturbing others.
+
+  `signing_secret` is **write-only**: it appears once on `createWebhookEndpoint`
+  and once on `rotateWebhookEndpointSecret`, never on subsequent
+  `getWebhookEndpoint` / `listWebhookEndpoints` reads.
+required:
+  - id
+  - object
+  - url
+  - enabled_event_types
+  - enabled
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: webhook_endpoint
+  url:
+    type: string
+    format: uri
+    description: HTTPS URL the dispatcher POSTs events to.
+    examples: ["https://app.acme.com/webhooks/authn"]
+  signing_secret:
+    type: string
+    writeOnly: true
+    description: |
+      Per-endpoint HMAC-SHA256 secret. Format: `whsec_<base64>`.
+      Returned exactly once, on create and on rotate. Subsequent reads
+      omit this field entirely.
+    examples: ["whsec_dGVzdC1zZWNyZXQ="]
+  signing_secret_prefix:
+    type: [string, "null"]
+    description: |
+      Read-safe partial fingerprint (first 8 chars of `signing_secret`)
+      so the dashboard can display "ends in `…dGVz`" without exposing
+      the secret.
+    examples: ["whsec_dG"]
+  enabled_event_types:
+    type: array
+    description: |
+      Subset of the `WebhookEvent.type` enum the endpoint subscribes
+      to. `["*"]` means "every event"; v0.1 limits the catalog to the
+      list documented on `WebhookEvent`.
+    items:
+      type: string
+    examples: [["user.created", "user.deleted", "session.revoked"]]
+  enabled:
+    type: boolean
+    default: true
+    description: |
+      When `false`, the dispatcher skips this endpoint without retrying.
+      Toggled from the dashboard during incidents.
+  created_at:
+    $ref: ./Timestamp.yaml
+  updated_at:
+    $ref: ./Timestamp.yaml

--- a/components/schemas/WebhookEndpointCreateRequest.yaml
+++ b/components/schemas/WebhookEndpointCreateRequest.yaml
@@ -1,0 +1,22 @@
+type: object
+description: Body for `POST /v1/webhooks/endpoints`.
+required: [url, enabled_event_types]
+additionalProperties: false
+properties:
+  url:
+    type: string
+    format: uri
+    description: |
+      HTTPS URL. The dispatcher refuses non-HTTPS targets in production
+      environments; `http://localhost:*` is allowed in test environments.
+  enabled_event_types:
+    type: array
+    minItems: 1
+    items:
+      type: string
+    description: |
+      Initial subscription set. Use `["*"]` to subscribe to every event
+      in the v0.1 catalog.
+  enabled:
+    type: boolean
+    default: true

--- a/components/schemas/WebhookEndpointUpdateRequest.yaml
+++ b/components/schemas/WebhookEndpointUpdateRequest.yaml
@@ -1,0 +1,14 @@
+type: object
+description: Body for `PATCH /v1/webhooks/endpoints/{endpoint_id}`. Every field optional.
+additionalProperties: false
+properties:
+  url:
+    type: string
+    format: uri
+  enabled_event_types:
+    type: array
+    minItems: 1
+    items:
+      type: string
+  enabled:
+    type: boolean

--- a/components/schemas/WebhookEvent.yaml
+++ b/components/schemas/WebhookEvent.yaml
@@ -1,0 +1,85 @@
+type: object
+description: |
+  Envelope wrapping every webhook delivery. Customers receive this as
+  the JSON body of a `POST` to the configured endpoint, signed via the
+  scheme below.
+
+  ## Signature contract
+
+  Each delivery carries three headers:
+
+  - `svix-id` — message ID (also the `WebhookDelivery.id`).
+  - `svix-timestamp` — unix-second epoch when the server signed the body.
+  - `svix-signature` — space-separated list of `v1,<base64>` entries.
+    Multiple entries appear during a `rotateWebhookEndpointSecret`
+    overlap window; verifiers accept any.
+
+  Verifier formula:
+
+  ```
+  signed_payload = "{svix-id}.{svix-timestamp}.{raw_request_body}"
+  candidate      = base64(HMAC-SHA256(decoded(signing_secret), signed_payload))
+  ```
+
+  Compare each `v1,<…>` entry constant-time against `candidate`; refuse
+  the request if no match is found, if `svix-timestamp` is more than
+  300 seconds away from now, or if any of the three headers are
+  missing.
+required:
+  - id
+  - object
+  - type
+  - data
+  - timestamp
+  - instance_id
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+    description: Same as `WebhookDelivery.id` and the `svix-id` header.
+  object:
+    type: string
+    const: event
+  type:
+    type: string
+    description: |
+      Stable event type identifier. v0.1 ships the events listed below.
+      Future events (organizations, OAuth, enterprise SSO) will be
+      added additively under their own milestones.
+    enum:
+      - user.created
+      - user.updated
+      - user.deleted
+      - session.created
+      - session.ended
+      - session.removed
+      - session.revoked
+      - email.created
+      - invitation.created
+      - invitation.accepted
+      - invitation.revoked
+  data:
+    description: |
+      The resource snapshot. Concrete shape depends on `type`:
+
+      - `user.*` → `User`
+      - `session.*` → `Session`
+      - `email.*` → `EmailAddress`
+      - `invitation.*` → `Invitation`
+    oneOf:
+      - $ref: ./User.yaml
+      - $ref: ./Session.yaml
+      - $ref: ./EmailAddress.yaml
+      - $ref: ./Invitation.yaml
+  timestamp:
+    $ref: ./Timestamp.yaml
+  instance_id:
+    type: string
+    description: ID of the originating `Environment` (so customers can route by tenant).
+  was_test:
+    type: boolean
+    default: false
+    description: |
+      `true` when the event originated from a test-mode user / session
+      (per `Environment.test_mode`). Customers should usually filter
+      these out in production handlers.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -199,6 +199,20 @@ paths:
   /v1/instance/organization_settings:
     $ref: ./paths/instance-organization-settings.yaml
 
+  # Webhooks: endpoint CRUD + secret rotation + delivery audit log + replay.
+  /v1/webhooks/endpoints:
+    $ref: ./paths/webhook-endpoints.yaml
+  /v1/webhooks/endpoints/{endpoint_id}:
+    $ref: ./paths/webhook-endpoint.yaml
+  /v1/webhooks/endpoints/{endpoint_id}/rotate_secret:
+    $ref: ./paths/webhook-endpoint-rotate.yaml
+  /v1/webhooks/deliveries:
+    $ref: ./paths/webhook-deliveries.yaml
+  /v1/webhooks/deliveries/{delivery_id}:
+    $ref: ./paths/webhook-delivery.yaml
+  /v1/webhooks/deliveries/{delivery_id}/replay:
+    $ref: ./paths/webhook-delivery-replay.yaml
+
 components:
   securitySchemes:
     bearer_secret_key:
@@ -261,6 +275,11 @@ components:
     InstanceUpdateRequest:            { $ref: ./components/schemas/InstanceUpdateRequest.yaml }
     RestrictionsUpdateRequest:        { $ref: ./components/schemas/RestrictionsUpdateRequest.yaml }
     OrganizationSettingsUpdateRequest: { $ref: ./components/schemas/OrganizationSettingsUpdateRequest.yaml }
+    WebhookEvent:                      { $ref: ./components/schemas/WebhookEvent.yaml }
+    WebhookEndpoint:                   { $ref: ./components/schemas/WebhookEndpoint.yaml }
+    WebhookEndpointCreateRequest:      { $ref: ./components/schemas/WebhookEndpointCreateRequest.yaml }
+    WebhookEndpointUpdateRequest:      { $ref: ./components/schemas/WebhookEndpointUpdateRequest.yaml }
+    WebhookDelivery:                   { $ref: ./components/schemas/WebhookDelivery.yaml }
 
   responses:
     BadRequest:           { $ref: ./components/responses/BadRequest.yaml }

--- a/paths/webhook-deliveries.yaml
+++ b/paths/webhook-deliveries.yaml
@@ -1,0 +1,67 @@
+get:
+  operationId: listWebhookDeliveries
+  summary: List webhook deliveries
+  description: |
+    Paginated audit log of delivery attempts. Combine the filters below
+    to investigate why a particular endpoint is misbehaving.
+  tags: [Webhooks]
+  parameters:
+    - $ref: ../components/parameters/LimitParam.yaml
+    - $ref: ../components/parameters/OffsetParam.yaml
+    - name: endpoint_id
+      in: query
+      required: false
+      schema: { type: string }
+    - name: event_id
+      in: query
+      required: false
+      schema: { type: string }
+    - name: event_type
+      in: query
+      required: false
+      schema: { type: string }
+    - name: succeeded
+      in: query
+      required: false
+      schema: { type: boolean }
+    - name: created_at_after
+      in: query
+      required: false
+      description: Unix ms; only return deliveries created strictly after this instant.
+      schema: { type: integer, format: int64, minimum: 0 }
+    - name: created_at_before
+      in: query
+      required: false
+      description: Unix ms; only return deliveries created strictly before this instant.
+      schema: { type: integer, format: int64, minimum: 0 }
+  responses:
+    "200":
+      description: A page of deliveries.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: ../components/schemas/PaginatedList.yaml
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: ../components/schemas/WebhookDelivery.yaml }
+          examples:
+            failures:
+              summary: Failed deliveries to one endpoint in the last hour
+              value:
+                data:
+                  - id: whd_01HKX9SY9V7H7TF8C8K7J9X4ZK
+                    object: webhook_delivery
+                    endpoint_id: whe_01HKX9SY9V7H7TF8C8K7J9X4ZH
+                    event_id: evt_01HKX9SY9V7H7TF8C8K7J9X4ZM
+                    event_type: user.created
+                    attempt: 3
+                    response_status: 500
+                    response_body: '{"error":"internal"}'
+                    next_retry_at: 1714896800000
+                    succeeded: false
+                    created_at: 1714896500000
+                total_count: 1
+    "401": { $ref: ../components/responses/Unauthorized.yaml }

--- a/paths/webhook-delivery-replay.yaml
+++ b/paths/webhook-delivery-replay.yaml
@@ -1,0 +1,43 @@
+parameters:
+  - name: delivery_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+post:
+  operationId: replayWebhookDelivery
+  summary: Replay a webhook delivery
+  description: |
+    Re-send the original event payload to the original endpoint. The
+    replay is a fresh attempt with a new `WebhookDelivery.id` and
+    `attempt = 1`; it shares the same `event_id` as the original so
+    customers can correlate.
+
+    Common use: a customer endpoint went down for a few hours, missed
+    a batch of `user.created` events, and the operator wants to backfill
+    after the endpoint comes back.
+  tags: [Webhooks]
+  parameters:
+    - $ref: ../components/parameters/IdempotencyKeyHeader.yaml
+  responses:
+    "201":
+      description: The replay attempt.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/WebhookDelivery.yaml }
+          examples:
+            replayed:
+              value:
+                id: whd_01HKX9SY9V7H7TF8C8K7J9X4ZN
+                object: webhook_delivery
+                endpoint_id: whe_01HKX9SY9V7H7TF8C8K7J9X4ZH
+                event_id: evt_01HKX9SY9V7H7TF8C8K7J9X4ZM
+                event_type: user.created
+                attempt: 1
+                response_status: null
+                response_body: null
+                next_retry_at: null
+                succeeded: false
+                created_at: 1714900000000
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }

--- a/paths/webhook-delivery.yaml
+++ b/paths/webhook-delivery.yaml
@@ -1,0 +1,19 @@
+parameters:
+  - name: delivery_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+get:
+  operationId: getWebhookDelivery
+  summary: Get a webhook delivery
+  description: Fetch one delivery attempt by ID.
+  tags: [Webhooks]
+  responses:
+    "200":
+      description: The delivery.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/WebhookDelivery.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }

--- a/paths/webhook-endpoint-rotate.yaml
+++ b/paths/webhook-endpoint-rotate.yaml
@@ -1,0 +1,63 @@
+parameters:
+  - name: endpoint_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+post:
+  operationId: rotateWebhookEndpointSecret
+  summary: Rotate a webhook endpoint's signing secret
+  description: |
+    Mint a fresh `signing_secret` and return it once. The previous
+    secret stays live for an overlap window (5 minutes by default) so
+    in-flight deliveries continue to verify; after that, the new
+    secret is the only valid one.
+
+    The dispatcher signs each delivery during the overlap with a
+    multi-value `svix-signature` header (`v1,<old> v1,<new>`) so
+    customer verifiers that already accept multiple `v1,…` entries
+    won't see any failed deliveries.
+  tags: [Webhooks]
+  parameters:
+    - $ref: ../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: false
+    content:
+      application/json:
+        schema:
+          type: object
+          additionalProperties: false
+          properties:
+            overlap_seconds:
+              type: integer
+              minimum: 0
+              maximum: 86400
+              default: 300
+              description: |
+                How long both secrets stay valid. `0` cuts over instantly
+                (use only when you trust the customer endpoint to update
+                synchronously).
+        examples:
+          longer_overlap:
+            summary: One-hour overlap during a coordinated rollout
+            value: { overlap_seconds: 3600 }
+  responses:
+    "200":
+      description: The endpoint with the new one-time `signing_secret`.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/WebhookEndpoint.yaml }
+          examples:
+            rotated:
+              value:
+                id: whe_01HKX9SY9V7H7TF8C8K7J9X4ZH
+                object: webhook_endpoint
+                url: https://app.acme.com/webhooks/authn
+                signing_secret: "whsec_bmV3LXNlY3JldC1jb3B5LWl0LW5vdyE="
+                signing_secret_prefix: "whsec_bm"
+                enabled_event_types: ["user.created", "user.updated", "user.deleted"]
+                enabled: true
+                created_at: 1714895999000
+                updated_at: 1714896500000
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }

--- a/paths/webhook-endpoint.yaml
+++ b/paths/webhook-endpoint.yaml
@@ -1,0 +1,79 @@
+parameters:
+  - name: endpoint_id
+    in: path
+    required: true
+    schema: { $ref: ../components/schemas/Id.yaml }
+
+get:
+  operationId: getWebhookEndpoint
+  summary: Get a webhook endpoint
+  description: |
+    Fetch a single endpoint. `signing_secret` is **never** included in
+    this response — only the read-safe `signing_secret_prefix`.
+  tags: [Webhooks]
+  responses:
+    "200":
+      description: The endpoint.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/WebhookEndpoint.yaml }
+          examples:
+            endpoint:
+              summary: Note the absence of `signing_secret`.
+              value:
+                id: whe_01HKX9SY9V7H7TF8C8K7J9X4ZH
+                object: webhook_endpoint
+                url: https://app.acme.com/webhooks/authn
+                signing_secret_prefix: "whsec_dG"
+                enabled_event_types: ["user.created", "user.updated"]
+                enabled: true
+                created_at: 1714895999000
+                updated_at: 1714895999000
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }
+
+patch:
+  operationId: updateWebhookEndpoint
+  summary: Update a webhook endpoint
+  description: |
+    Patch any of `url` / `enabled_event_types` / `enabled`. The
+    `signing_secret` cannot be set this way — use `rotate_secret`.
+  tags: [Webhooks]
+  parameters:
+    - $ref: ../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../components/schemas/WebhookEndpointUpdateRequest.yaml }
+        examples:
+          add_events:
+            summary: Subscribe to invitations as well
+            value:
+              enabled_event_types: ["user.created", "user.updated", "user.deleted", "invitation.created"]
+          disable:
+            summary: Pause an endpoint without deleting it
+            value: { enabled: false }
+  responses:
+    "200":
+      description: The updated endpoint (still no `signing_secret`).
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/WebhookEndpoint.yaml }
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }
+
+delete:
+  operationId: deleteWebhookEndpoint
+  summary: Delete a webhook endpoint
+  description: |
+    Permanently remove the endpoint. In-flight retries are abandoned;
+    the historical `WebhookDelivery` rows stay for audit but are
+    flagged with `endpoint_id` of the now-deleted endpoint.
+  tags: [Webhooks]
+  responses:
+    "204":
+      description: Deleted.
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../components/responses/NotFound.yaml }

--- a/paths/webhook-endpoints.yaml
+++ b/paths/webhook-endpoints.yaml
@@ -1,0 +1,92 @@
+get:
+  operationId: listWebhookEndpoints
+  summary: List webhook endpoints
+  description: Paginated list of every endpoint configured on the environment.
+  tags: [Webhooks]
+  parameters:
+    - $ref: ../components/parameters/LimitParam.yaml
+    - $ref: ../components/parameters/OffsetParam.yaml
+  responses:
+    "200":
+      description: A page of endpoints. `signing_secret` is omitted on every row.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: ../components/schemas/PaginatedList.yaml
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: ../components/schemas/WebhookEndpoint.yaml }
+          examples:
+            page:
+              summary: Two endpoints — neither carries `signing_secret`.
+              value:
+                data:
+                  - id: whe_01HKX9SY9V7H7TF8C8K7J9X4ZH
+                    object: webhook_endpoint
+                    url: https://app.acme.com/webhooks/authn
+                    signing_secret_prefix: "whsec_dG"
+                    enabled_event_types: ["user.created", "user.deleted"]
+                    enabled: true
+                    created_at: 1714895999000
+                    updated_at: 1714895999000
+                  - id: whe_01HKX9SY9V7H7TF8C8K7J9X4ZJ
+                    object: webhook_endpoint
+                    url: https://app.acme.com/webhooks/sessions
+                    signing_secret_prefix: "whsec_xY"
+                    enabled_event_types: ["session.created", "session.revoked"]
+                    enabled: false
+                    created_at: 1714809600000
+                    updated_at: 1714895500000
+                total_count: 2
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+
+post:
+  operationId: createWebhookEndpoint
+  summary: Create a webhook endpoint
+  description: |
+    Mint a new endpoint **and** its `signing_secret`. The secret is
+    returned exactly once in this response — copy it into the customer
+    side immediately. Subsequent `GET` calls won't include it.
+  tags: [Webhooks]
+  parameters:
+    - $ref: ../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../components/schemas/WebhookEndpointCreateRequest.yaml }
+        examples:
+          subscribe_users:
+            summary: Subscribe to every user.* event
+            value:
+              url: https://app.acme.com/webhooks/authn
+              enabled_event_types: ["user.created", "user.updated", "user.deleted"]
+          everything:
+            summary: Catch-all
+            value:
+              url: https://app.acme.com/webhooks/authn
+              enabled_event_types: ["*"]
+  responses:
+    "201":
+      description: The new endpoint, with the one-time `signing_secret`.
+      content:
+        application/json:
+          schema: { $ref: ../components/schemas/WebhookEndpoint.yaml }
+          examples:
+            created:
+              value:
+                id: whe_01HKX9SY9V7H7TF8C8K7J9X4ZH
+                object: webhook_endpoint
+                url: https://app.acme.com/webhooks/authn
+                signing_secret: "whsec_dGVzdC1zZWNyZXQtZG8tbm90LXJldXNlLXRoaXM="
+                signing_secret_prefix: "whsec_dG"
+                enabled_event_types: ["user.created", "user.updated", "user.deleted"]
+                enabled: true
+                created_at: 1714895999000
+                updated_at: 1714895999000
+    "401": { $ref: ../components/responses/Unauthorized.yaml }
+    "409": { $ref: ../components/responses/Conflict.yaml }
+    "422": { $ref: ../components/responses/UnprocessableEntity.yaml }


### PR DESCRIPTION
## Summary

Implements [OA-5](https://github.com/authn-sh/openapi/issues/5) — the last v0.1 openapi issue (modulo the BAPI-sessions follow-up [#9](https://github.com/authn-sh/openapi/issues/9)). Defines the webhook delivery envelope, the v0.1 event-type catalog, the endpoint CRUD surface with secret rotation, and the delivery audit log + replay endpoint.

### Schemas (`components/schemas/`) — 5 new

- **`WebhookEvent`** — envelope: `id` (mirrors `svix-id`), `object: 'event'`, `type` enum covering the v0.1 catalog (`user.created/updated/deleted`, `session.created/ended/removed/revoked`, `email.created`, `invitation.created/accepted/revoked`), `was_test`. `data` is a `oneOf` over `User` / `Session` / `EmailAddress` / `Invitation` (already merged via OA-2 and OA-4). Schema description carries the full HMAC-SHA256 verifier formula and multi-value rotation rules.
- **`WebhookEndpoint`** — `signing_secret` marked **`writeOnly: true`** (only present on create / rotate responses). `signing_secret_prefix` is the read-safe fingerprint surfaced to the dashboard.
- **`WebhookEndpointCreateRequest`**, **`WebhookEndpointUpdateRequest`**.
- **`WebhookDelivery`** — per-attempt audit row.

### Paths (`paths/`) — 6 new path items / 9 new operations

- `/v1/webhooks/endpoints` GET + POST (`listWebhookEndpoints` + `createWebhookEndpoint`)
- `/v1/webhooks/endpoints/{id}` GET + PATCH + DELETE
- `/v1/webhooks/endpoints/{id}/rotate_secret` POST — returns the new secret once; configurable `overlap_seconds`
- `/v1/webhooks/deliveries` GET — filter by `endpoint_id` / `event_id` / `event_type` / `succeeded` / time range
- `/v1/webhooks/deliveries/{id}` GET
- `/v1/webhooks/deliveries/{id}/replay` POST

### Examples included

`createWebhookEndpoint` (subscribe set + catch-all), `rotateWebhookEndpointSecret` (longer overlap variant), `listWebhookDeliveries` (failures filter), `replayWebhookDelivery`. The `getWebhookEndpoint` and `listWebhookEndpoints` response examples explicitly omit `signing_secret` — only `signing_secret_prefix` is present, satisfying the "provably absent" acceptance criterion.

### README — signature contract

New section walks through the headers, replay window, multi-value rotation behavior, and a **worked example** with concrete bytes (decoded secret, signed payload, expected base64 signature). Cross-links to the PHP reference verifier (`Authn\Sdk\Webhooks\SignatureVerifier`).

### Test plan

- [x] `npm run lint` — clean
- [x] `npm run bundle` — **60 path items, 84 operations, 36 schemas**
- [x] `npm run stats` — sanity-checked

Closes #5