### PR TITLE
Spec: email_link strategy — sign-in / sign-up, transferable, cross-device polling (OA-4)

### DIFF
--- a/components/schemas/SignIn.yaml
+++ b/components/schemas/SignIn.yaml
@@ -5,7 +5,51 @@ description: |
   (optionally) prepare/attempt a second factor → `complete`.
 
   v0.1 ships `password` + `email_code` + `reset_password_email_code`
-  + `ticket`. OAuth/SAML/passkey/TOTP land in later milestones.
+  + `ticket`. v0.2 adds `email_link` (magic link). OAuth/SAML/passkey/TOTP
+  land in later milestones.
+
+  ### Magic-link cross-device polling (PLAN §9.10)
+
+  `email_link` is the only first-factor strategy that completes
+  out-of-band — the user clicks the link in their inbox, possibly on a
+  different device, while the originating device polls for the result.
+
+  1. Caller calls `prepareFirstFactor` with `strategy: email_link` on
+     the originating device. The server emails a click-through URL of
+     shape:
+
+     `https://{env_slug}.authn.sh/v1/client/handshake?__authn_ticket=<jwt>&__authn_status=complete`
+
+     The JWT carries `purpose=email_link`, the originating
+     `sign_in_id`, and the verifying `email_address_id`. Its
+     `external_verification_redirect_url` is mirrored into
+     `first_factor_verification.external_verification_redirect_url`
+     so the originating device can render a "Open the email" UI.
+
+  2. The originating device calls `attemptFirstFactor` with
+     `strategy: email_link` and **no payload** — the body is just
+     `{strategy: "email_link"}`. This commits the SDK to polling but
+     does not synchronously verify anything.
+
+  3. The originating device polls `getClient` (the recommended
+     cadence is **every 2 seconds for the first 60 seconds, then 5
+     seconds for the next 5 minutes, then stop**). Each poll returns
+     the same `SignIn` with its `first_factor_verification.status`
+     unchanged until the link is clicked.
+
+  4. When the link is clicked — possibly on a different device —
+     the click hits `clientHandshake`
+     (`GET /v1/client/handshake?__authn_ticket=…`) on the FAPI host.
+     `clientHandshake` decodes the ticket, marks the originating
+     attempt's `first_factor_verification.status` as `verified` (or
+     `transferable` for an unknown identifier — see `Verification`),
+     and the next poll on the originating device sees the new
+     status, completing the sign-in.
+
+  Cross-device polling does *not* use SSE or WebSockets — plain
+  `getClient` polling keeps the FAPI infrastructure simple and works
+  across every browser. Servers may rate-limit polling above the
+  recommended cadence (`429 too_many_requests`).
 required:
   - id
   - object
@@ -62,6 +106,14 @@ properties:
       properties:
         strategy:
           type: string
+          description: |
+            v0.1 emits `password`, `email_code`,
+            `reset_password_email_code`. v0.2 adds `email_link`.
+          examples:
+            - password
+            - email_code
+            - email_link
+            - reset_password_email_code
         email_address_id:
           type: string
         phone_number_id:

--- a/components/schemas/SignUp.yaml
+++ b/components/schemas/SignUp.yaml
@@ -4,8 +4,47 @@ description: |
   requires, which the caller has already supplied, which still need
   verification, and the per-attribute verification challenges.
 
-  v0.1 supports email + password sign-ups; phone, OAuth, SAML, and
-  passkey sign-ups ship in later milestones.
+  v0.1 supports email + password sign-ups via `email_code`. v0.2 adds
+  `email_link` (magic link). Phone, OAuth, SAML, and passkey sign-ups
+  ship in later milestones.
+
+  ### Magic-link cross-device polling (PLAN §9.10)
+
+  Sign-up `email_link` works the same way as sign-in `email_link`
+  — the click can happen on a different device while the originating
+  device polls the FAPI for completion. The full handshake is:
+
+  1. Caller calls `prepareVerification` with `strategy: email_link`.
+     The server emails a click-through URL of shape:
+
+     `https://{env_slug}.authn.sh/v1/client/handshake?__authn_ticket=<jwt>&__authn_status=complete`
+
+     The JWT carries `purpose=email_link`, the `sign_up_id`, and the
+     attribute being verified (always `email_address` in v0.2). The
+     URL is mirrored into the matching
+     `verifications.email_address.external_verification_redirect_url`
+     so the SDK can render a "Open the email" UI.
+
+  2. Caller calls `attemptVerification` with
+     `strategy: email_link` and **no payload** — body is just
+     `{strategy: "email_link"}`. This commits the SDK to polling.
+
+  3. Caller polls `getClient` (recommended cadence: **every 2
+     seconds for the first 60 seconds, then 5 seconds for the next
+     5 minutes**) until the matching
+     `verifications.email_address.status` flips to `verified` or
+     `transferable`.
+
+  4. The click on any device hits `clientHandshake`
+     (`GET /v1/client/handshake?__authn_ticket=…`), which marks the
+     verification on the originating attempt and lets the polling
+     device complete.
+
+  If the address being signed up already has a `User`, the
+  verification flips to `transferable` instead of `verified` and the
+  SDK should bounce to sign-in via
+  `POST /v1/client/sign_ins { transfer: true }` — see the
+  `Verification` schema for the full transferable rules.
 required:
   - id
   - object
