### PR TITLE
Spec: v0.2 webhook event types — organization.*, role.*, permission.* (OA-5)

### DIFF
--- a/components/schemas/Session.yaml
+++ b/components/schemas/Session.yaml
@@ -51,8 +51,47 @@ properties:
   last_active_organization_id:
     type: [string, "null"]
     description: |
-      Set by `POST /v1/client/sessions/{id}/touch`. Populated once
-      organizations land in v0.2.
+      Set by `POST /v1/client/sessions/{id}/touch` (or
+      `setMyActiveOrganization`). Mirrors the `org.id` claim minted
+      into the session JWT.
+  organization:
+    description: |
+      Active-organization context for this session. Present whenever
+      `last_active_organization_id` is non-null — the embedded
+      `id`/`slug`/`role`/`permissions[]` are exactly what the next
+      `getSessionToken` will fold into the JWT's `org` claim, so
+      handlers receiving `session.created` / `session.touched`
+      events don't need a follow-up `getOrganizationMembership`
+      round-trip.
+
+      **Additive in v0.2** — the field is omitted in v0.1 payloads,
+      so existing handlers see no change until the producing
+      environment is on a v0.2 server.
+    oneOf:
+      - type: object
+        required: [id, slug, role, permissions]
+        additionalProperties: false
+        properties:
+          id:
+            type: string
+            description: Active `Organization.id`.
+          slug:
+            type: string
+            description: Active `Organization.slug`.
+          role:
+            type: string
+            description: |
+              `OrganizationMembership.role` for the calling user in
+              this organization.
+            examples: ["org:admin", "org:member"]
+          permissions:
+            type: array
+            description: |
+              The full permission set granted by `role` at the time
+              this token was minted. Order is stable (alphabetical).
+            items:
+              type: string
+      - type: "null"
   expire_at:
     $ref: ./Timestamp.yaml
   abandon_at:

--- a/components/schemas/WebhookEndpoint.yaml
+++ b/components/schemas/WebhookEndpoint.yaml
@@ -46,11 +46,23 @@ properties:
     type: array
     description: |
       Subset of the `WebhookEvent.type` enum the endpoint subscribes
-      to. `["*"]` means "every event"; v0.1 limits the catalog to the
-      list documented on `WebhookEvent`.
+      to. `["*"]` means "every event in every milestone" and is the
+      simplest way to opt into v0.2 organization events without
+      revisiting subscriptions on every release.
+
+      Wildcards at the resource level are also accepted —
+      `"organization.*"` matches every `organization.*` event,
+      `"organizationMembership.*"` matches the membership lifecycle,
+      etc. Wildcard expansion is evaluated at delivery time so an
+      endpoint listed with `organization.*` automatically receives
+      future event types added to the resource without an explicit
+      update.
     items:
       type: string
-    examples: [["user.created", "user.deleted", "session.revoked"]]
+    examples:
+      - ["user.created", "user.deleted", "session.revoked"]
+      - ["organization.*", "organizationMembership.*", "user.created"]
+      - ["*"]
   enabled:
     type: boolean
     default: true

--- a/components/schemas/WebhookEvent.yaml
+++ b/components/schemas/WebhookEvent.yaml
@@ -25,6 +25,13 @@ description: |
   the request if no match is found, if `svix-timestamp` is more than
   300 seconds away from now, or if any of the three headers are
   missing.
+
+  ## Magic-link emails
+
+  Magic-link sign-in / sign-up does **not** introduce its own event
+  type. The outgoing email is reported through the existing
+  `email.created` event with the rendered subject + body, exactly the
+  same as for `email_code` and `reset_password_email_code`.
 required:
   - id
   - object
@@ -43,10 +50,14 @@ properties:
   type:
     type: string
     description: |
-      Stable event type identifier. v0.1 ships the events listed below.
-      Future events (organizations, OAuth, enterprise SSO) will be
-      added additively under their own milestones.
+      Stable event type identifier. v0.1 shipped the `user.*`,
+      `session.*`, `email.*`, and `invitation.*` events. v0.2 adds the
+      organization, role, and permission events listed below.
+
+      Future surfaces (OAuth, enterprise SSO, SCIM) will be added
+      additively under their own milestones.
     enum:
+      # v0.1
       - user.created
       - user.updated
       - user.deleted
@@ -58,6 +69,29 @@ properties:
       - invitation.created
       - invitation.accepted
       - invitation.revoked
+      # v0.2
+      - session.touched
+      - organization.created
+      - organization.updated
+      - organization.deleted
+      - organizationMembership.created
+      - organizationMembership.updated
+      - organizationMembership.deleted
+      - organizationInvitation.created
+      - organizationInvitation.accepted
+      - organizationInvitation.revoked
+      - organizationDomain.created
+      - organizationDomain.updated
+      - organizationDomain.deleted
+      - organizationMembershipRequest.created
+      - organizationMembershipRequest.accepted
+      - organizationMembershipRequest.rejected
+      - role.created
+      - role.updated
+      - role.deleted
+      - permission.created
+      - permission.updated
+      - permission.deleted
   data:
     description: |
       The resource snapshot. Concrete shape depends on `type`:
