### PR TITLE
Refactor: kebab-case URL path segments

### DIFF
--- a/bapi.yaml
+++ b/bapi.yaml
@@ -82,15 +82,15 @@ paths:
     $ref: ./paths/bapi/user-lock.yaml
   /v1/users/{user_id}/unlock:
     $ref: ./paths/bapi/user-unlock.yaml
-  /v1/users/{user_id}/profile_image:
+  /v1/users/{user_id}/profile-image:
     $ref: ./paths/bapi/user-profile-image.yaml
   /v1/users/{user_id}/metadata:
     $ref: ./paths/bapi/user-metadata.yaml
-  /v1/users/{user_id}/verify_password:
+  /v1/users/{user_id}/verify-password:
     $ref: ./paths/bapi/user-verify-password.yaml
-  /v1/email_addresses:
+  /v1/email-addresses:
     $ref: ./paths/bapi/email-addresses.yaml
-  /v1/email_addresses/{email_address_id}:
+  /v1/email-addresses/{email_address_id}:
     $ref: ./paths/bapi/email-address.yaml
   /v1/sessions:
     $ref: ./paths/bapi/sessions.yaml
@@ -136,29 +136,29 @@ paths:
     $ref: ./paths/bapi/invitations-bulk.yaml
   /v1/invitations/{invitation_id}/revoke:
     $ref: ./paths/bapi/invitation-revoke.yaml
-  /v1/allowlist_identifiers:
+  /v1/allowlist-identifiers:
     $ref: ./paths/bapi/allowlist-identifiers.yaml
-  /v1/allowlist_identifiers/{identifier_id}:
+  /v1/allowlist-identifiers/{identifier_id}:
     $ref: ./paths/bapi/allowlist-identifier.yaml
-  /v1/blocklist_identifiers:
+  /v1/blocklist-identifiers:
     $ref: ./paths/bapi/blocklist-identifiers.yaml
-  /v1/blocklist_identifiers/{identifier_id}:
+  /v1/blocklist-identifiers/{identifier_id}:
     $ref: ./paths/bapi/blocklist-identifier.yaml
-  /v1/redirect_urls:
+  /v1/redirect-urls:
     $ref: ./paths/bapi/redirect-urls.yaml
-  /v1/redirect_urls/{redirect_url_id}:
+  /v1/redirect-urls/{redirect_url_id}:
     $ref: ./paths/bapi/redirect-url.yaml
   /v1/instance:
     $ref: ./paths/bapi/instance.yaml
   /v1/instance/restrictions:
     $ref: ./paths/bapi/instance-restrictions.yaml
-  /v1/instance/organization_settings:
+  /v1/instance/organization-settings:
     $ref: ./paths/bapi/instance-organization-settings.yaml
   /v1/webhooks/endpoints:
     $ref: ./paths/bapi/webhook-endpoints.yaml
   /v1/webhooks/endpoints/{endpoint_id}:
     $ref: ./paths/bapi/webhook-endpoint.yaml
-  /v1/webhooks/endpoints/{endpoint_id}/rotate_secret:
+  /v1/webhooks/endpoints/{endpoint_id}/rotate-secret:
     $ref: ./paths/bapi/webhook-endpoint-rotate.yaml
   /v1/webhooks/deliveries:
     $ref: ./paths/bapi/webhook-deliveries.yaml

--- a/fapi.yaml
+++ b/fapi.yaml
@@ -80,27 +80,27 @@ paths:
     $ref: ./paths/fapi/client.yaml
   /v1/client/handshake:
     $ref: ./paths/fapi/client-handshake.yaml
-  /v1/client/sign_ins:
+  /v1/client/sign-ins:
     $ref: ./paths/fapi/sign-ins.yaml
-  /v1/client/sign_ins/{sign_in_id}:
+  /v1/client/sign-ins/{sign_in_id}:
     $ref: ./paths/fapi/sign-in.yaml
-  /v1/client/sign_ins/{sign_in_id}/prepare_first_factor:
+  /v1/client/sign-ins/{sign_in_id}/prepare-first-factor:
     $ref: ./paths/fapi/sign-in-prepare-first-factor.yaml
-  /v1/client/sign_ins/{sign_in_id}/attempt_first_factor:
+  /v1/client/sign-ins/{sign_in_id}/attempt-first-factor:
     $ref: ./paths/fapi/sign-in-attempt-first-factor.yaml