@@ -41,8 +80,11 @@ properties:
         to verify.
       - `complete` — `created_user_id` and `created_session_id` are set;
         SDK can stop driving.
-      - `transferable` — an OAuth identity matched but no local user
-        exists; the caller can transfer to sign-up. (v0.4.)
+      - `transferable` — the verified identity belongs in the opposite
+        flow. v0.2: a sign-up `email_link` was clicked for an address
+        that already has a `User` — the SDK should bounce to sign-in
+        with `POST /v1/client/sign_ins { transfer: true }`. v0.4
+        extends this to OAuth.
       - `abandoned` — `abandon_at` passed.
   required_fields:
     type: array

--- a/components/schemas/Verification.yaml
+++ b/components/schemas/Verification.yaml
@@ -21,18 +21,34 @@ properties:
     description: |
       - `unverified` — challenge created, no successful attempt yet.
       - `verified` — challenge succeeded; the parent identifier is now trusted.
-      - `transferable` — succeeded against an OAuth provider but the local
-        account doesn't exist yet (used during sign-up).
+      - `transferable` — succeeded against the wrong flow type — the SDK
+        should bounce to the opposite flow with `transfer: true`. v0.2
+        cases:
+          1. **Magic-link sign-in for an unknown identifier** — the user
+             clicked a sign-in `email_link` for an address with no
+             matching `User`. The SDK creates a fresh sign-up via
+             `POST /v1/client/sign_ups { transfer: true }` to convert
+             the verified link into account creation.
+          2. **Magic-link sign-up for an existing identifier** — the
+             user clicked a sign-up `email_link` for an address that
+             already has a `User`. The SDK creates a fresh sign-in via
+             `POST /v1/client/sign_ins { transfer: true }` to convert
+             the verified link into a session. (Future OAuth flows
+             reuse the same status; the `transfer: true` body field is
+             unchanged from v0.1.)
       - `failed` — too many wrong attempts; the challenge can no longer be retried.
       - `expired` — `expire_at` is in the past; the challenge must be re-issued.
   strategy:
     type: string
     description: |
       How this verification is being completed. v0.1 issues `email_code`,
-      `reset_password_email_code`, `ticket`, `password`, and `transfer`;
-      OAuth, phone, passkeys, and TOTP land in later milestones.
+      `reset_password_email_code`, `ticket`, `password`, and `transfer`.
+      v0.2 adds `email_link` (magic link) — see the cross-device polling
+      note on `SignIn` / `SignUp`. OAuth, phone, passkeys, and TOTP
+      land in later milestones.
     examples:
       - email_code
+      - email_link
       - reset_password_email_code
       - password
       - ticket
@@ -69,3 +85,29 @@ properties:
     oneOf:
       - $ref: "./Error.yaml"
       - type: "null"
+examples:
+  - status: unverified
+    strategy: email_link
+    attempts: 0
+    expire_at: 1714724000000
+    external_verification_redirect_url: "https://acme.authn.sh/v1/client/handshake?__authn_ticket=tkt_01HKX9SY9V7H7TF8C8K7J9X4ZG&__authn_status=complete"
+    nonce: null
+    error: null
+  - status: verified
+    strategy: email_link
+    attempts: 1
+    expire_at: 1714724000000
+    external_verification_redirect_url: null
+    nonce: null
+    error: null
+  - status: transferable
+    strategy: email_link
+    attempts: 1
+    expire_at: 1714724000000
+    external_verification_redirect_url: null
+    nonce: null
+    error:
+      code: identifier_not_found
+      message: "No user matches this email address."
+      long_message: "No user matches this email address. Bounce to sign-up with `transfer: true`."
+      meta: {}

--- a/paths/fapi/sign-in-attempt-first-factor.yaml
+++ b/paths/fapi/sign-in-attempt-first-factor.yaml
@@ -16,6 +16,13 @@ post:
       `{strategy: "reset_password_email_code", code: "…"}` — on success
       the sign-in transitions to `needs_new_password`.
     - `ticket` — body `{strategy: "ticket", ticket: "…"}`.
