### PR TITLE
Fix v0.2 spec drift uncovered during contract validation

### DIFF
--- a/components/schemas/WebhookEndpoint.yaml
+++ b/components/schemas/WebhookEndpoint.yaml
@@ -69,6 +69,19 @@ properties:
     description: |
       When `false`, the dispatcher skips this endpoint without retrying.
       Toggled from the dashboard during incidents.
+  rotation_window_expires_at:
+    type: [integer, "null"]
+    format: int64
+    description: |
+      When set, the prior `signing_secret` is still accepted on
+      replay until this timestamp. Cleared once the rotation
+      window closes.
+  disabled_at:
+    type: [integer, "null"]
+    format: int64
+    description: |
+      Set by the dispatcher when an endpoint is auto-disabled
+      after sustained delivery failures. `null` while healthy.
   created_at:
     $ref: ./Timestamp.yaml
   updated_at:

--- a/paths/fapi/organization-invitations.yaml
+++ b/paths/fapi/organization-invitations.yaml
@@ -64,7 +64,7 @@ post:
               role: "org:member"
               redirect_url: https://app.acme.com/welcome
   responses:
-    "200":
+    "201":
       description: The new invitation, wrapped.
       content:
         application/json:

--- a/paths/fapi/organization-memberships.yaml
+++ b/paths/fapi/organization-memberships.yaml
@@ -84,7 +84,7 @@ post:
               role: "org:member"
               redirect_url: https://app.acme.com/welcome
   responses:
-    "200":
+    "201":
       description: The new invitation, wrapped.
       content:
         application/json:

--- a/paths/fapi/organizations.yaml
+++ b/paths/fapi/organizations.yaml
@@ -41,7 +41,7 @@ post:
               name: Acme Inc.
               slug: acme
   responses:
-    "200":
+    "201":
       description: The new organization, wrapped.
       content:
         application/json:


### PR DESCRIPTION
Three small fixes to align v0.2 specs with what the controllers and SDK actually emit:

- FAPI organization create / membership create / invitation create now declare 201 (per REST convention). Previously documented as 200 only — controllers ship 201 and tests assert 201.
- WebhookEndpoint exposes `rotation_window_expires_at` and `disabled_at` (both nullable). The dispatcher already populates them for rotation overlap windows and auto-disable.

Discovered by the auto-applied OpenAPI contract validation in authn (PR pending), which now runs against every feature test response on every CI run.

## Test plan
- [ ] redocly lint clean
- [ ] redocly bundle clean
- [ ] No downstream impact on v0.1 SDK consumers (additive; new statuses + nullable fields)