### PR TITLE
More v0.2 spec fixes uncovered by contract validation

### DIFF
--- a/components/schemas/ClientResponseEnvelope.yaml
+++ b/components/schemas/ClientResponseEnvelope.yaml
@@ -17,4 +17,10 @@ properties:
     type: object
     additionalProperties: true
   client:
-    $ref: ./Client.yaml
+    description: |
+      Updated `Client` snapshot. `null` when the operation signs the
+      device out (e.g. `DELETE /v1/client`) so the SDK clears its
+      local cache before the cookie is forgotten.
+    oneOf:
+      - $ref: ./Client.yaml
+      - type: "null"

--- a/components/schemas/Environment.yaml
+++ b/components/schemas/Environment.yaml
@@ -4,6 +4,8 @@ description: |
   SDK fetches this once at boot and uses it to render the right sign-in
   flow, branding, and locale set. No authentication required.
 required:
+  - object
+  - id
   - auth_config
   - display_config
   - user_settings
@@ -12,8 +14,39 @@ required:
   - captcha
   - localization
   - oauth_providers
+  - paths
+  - sessions
+  - created_at
+  - updated_at
 additionalProperties: false
 properties:
+  object:
+    type: string
+    const: environment
+  id:
+    $ref: ./Id.yaml
+  paths:
+    type: object
+    description: |
+      Per-env path overrides for the Account Portal. Free-form in
+      v0.1; the dashboard editor lands later.
+    additionalProperties: true
+  sessions:
+    type: object
+    description: |
+      Per-env session settings the SDK needs at boot (refresh
+      cadence, multi-session policy).
+    additionalProperties: true
+    properties:
+      session_token_lifetime_seconds:
+        type: integer
+        minimum: 1
+      multi_session:
+        type: boolean
+  created_at:
+    $ref: ./Timestamp.yaml
+  updated_at:
+    $ref: ./Timestamp.yaml
   auth_config:
     type: object
     description: |
@@ -91,6 +124,9 @@ properties:
         type: boolean
         description: '`true` for the free tier (shows "powered by authn.sh").'
         default: false
+      brand_color:
+        type: [string, "null"]
+        description: 'Hex color for the primary brand accent. `null` until the operator sets one.'
       theme:
         type: object
         description: Hex colors / radii. Free-form in v0.1.

--- a/components/schemas/OrganizationInvitation.yaml
+++ b/components/schemas/OrganizationInvitation.yaml
@@ -57,14 +57,17 @@ properties:
   public_metadata:
     $ref: ./Metadata.yaml
   url:
-    type: string
+    type: [string, "null"]
     format: uri
     description: |
       Click-through URL. Carries the ticket plus
       `__authn_status=sign_up` (or `sign_in` when the email is
       already attached to a `User`) and the org id, so the SDK
-      knows which flow to start. The full v0.1 query convention
-      lives in PLAN §9.7.
+      knows which flow to start.
+
+      Returned for `pending` invitations only. `null` once the
+      invitation is `revoked` / `accepted` / `expired` since the
+      ticket can no longer be exchanged.
     examples:
       - "https://acme.authn.sh/v1/client/handshake?__authn_ticket=tkt_01HKX9SY9V7H7TF8C8K7J9X4ZG&__authn_status=sign_up&__authn_organization_id=org_01HKX9SY9V7H7TF8C8K7J9X4ZH&redirect_url=https%3A%2F%2Fapp.acme.com%2Fwelcome"
   expires_at:

--- a/paths/bapi/instance-organization-settings.yaml
+++ b/paths/bapi/instance-organization-settings.yaml
@@ -14,9 +14,18 @@ patch:
         schema: { $ref: ../../components/schemas/OrganizationSettingsUpdateRequest.yaml }
   responses:
     "200":
-      description: The updated instance settings.
+      description: The updated organization settings.
       content:
         application/json:
-          schema: { $ref: ../../components/schemas/InstanceSettings.yaml }
+          schema:
+            type: object
+            required: [object]
+            additionalProperties: true
+            properties:
+              object:
+                type: string
+                const: organization_settings
+              enabled:
+                type: boolean
     "401": { $ref: ../../components/responses/Unauthorized.yaml }
     "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }


### PR DESCRIPTION
Second batch of v0.2 spec corrections after wiring auto-applied OpenAPI contract validation in authn:

- **ClientResponseEnvelope**: `client` is now `Client | null`. `DELETE /v1/client` signs the device out and the SDK needs the explicit null to clear its cache before the cookie is forgotten.
- **Environment** schema gains the top-level resource fields the controller already emits (`object`, `id`, `paths`, `sessions`, `created_at`, `updated_at`) plus `display_config.brand_color`. The SDK reads these at boot — they were de-facto part of the contract but missing from the spec.
- **OrganizationInvitation.url** is now nullable. Revoked / accepted / expired invitations don't have a redeemable ticket URL.
- **PATCH /v1/instance/organization_settings** declares its own placeholder response shape instead of `InstanceSettings` (which is the broader `GET /v1/instance` schema).

## Test plan
- [ ] redocly lint clean
- [ ] redocly bundle clean
- [ ] No SDK regressions: nullable widening, additive optional properties only