+    - `email_link` (v0.2) — body `{strategy: "email_link"}` — **no
+      payload**. This commits the SDK to polling
+      `first_factor_verification.status` via `getClient`; the actual
+      verification happens out-of-band when the user clicks the
+      magic link. The response is the polled state, not a
+      synchronous success. See the cross-device polling note on
+      `SignIn`.
   tags: [Sign-Ins]
   security:
     - client_cookie: []
@@ -31,7 +38,7 @@ post:
           properties:
             strategy:
               type: string
-              enum: [password, email_code, reset_password_email_code, ticket]
+              enum: [password, email_code, reset_password_email_code, ticket, email_link]
             password: { type: string }
             code:     { type: string }
             ticket:   { type: string }
@@ -43,6 +50,9 @@ post:
             value: { strategy: password, password: "correct horse battery staple" }
           email_code:
             value: { strategy: email_code, code: "542178" }
+          email_link:
+            summary: Magic-link — no payload, poll for completion
+            value: { strategy: email_link }
   responses:
     "200":
       description: Sign-in transitioned (possibly to `complete`), wrapped.

--- a/paths/fapi/sign-in-prepare-first-factor.yaml
+++ b/paths/fapi/sign-in-prepare-first-factor.yaml
@@ -10,6 +10,18 @@ post:
   description: |
     Issue a first-factor challenge (e.g. send the email code) without
     yet evaluating an answer. The next step is `attempt_first_factor`.
+
+    Supported strategies:
+
+    - `email_code` — sends a 6-digit code to the resolved email.
+    - `reset_password_email_code` — same channel; on success the
+      sign-in transitions to `needs_new_password` instead of
+      `complete`.
+    - `email_link` (v0.2) — sends a click-through link instead of a
+      code. The originating device must follow up with
+      `attempt_first_factor { strategy: "email_link" }` (no payload)
+      and poll `getClient` until the verification flips. See the
+      cross-device polling note on `SignIn`.
   tags: [Sign-Ins]
   security:
     - client_cookie: []
@@ -25,7 +37,7 @@ post:
           properties:
             strategy:
               type: string
-              enum: [email_code, reset_password_email_code]
+              enum: [email_code, reset_password_email_code, email_link]
             email_address_id:
               type: string
             phone_number_id:
@@ -33,9 +45,18 @@ post:
             redirect_url:
               type: string
               format: uri
+              description: |
+                For `email_link`, the URL the magic link bounces back
+                to after `clientHandshake` consumes the ticket. Must
+                be on the redirect-URL allowlist.
         examples:
           email_code:
             value: { strategy: email_code, email_address_id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE }
+          email_link:
+            value:
+              strategy: email_link
+              email_address_id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE
+              redirect_url: https://app.acme.com/dashboard
   responses:
     "200":
       description: Sign-in with the new `first_factor_verification`, wrapped.

--- a/paths/fapi/sign-up-attempt-verification.yaml
+++ b/paths/fapi/sign-up-attempt-verification.yaml
@@ -8,11 +8,24 @@ post:
   operationId: attemptVerification
   summary: Attempt sign-up verification
   description: |
-    Submit the user's answer to a sign-up challenge (the email code in
-    v0.1). On success the matching attribute moves out of
-    `unverified_fields` and — if no other requirements remain — the
-    sign-up transitions to `complete` (sets `created_user_id` and
-    `created_session_id`).
+    Submit the user's answer to a sign-up challenge.
+
+    Supported strategies:
+
+    - `email_code` (v0.1) — body `{strategy: "email_code", code: "…"}`.
+    - `email_link` (v0.2) — body `{strategy: "email_link"}` — **no
+      payload**. This commits the SDK to polling
+      `verifications.<attribute>.status` via `getClient`; the actual
+      verification happens out-of-band when the user clicks the magic
+      link. The response is the polled state, not a synchronous
+      success. See the cross-device polling note on `SignUp`.
+
+    On success the matching attribute moves out of `unverified_fields`
+    and — if no other requirements remain — the sign-up transitions
+    to `complete` (sets `created_user_id` and `created_session_id`).
+    For `email_link` against an existing identifier, the verification
+    flips to `transferable` and the SDK should bounce to sign-in via
+    `POST /v1/client/sign_ins { transfer: true }` instead.
   tags: [Sign-Ups]
   security:
     - client_cookie: []
@@ -28,12 +41,15 @@ post:
           properties:
             strategy:
               type: string
-              enum: [email_code]
+              enum: [email_code, email_link]
             code:      { type: string }
             signature: { type: string, description: Reserved for v0.5 (passkey). }
         examples:
           email_code:
             value: { strategy: email_code, code: "542178" }