@@ -66,11 +100,28 @@ properties:
       - `session.*` → `Session`
       - `email.*` → `EmailAddress`
       - `invitation.*` → `Invitation`
+      - `organization.*` → `Organization`
+      - `organizationMembership.*` → `OrganizationMembership` (with
+        populated `public_user_data`, so handlers don't need a
+        follow-up `getUser`)
+      - `organizationInvitation.*` → `OrganizationInvitation`
+      - `organizationDomain.*` → `OrganizationDomain`
+      - `organizationMembershipRequest.*` → `OrganizationMembershipRequest`
+      - `role.*` → `Role`
+      - `permission.*` → `Permission` (custom permissions only —
+        system permissions are seeded and don't emit lifecycle events)
     oneOf:
       - $ref: ./User.yaml
       - $ref: ./Session.yaml
       - $ref: ./EmailAddress.yaml
       - $ref: ./Invitation.yaml
+      - $ref: ./Organization.yaml
+      - $ref: ./OrganizationMembership.yaml
+      - $ref: ./OrganizationInvitation.yaml
+      - $ref: ./OrganizationDomain.yaml
+      - $ref: ./OrganizationMembershipRequest.yaml
+      - $ref: ./Role.yaml
+      - $ref: ./Permission.yaml
   timestamp:
     $ref: ./Timestamp.yaml
   instance_id:
@@ -83,3 +134,256 @@ properties:
       `true` when the event originated from a test-mode user / session
       (per `Environment.test_mode`). Customers should usually filter
       these out in production handlers.
+examples:
+  - id: whd_01HKX9SY9V7H7TF8C8K7J9X4Z1
+    object: event
+    type: organization.created
+    timestamp: 1714896500000
+    instance_id: env_acme_test
+    was_test: false
+    data:
+      id: org_01HKX9SY9V7H7TF8C8K7J9X4ZH
+      object: organization
+      name: Acme Inc.
+      slug: acme
+      image_url: null
+      has_image: false
+      members_count: 1
+      pending_invitations_count: 0
+      max_allowed_memberships: null
+      admin_delete_enabled: true
+      public_metadata: {}
+      private_metadata: {}
+      created_by: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+      created_at: 1714896500000
+      updated_at: 1714896500000
+  - id: whd_01HKX9SY9V7H7TF8C8K7J9X4Z2
+    object: event
+    type: organizationMembership.created
+    timestamp: 1714896600000
+    instance_id: env_acme_test
+    was_test: false
+    data:
+      id: orgmem_01HKX9SY9V7H7TF8C8K7J9X4ZJ
+      object: organization_membership
+      role: "org:member"
+      role_name: Member
+      permissions:
+        - "org:sys_domains:read"
+        - "org:sys_memberships:read"
+        - "org:sys_profile:read"
+      public_metadata: {}
+      private_metadata: {}
+      organization:
+        id: org_01HKX9SY9V7H7TF8C8K7J9X4ZH
+        object: organization
+        name: Acme Inc.
+        slug: acme
+        image_url: null
+        has_image: false
+        members_count: 2
+        pending_invitations_count: 0
+        max_allowed_memberships: null
+        admin_delete_enabled: true
+        public_metadata: {}
+        private_metadata: {}
+        created_by: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+        created_at: 1714896500000
+        updated_at: 1714896600000
+      public_user_data:
+        first_name: Jane
+        last_name: Doe
+        image_url: null
+        has_image: false
+        identifier: jane@acme.com
+        user_id: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+      created_at: 1714896600000
+      updated_at: 1714896600000
+  - id: whd_01HKX9SY9V7H7TF8C8K7J9X4Z3
+    object: event
+    type: organizationMembership.updated
+    timestamp: 1714896700000
+    instance_id: env_acme_test
+    was_test: false
+    data:
+      id: orgmem_01HKX9SY9V7H7TF8C8K7J9X4ZJ
+      object: organization_membership
+      role: "org:admin"
+      role_name: Admin
+      permissions:
+        - "org:sys_domains:manage"
+        - "org:sys_domains:read"
+        - "org:sys_memberships:manage"
+        - "org:sys_memberships:read"
+        - "org:sys_profile:delete"
+        - "org:sys_profile:manage"
+      public_metadata: {}
+      private_metadata: {}
+      organization:
+        id: org_01HKX9SY9V7H7TF8C8K7J9X4ZH
+        object: organization
+        name: Acme Inc.
+        slug: acme
+        image_url: null
+        has_image: false
+        members_count: 2
+        pending_invitations_count: 0
+        max_allowed_memberships: null
+        admin_delete_enabled: true
+        public_metadata: {}
+        private_metadata: {}
+        created_by: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+        created_at: 1714896500000
+        updated_at: 1714896700000
+      public_user_data:
+        first_name: Jane
+        last_name: Doe
+        image_url: null
+        has_image: false
+        identifier: jane@acme.com
+        user_id: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+      created_at: 1714896600000
+      updated_at: 1714896700000
+  - id: whd_01HKX9SY9V7H7TF8C8K7J9X4Z4
+    object: event
+    type: organizationInvitation.created
+    timestamp: 1714896800000
+    instance_id: env_acme_test
+    was_test: false
+    data:
+      id: orginv_01HKX9SY9V7H7TF8C8K7J9X4ZK
+      object: organization_invitation
+      organization_id: org_01HKX9SY9V7H7TF8C8K7J9X4ZH
+      email_address: kate@acme.com
+      role: "org:member"
+      role_name: Member
+      inviter_user_id: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+      redirect_url: https://app.acme.com/welcome
+      status: pending
+      public_metadata: {}
+      url: "https://acme.authn.sh/v1/client/handshake?__authn_ticket=tkt_01HKX9SY9V7H7TF8C8K7J9X4ZK&__authn_status=sign_up&__authn_organization_id=org_01HKX9SY9V7H7TF8C8K7J9X4ZH&redirect_url=https%3A%2F%2Fapp.acme.com%2Fwelcome"
+      expires_at: 1717488800000
+      created_at: 1714896800000
+      updated_at: 1714896800000
+  - id: whd_01HKX9SY9V7H7TF8C8K7J9X4Z5
+    object: event
+    type: organizationDomain.created
+    timestamp: 1714896900000
+    instance_id: env_acme_test
+    was_test: false
+    data:
+      id: orgdom_01HKX9SY9V7H7TF8C8K7J9X4ZM
+      object: organization_domain
+      organization_id: org_01HKX9SY9V7H7TF8C8K7J9X4ZH
+      name: acme.com
+      verified: false
+      enrollment_mode: automatic_invitation
+      verification:
+        status: unverified
+        strategy: email_code
+        attempts: 0
+        expire_at: 1714983300000
+        external_verification_redirect_url: null
+        nonce: null
+        error: null
+      affiliation_email_address: admin@acme.com
+      total_pending_invitations: 0
+      total_pending_suggestions: 0
+      created_at: 1714896900000
+      updated_at: 1714896900000
+  - id: whd_01HKX9SY9V7H7TF8C8K7J9X4Z6
+    object: event
+    type: organizationMembershipRequest.created
+    timestamp: 1714897000000
+    instance_id: env_acme_test
+    was_test: false
+    data:
+      id: orgreq_01HKX9SY9V7H7TF8C8K7J9X4ZN
+      object: organization_membership_request
+      organization_id: org_01HKX9SY9V7H7TF8C8K7J9X4ZH
+      status: pending
+      public_user_data:
+        first_name: Lee
+        last_name: Tran
+        image_url: null
+        has_image: false
+        identifier: lee@acme.com
+        user_id: user_01HKX9SY9V7H7TF8C8K7J9X4ZP
+      created_at: 1714897000000
+      updated_at: 1714897000000
+  - id: whd_01HKX9SY9V7H7TF8C8K7J9X4Z7
+    object: event
+    type: role.created
+    timestamp: 1714897100000
+    instance_id: env_acme_test
+    was_test: false
+    data:
+      id: role_01HKX9SY9V7H7TF8C8K7J9X4ZR
+      object: role
+      key: "org:billing"
+      name: Billing
+      description: Read and edit billing settings.
+      is_creator_eligible: false
+      is_default: false
+      is_system: false
+      permissions:
+        - "org:sys_billing:manage"
+        - "org:sys_billing:read"
+      created_at: 1714897100000
+      updated_at: 1714897100000
+  - id: whd_01HKX9SY9V7H7TF8C8K7J9X4Z8
+    object: event
+    type: permission.created
+    timestamp: 1714897200000
+    instance_id: env_acme_test
+    was_test: false
+    data:
+      id: perm_01HKX9SY9V7H7TF8C8K7J9X4ZS
+      object: permission
+      key: "org:billing:export"
+      name: Export billing data
+      description: Allow exporting invoices and usage reports.
+      is_system: false
+      created_at: 1714897200000
+      updated_at: 1714897200000
+  - id: whd_01HKX9SY9V7H7TF8C8K7J9X4Z9
+    object: event
+    type: session.created
+    timestamp: 1714897300000
+    instance_id: env_acme_test
+    was_test: false
+    data:
+      id: sess_01HKX9SY9V7H7TF8C8K7J9X4ZC
+      object: session
+      client_id: client_01HKX9SY9V7H7TF8C8K7J9X4ZA
+      user_id: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+      status: active
+      last_active_at: 1714897300000
+      last_active_organization_id: org_01HKX9SY9V7H7TF8C8K7J9X4ZH
+      organization:
+        id: org_01HKX9SY9V7H7TF8C8K7J9X4ZH
+        slug: acme
+        role: "org:admin"
+        permissions:
+          - "org:sys_domains:manage"
+          - "org:sys_domains:read"
+          - "org:sys_memberships:manage"
+          - "org:sys_memberships:read"
+          - "org:sys_profile:delete"
+          - "org:sys_profile:manage"
+      expire_at: 1715502100000
+      abandon_at: 1715502100000
+      actor: null
+      latest_activity:
+        id: sact_01HKX9SY9V7H7TF8C8K7J9X4ZT
+        object: session_activity
+        ip_address: "203.0.113.42"
+        user_agent: "Mozilla/5.0"
+        device_type: desktop
+        browser_name: Chrome
+        browser_version: "124.0"
+        is_mobile: false
+        city: "San Francisco"
+        country: "US"
+      created_at: 1714897300000
+      updated_at: 1714897300000


### PR DESCRIPTION
## Summary

Extends the v0.1 webhook event catalog with the v0.2 organization, role, and permission lifecycle events. Customers subscribed via \`enabled_event_types: ["*"]\` (or wildcards like \`"organization.*"\`) get them automatically once the dispatcher (AU-11) emits them.

### \`WebhookEvent.type\` additions (21 new)

| Resource | Events |
|---|---|
| \`organization\` | \`.created\`, \`.updated\`, \`.deleted\` |
| \`organizationMembership\` | \`.created\`, \`.updated\`, \`.deleted\` |
| \`organizationInvitation\` | \`.created\`, \`.accepted\`, \`.revoked\` |
| \`organizationDomain\` | \`.created\`, \`.updated\`, \`.deleted\` |
| \`organizationMembershipRequest\` | \`.created\`, \`.accepted\`, \`.rejected\` |
| \`role\` | \`.created\`, \`.updated\`, \`.deleted\` |
| \`permission\` | \`.created\`, \`.updated\`, \`.deleted\` (custom only — system permissions are seeded and don't emit) |
| \`session\` | \`.touched\` (rounds out the v0.1 set, covers the v0.2 active-org switcher) |

### \`WebhookEvent.data\` \`oneOf\`

Extended with \`Organization\`, \`OrganizationMembership\`, \`OrganizationInvitation\`, \`OrganizationDomain\`, \`OrganizationMembershipRequest\`, \`Role\`, \`Permission\`. \`organizationMembership\` events carry populated \`public_user_data\` inline so handlers don't need a follow-up \`getUser\`.

### Per-event payload examples

9 worked examples on \`WebhookEvent.examples\`:

- \`organization.created\`
- \`organizationMembership.created\`
- \`organizationMembership.updated\`
- \`organizationInvitation.created\`
- \`organizationDomain.created\`
- \`organizationMembershipRequest.created\`
- \`role.created\`
- \`permission.created\`
- \`session.created\` (with the new \`organization\` context populated)

### \`Session.organization\` (additive in v0.2)

Optional block on every session payload:

\`\`\`json
{
  "id": "org_…",
  "slug": "acme",
  "role": "org:admin",
  "permissions": ["org:sys_memberships:manage", …]
}
\`\`\`

Mirrors the \`org\` JWT claim minted by the next \`getSessionToken\`. Omitted in v0.1 payloads, so existing handlers see no change until the producing environment is on a v0.2 server.

### \`WebhookEndpoint.enabled_event_types\`

Documents wildcard expansion (\`"organization.*"\` matches every organization.* event). Three worked examples covering targeted, wildcard, and \`["*"]\` subscriptions.

### Explicitly out of scope

- **Magic-link emails do not introduce a new event type** — the existing \`email.created\` event covers them, documented inline on \`WebhookEvent\`.
- Enterprise SSO / SCIM events (\`enterpriseConnection.*\`, \`scimToken.*\`) — v0.6.
- \`localization.updated\` — v0.5.
- \`waitlistEntry.*\` — post-v1.

## Test plan

- [x] \`npm run lint\` — both specs valid
- [x] \`npm run bundle\` — resolves all refs (\`dist/{bapi,fapi}.bundled.{yaml,json}\` regenerated)
- [x] Every new event type listed in \`WebhookEvent.type\` enum and given a payload example
- [x] \`organization\` field documented on \`session.created\` example (and on the \`Session\` schema for \`session.touched\`)
- [x] \`WebhookEndpoint.enabled_event_types\` example shows a v0.2 mix (\`["organization.*", "organizationMembership.*", "user.created"]\`)

Closes authn-sh/openapi#16.