-  /v1/client/sign_ins/{sign_in_id}/prepare_second_factor:
+  /v1/client/sign-ins/{sign_in_id}/prepare-second-factor:
     $ref: ./paths/fapi/sign-in-prepare-second-factor.yaml
-  /v1/client/sign_ins/{sign_in_id}/attempt_second_factor:
+  /v1/client/sign-ins/{sign_in_id}/attempt-second-factor:
     $ref: ./paths/fapi/sign-in-attempt-second-factor.yaml
-  /v1/client/sign_ins/{sign_in_id}/reset_password:
+  /v1/client/sign-ins/{sign_in_id}/reset-password:
     $ref: ./paths/fapi/sign-in-reset-password.yaml
-  /v1/client/sign_ups:
+  /v1/client/sign-ups:
     $ref: ./paths/fapi/sign-ups.yaml
-  /v1/client/sign_ups/{sign_up_id}:
+  /v1/client/sign-ups/{sign_up_id}:
     $ref: ./paths/fapi/sign-up.yaml
-  /v1/client/sign_ups/{sign_up_id}/prepare_verification:
+  /v1/client/sign-ups/{sign_up_id}/prepare-verification:
     $ref: ./paths/fapi/sign-up-prepare-verification.yaml
-  /v1/client/sign_ups/{sign_up_id}/attempt_verification:
+  /v1/client/sign-ups/{sign_up_id}/attempt-verification:
     $ref: ./paths/fapi/sign-up-attempt-verification.yaml
   /v1/client/sessions/{session_id}:
     $ref: ./paths/fapi/client-session.yaml
@@ -116,23 +116,23 @@ paths:
     $ref: ./paths/fapi/client-session-tokens-template.yaml
   /v1/me:
     $ref: ./paths/fapi/me.yaml
-  /v1/me/profile_image:
+  /v1/me/profile-image:
     $ref: ./paths/fapi/me-profile-image.yaml
-  /v1/me/email_addresses:
+  /v1/me/email-addresses:
     $ref: ./paths/fapi/me-email-addresses.yaml
-  /v1/me/email_addresses/{email_address_id}:
+  /v1/me/email-addresses/{email_address_id}:
     $ref: ./paths/fapi/me-email-address.yaml
-  /v1/me/email_addresses/{email_address_id}/prepare_verification:
+  /v1/me/email-addresses/{email_address_id}/prepare-verification:
     $ref: ./paths/fapi/me-email-prepare-verification.yaml
-  /v1/me/email_addresses/{email_address_id}/attempt_verification:
+  /v1/me/email-addresses/{email_address_id}/attempt-verification:
     $ref: ./paths/fapi/me-email-attempt-verification.yaml
   /v1/me/sessions:
     $ref: ./paths/fapi/me-sessions.yaml
-  /v1/me/change_password:
+  /v1/me/change-password:
     $ref: ./paths/fapi/me-change-password.yaml
   /v1/me/password:
     $ref: ./paths/fapi/me-password.yaml
-  /v1/me/delete_self:
+  /v1/me/delete-self:
     $ref: ./paths/fapi/me-delete-self.yaml
   /v1/organizations:
     $ref: ./paths/fapi/organizations.yaml
@@ -156,21 +156,21 @@ paths:
     $ref: ./paths/fapi/organization-domain.yaml
   /v1/organizations/{organization_id}/domains/{domain_id}/verify:
     $ref: ./paths/fapi/organization-domain-verify.yaml
-  /v1/organizations/{organization_id}/membership_requests:
+  /v1/organizations/{organization_id}/membership-requests:
     $ref: ./paths/fapi/organization-membership-requests.yaml
-  /v1/organizations/{organization_id}/membership_requests/{request_id}/accept:
+  /v1/organizations/{organization_id}/membership-requests/{request_id}/accept:
     $ref: ./paths/fapi/organization-membership-request-accept.yaml
-  /v1/organizations/{organization_id}/membership_requests/{request_id}/reject:
+  /v1/organizations/{organization_id}/membership-requests/{request_id}/reject:
     $ref: ./paths/fapi/organization-membership-request-reject.yaml
-  /v1/me/organization_memberships:
+  /v1/me/organization-memberships:
     $ref: ./paths/fapi/me-organization-memberships.yaml
-  /v1/me/organization_invitations:
+  /v1/me/organization-invitations:
     $ref: ./paths/fapi/me-organization-invitations.yaml
-  /v1/me/organization_invitations/{invitation_id}/accept:
+  /v1/me/organization-invitations/{invitation_id}/accept:
     $ref: ./paths/fapi/me-organization-invitation-accept.yaml