+          email_link:
+            summary: Magic-link — no payload, poll for completion
+            value: { strategy: email_link }
   responses:
     "200":
       description: Sign-up transitioned (possibly to `complete`), wrapped.

--- a/paths/fapi/sign-up-prepare-verification.yaml
+++ b/paths/fapi/sign-up-prepare-verification.yaml
@@ -9,8 +9,17 @@ post:
   summary: Prepare sign-up verification
   description: |
     Issue a verification challenge for one of the unverified attributes
-    on the sign-up (e.g. send the email code). v0.1 supports
-    `email_code`.
+    on the sign-up.
+
+    Supported strategies:
+
+    - `email_code` (v0.1) — sends a 6-digit code to the email.
+    - `email_link` (v0.2) — sends a click-through link instead. The
+      caller must follow up with
+      `attempt_verification { strategy: "email_link" }` (no payload)
+      and poll `getClient` until the matching verification flips
+      to `verified` or `transferable`. See the cross-device polling
+      note on `SignUp`.
   tags: [Sign-Ups]
   security:
     - client_cookie: []
@@ -26,13 +35,21 @@ post:
           properties:
             strategy:
               type: string
-              enum: [email_code]
+              enum: [email_code, email_link]
             redirect_url:
               type: string
               format: uri
+              description: |
+                For `email_link`, the URL the magic link bounces back
+                to after `clientHandshake` consumes the ticket. Must
+                be on the redirect-URL allowlist.
         examples:
           email_code:
             value: { strategy: email_code }
+          email_link:
+            value:
+              strategy: email_link
+              redirect_url: https://app.acme.com/welcome
   responses:
     "200":
       description: Sign-up with the new verification populated, wrapped.


### PR DESCRIPTION
## Summary

Adds magic-link (\`email_link\`) as a first-factor strategy on sign-ins and sign-ups, plus the \`transferable\` cross-flow status and the cross-device polling story from PLAN §9.10.

### Schema changes

- **\`Verification.strategy\`**: \`email_link\` added to the documented enum / examples.
- **\`Verification.status: transferable\`**: rewrite to cover the v0.2 magic-link cases — sign-in for an unknown identifier (bounce to sign-up with \`transfer: true\`), sign-up for an existing identifier (bounce to sign-in).
- **\`Verification.examples\`**: three worked examples — \`unverified\` → \`verified\` → \`transferable\` — each carrying the magic-link \`external_verification_redirect_url\`.
- **\`SignIn.description\`** and **\`SignUp.description\`**: each gets a \`### Magic-link cross-device polling (PLAN §9.10)\` section documenting the 4-step handshake (prepare → no-payload attempt → poll \`getClient\` → click bounces through \`clientHandshake\`), the recommended polling cadence (2s for the first 60s, 5s for the next 5min), and the JWT shape (\`purpose=email_link\`).
- **\`SignIn.supported_first_factors[].strategy\`**: examples extended with \`email_link\`.

### Path body schemas extended

- \`prepareFirstFactor\` (sign-in): enum → \`[email_code, reset_password_email_code, email_link]\`; \`redirect_url\` description notes its role for \`email_link\`; new \`email_link\` example.
- \`attemptFirstFactor\` (sign-in): enum extended; description documents the no-payload polling shape; new \`email_link\` example.
- \`prepareVerification\` (sign-up): enum → \`[email_code, email_link]\`; new \`email_link\` example.
- \`attemptVerification\` (sign-up): enum extended; description documents the no-payload polling shape; new \`email_link\` example.

### What's not changed

- No \`transfer: true\` body change — already in v0.1's \`createSignIn\` / \`createSignUp\`.
- No \`clientHandshake\` body change — already accepts \`__authn_ticket\` from v0.1; the magic-link flow reuses the same handler with the existing \`__authn_status=complete\` query convention.

### Out of scope (deferred)

- Server implementation — AU-10
- Email template MJML — AU-14
- \`phone_link\` — out of v0.x

## Test plan

- [x] \`npm run lint\` — both specs valid
- [x] \`npm run bundle\` — resolves all refs (\`dist/{bapi,fapi}.bundled.{yaml,json}\` regenerated)
- [x] \`email_link\` in the strategy enums of \`prepareFirstFactor\`, \`prepareVerification\`, and \`Verification.strategy\` examples
- [x] \`attemptFirstFactor\` / \`attemptVerification\` body for \`email_link\` documented as no-payload + polled response
- [x] \`transferable\` status documented on \`Verification\` with worked example
- [x] Cross-device polling section on \`SignIn\` and \`SignUp\`, explicitly referencing \`clientHandshake\`
- [x] No \`transfer: true\` body change (already in v0.1)

Closes authn-sh/openapi#15.