### PR TITLE
Spec: Session.user (embedded) for the SDK's hydrate-from-client-snapshot path

### DIFF
--- a/components/schemas/Session.yaml
+++ b/components/schemas/Session.yaml
@@ -105,6 +105,16 @@ properties:
       user. Carries `iss`, `sub`, `sid` of the actor's session.
   latest_activity:
     $ref: ./SessionActivity.yaml
+  user:
+    description: |
+      Optional embedded `User` snapshot. Present when the FAPI returns
+      this Session inside a `Client` envelope so the SDK can hydrate
+      the active user without a follow-up `GET /v1/me` round-trip.
+      Omitted on standalone `GET /v1/client/sessions/{id}` reads
+      (consumers can still fetch the user via the `user_id` field).
+    oneOf:
+      - $ref: ./User.yaml
+      - type: "null"
   created_at:
     $ref: ./Timestamp.yaml
   updated_at:


### PR DESCRIPTION
Tiny v0.2 follow-up. The SDK's `Authn.applyClientSnapshot` reads `snapshot.sessions[].user` to populate the active user, so the dashboard's `<UserButton />` can render without an extra `GET /v1/me` round-trip. The server has always emitted that field; it just wasn't in the Session schema. This adds it explicitly as an optional embedded `User` ref.

Caught by the auto-applied OpenAPI contract validation in authn (PR #82): without this, the inner Session shape inside the Client envelope was strict and rejected the `user` key.

## Test plan
- [ ] redocly lint clean
- [ ] redocly bundle clean