-  /v1/me/organization_membership_requests:
+  /v1/me/organization-membership-requests:
     $ref: ./paths/fapi/me-organization-membership-requests.yaml
-  /v1/me/active_organization:
+  /v1/me/active-organization:
     $ref: ./paths/fapi/me-active-organization.yaml
 
 components:

--- a/paths/bapi/webhook-endpoint.yaml
+++ b/paths/bapi/webhook-endpoint.yaml
@@ -37,7 +37,7 @@ patch:
   summary: Update a webhook endpoint
   description: |
     Patch any of `url` / `enabled_event_types` / `enabled`. The
-    `signing_secret` cannot be set this way — use `rotate_secret`.
+    `signing_secret` cannot be set this way — use `rotate-secret`.
   tags: [Webhooks]
   parameters:
     - $ref: ../../components/parameters/IdempotencyKeyHeader.yaml

--- a/paths/fapi/client-session-touch.yaml
+++ b/paths/fapi/client-session-touch.yaml
@@ -21,7 +21,7 @@ post:
 
     For pure switcher flows that don't need to bump
     `last_active_at` at the same time, prefer
-    `setMyActiveOrganization` (`PUT /v1/me/active_organization`).
+    `setMyActiveOrganization` (`PUT /v1/me/active-organization`).
   tags: [Sessions]
   requestBody:
     required: false

--- a/paths/fapi/me.yaml
+++ b/paths/fapi/me.yaml
@@ -92,7 +92,7 @@ delete:
   operationId: deleteMe
   summary: Delete the current user (alias for delete_self)
   description: |
-    Convenience wrapper around `POST /v1/me/delete_self`. Subject to
+    Convenience wrapper around `POST /v1/me/delete-self`. Subject to
     the environment's `delete_self_enabled` setting.
   tags: [Me]
   security:

--- a/paths/fapi/sign-up-attempt-verification.yaml
+++ b/paths/fapi/sign-up-attempt-verification.yaml
@@ -25,7 +25,7 @@ post:
     to `complete` (sets `created_user_id` and `created_session_id`).
     For `email_link` against an existing identifier, the verification
     flips to `transferable` and the SDK should bounce to sign-in via
-    `POST /v1/client/sign_ins { transfer: true }` instead.
+    `POST /v1/client/sign-ins { transfer: true }` instead.
   tags: [Sign-Ups]
   security:
     - client_cookie: []


### PR DESCRIPTION
## Summary

- Replace all underscore-separated URL path segments in `bapi.yaml` and `fapi.yaml` with hyphen-separated equivalents
- Path parameter names (`{user_id}`, `{email_address_id}`), query params, JSON field names, operationIds, and schema names are unchanged
- Updated three inline description URL references to match (`/v1/me/delete-self`, `/v1/me/active-organization`, `/v1/client/sign-ins`)

**BAPI paths changed:**
- `/v1/email_addresses` → `/v1/email-addresses`
- `/v1/users/{user_id}/profile_image` → `.../profile-image`
- `/v1/users/{user_id}/verify_password` → `.../verify-password`
- `/v1/allowlist_identifiers` → `/v1/allowlist-identifiers`
- `/v1/blocklist_identifiers` → `/v1/blocklist-identifiers`
- `/v1/redirect_urls` → `/v1/redirect-urls`
- `/v1/instance/organization_settings` → `.../organization-settings`
- `/v1/webhooks/endpoints/{id}/rotate_secret` → `.../rotate-secret`

**FAPI paths changed:**
- `/v1/client/sign_ins` → `/v1/client/sign-ins` (and all sub-paths)
- `/v1/client/sign_ups` → `/v1/client/sign-ups` (and all sub-paths)
- `/v1/me/profile_image` → `.../profile-image`
- `/v1/me/email_addresses` → `.../email-addresses` (and sub-paths)
- `/v1/me/change_password` → `.../change-password`
- `/v1/me/delete_self` → `.../delete-self`
- `/v1/me/active_organization` → `.../active-organization`
- `/v1/me/organization_memberships` → `.../organization-memberships`
- `/v1/me/organization_invitations` → `.../organization-invitations`
- `/v1/me/organization_membership_requests` → `.../organization-membership-requests`
- `/v1/organizations/{id}/membership_requests` → `.../membership-requests`

## Test plan

- [x] `npm run lint` — clean (both bapi and fapi)
- [x] `npm run bundle` — clean (all four output files generated)