### PR TITLE
v0.3 MFA: TOTP + backup-code spec sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Multi-factor authentication surface (v0.3)**.
+  - `TotpSecret` (one per `User`, `totp_` prefix) and `BackupCode` (`bcc_` prefix) resource schemas, plus `BackupCodeBatch` envelope for the one-time plaintext reveal.
+  - `Challenge.strategy` enum gains `totp` and `backup_code`. `ChallengeCreateRequest` documents the second-factor variants (no extra fields needed beyond `strategy`); `ChallengeAnswerRequest` documents the `{ code }` answer shape for both.
+  - FAPI: `POST /v1/me/totp` (start enrollment), `POST /v1/me/totp/verify` (confirm with first code), `DELETE /v1/me/totp` (remove). `POST /v1/me/backup-codes` ((re)generate batch), `DELETE /v1/me/backup-codes` (remove all unused).
+  - BAPI: `POST /v1/users/{user_id}/verify-totp` (operator-driven TOTP check) and `DELETE /v1/users/{user_id}/mfa` (operator MFA reset).
+  - `SignIn` documents the `needs_second_factor` step end-to-end — second-factor Challenge issuance with `step: "second"`, `supported_strategies` narrowing per the resolved user's enrolled methods (`totp` / `backup_code`), and the answer + transition rules.
+  - `InstanceSettings.multi_factor` block — per-env `totp.enabled`, `backup_codes.enabled`, `backup_codes.default_count` (4..24, default 10). Matching `InstanceUpdateRequest.multi_factor` patch shape.
+
 ## [0.2.0] — 2026-05-10
 
 ### Added

--- a/bapi.yaml
+++ b/bapi.yaml
@@ -88,6 +88,10 @@ paths:
     $ref: ./paths/bapi/user-metadata.yaml
   /v1/users/{user_id}/verify-password:
     $ref: ./paths/bapi/user-verify-password.yaml
+  /v1/users/{user_id}/verify-totp:
+    $ref: ./paths/bapi/user-verify-totp.yaml
+  /v1/users/{user_id}/mfa:
+    $ref: ./paths/bapi/user-mfa.yaml
   /v1/email-addresses:
     $ref: ./paths/bapi/email-addresses.yaml
   /v1/email-addresses/{email_address_id}:
@@ -192,6 +196,9 @@ components:
     Challenge:                                 { $ref: ./components/schemas/Challenge.yaml }
     ChallengeCreateRequest:                    { $ref: ./components/schemas/ChallengeCreateRequest.yaml }
     ChallengeAnswerRequest:                    { $ref: ./components/schemas/ChallengeAnswerRequest.yaml }
+    TotpSecret:                                { $ref: ./components/schemas/TotpSecret.yaml }
+    BackupCode:                                { $ref: ./components/schemas/BackupCode.yaml }
+    BackupCodeBatch:                           { $ref: ./components/schemas/BackupCodeBatch.yaml }
     EmailAddress:                              { $ref: ./components/schemas/EmailAddress.yaml }
     User:                                      { $ref: ./components/schemas/User.yaml }
     UserCreateRequest:                         { $ref: ./components/schemas/UserCreateRequest.yaml }

--- a/components/schemas/BackupCode.yaml
+++ b/components/schemas/BackupCode.yaml
@@ -1,0 +1,76 @@
+type: object
+description: |
+  A single-use recovery code paired with a `User`'s second factor.
+  Backup codes let a user complete sign-in if they've lost access to
+  their TOTP authenticator. The plaintext code is **only ever returned
+  in the generation response** — at rest the code is hashed (Argon2id),
+  matched against the user's hash list at sign-in time, and marked
+  consumed on first successful answer.
+
+  ### Lifecycle
+
+  1. `POST /v1/me/backup-codes` (re)generates `default_count` plaintext
+     codes (instance-configurable; default 10) and returns the full
+     batch as `codes[]`. The batch supersedes any prior backup-code
+     rows — every old row is deleted server-side before the new batch
+     is stored, so previously-shown codes stop working immediately.
+  2. The user copies the codes to a safe place. Subsequent reads
+     never re-surface them.
+  3. At sign-in, the user answers a `step: "second"` Challenge with
+     `strategy: backup_code` and `{ code: "abcd-efgh" }`. The matching
+     row's `consumed_at` is stamped and the code can never be reused.
+  4. `DELETE /v1/me/backup-codes` removes every unused code on the
+     user. Combined with `DELETE /v1/me/totp` this is how a user
+     fully disables MFA from the Account Portal.
+  5. BAPI `DELETE /v1/users/{user_id}/mfa` is the operator override —
+     clears every TotpSecret + BackupCode and flips
+     `User.mfa_disabled_at`.
+
+  ### Surface representation
+
+  Backup-code rows themselves are not separately enumerated through a
+  list endpoint; the user-facing surface is exactly the one-time
+  `BackupCodeBatch` reveal. The `BackupCode` schema is documented for
+  completeness — it shows up in audit-log payloads, the BAPI admin
+  view of MFA state, and the SDK type hierarchy.
+required:
+  - id
+  - object
+  - user_id
+  - consumed_at
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+    description: ULID with prefix `bcc_`.
+  object:
+    type: string
+    const: backup_code
+  user_id:
+    $ref: ./Id.yaml
+  consumed_at:
+    type: [integer, "null"]
+    format: int64
+    minimum: 0
+    description: |
+      Unix-ms timestamp of the sign-in answer that consumed this code.
+      `null` while the code is still spendable.
+  created_at:
+    $ref: ./Timestamp.yaml
+  updated_at:
+    $ref: ./Timestamp.yaml
+examples:
+  - id: bcc_01HKX9SY9V7H7TF8C8K7J9X4ZS
+    object: backup_code
+    user_id: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    consumed_at: null
+    created_at: 1714896900000
+    updated_at: 1714896900000
+  - id: bcc_01HKX9SY9V7H7TF8C8K7J9X4ZS
+    object: backup_code
+    user_id: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    consumed_at: 1714983300000
+    created_at: 1714896900000
+    updated_at: 1714983300000

--- a/components/schemas/BackupCodeBatch.yaml
+++ b/components/schemas/BackupCodeBatch.yaml
@@ -1,0 +1,58 @@
+type: object
+description: |
+  One-time payload returned by `POST /v1/me/backup-codes`. Carries the
+  freshly-minted plaintext `codes[]` exactly once — they're hashed at
+  rest and never re-surfaced. The SDK is expected to render the codes
+  immediately for the user to copy / download / print and to clear the
+  array from memory once the user dismisses the reveal modal.
+
+  Re-issuing this endpoint replaces every prior code on the user, so the
+  matching `count` reflects the new batch size — there's no merge with
+  previous batches.
+required:
+  - object
+  - user_id
+  - count
+  - codes
+  - generated_at
+additionalProperties: false
+properties:
+  object:
+    type: string
+    const: backup_code_batch
+  user_id:
+    $ref: ./Id.yaml
+  count:
+    type: integer
+    minimum: 1
+    description: Number of codes in `codes[]`. Defaults to `multi_factor.backup_codes.default_count` from `InstanceSettings`.
+  codes:
+    type: array
+    description: |
+      Plaintext recovery codes — formatted `xxxx-xxxx` (8 lowercase
+      Crockford-base32 chars with a hyphen at the midpoint). Single-use;
+      the server hashes each one before storage and discards the
+      plaintext when the response is sent.
+    items:
+      type: string
+      pattern: "^[a-z0-9]{4}-[a-z0-9]{4}$"
+    examples:
+      - ["abcd-efgh", "ijkl-mnop", "qrst-uvwx"]
+  generated_at:
+    $ref: ./Timestamp.yaml
+examples:
+  - object: backup_code_batch
+    user_id: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    count: 10
+    codes:
+      - "abcd-efgh"
+      - "ijkl-mnop"
+      - "qrst-uvwx"
+      - "yzab-cdef"
+      - "ghij-klmn"
+      - "opqr-stuv"
+      - "wxyz-1234"
+      - "5678-90ab"
+      - "cdef-ghij"
+      - "klmn-opqr"
+    generated_at: 1714896900000

--- a/components/schemas/Challenge.yaml
+++ b/components/schemas/Challenge.yaml
@@ -16,9 +16,15 @@ description: |
   challenge is verifying. The set of legal `strategy` values is
   parent-specific:
 
-  - `SignIn` — `password`, `email_code`, `email_link`,
+  - `SignIn` (first factor) — `password`, `email_code`, `email_link`,
     `reset_password_email_code`, `ticket`, `transfer`.
-  - `SignUp` — `email_code`, `email_link`, `ticket`, `transfer`.
+  - `SignIn` (second factor) — `totp`, `backup_code`. Issued only when
+    the parent SignIn is in `needs_second_factor`, scoped to whichever
+    methods the resolved user has enrolled (`SignIn.supported_strategies`
+    narrows to that set).
+  - `SignUp` — `email_code`, `email_link`, `ticket`, `transfer`. Sign-up
+    never gains a second factor — MFA enrollment happens after the
+    sign-up completes, on the resulting User.
   - `EmailAddress` — `email_code`, `email_link`. Used by FAPI
     `/v1/me/email-addresses/{id}/challenges` to verify additional
     addresses on an already-signed-in user.
@@ -152,26 +158,34 @@ properties:
       - `first` — first authentication factor on a `SignIn` (typical
         password / email_code / oauth / magic-link).
       - `second` — second factor for MFA on a `SignIn` (TOTP,
-        backup_code, sms_code, …). v0.3+.
+        backup_code, sms_code, …). Issued only when the parent SignIn
+        is in `needs_second_factor`. v0.3+.
       - `single` — every other case: sign-up email/phone verification,
         ticket-bound flows, magic-link sign-up, email-address
         verification, and organization-domain verification. There's no
-        MFA layered on top.
+        MFA layered on top. **Note:** TOTP enrollment verification on
+        `/v1/me/totp/verify` is not modelled as a Challenge at all —
+        it's a direct verify call against the enrolling user, not a
+        sub-resource on a parent flow.
   strategy:
     type: string
     description: |
-      How this challenge is being completed. v0.2 surface:
+      How this challenge is being completed. v0.3 surface:
 
       - `password`, `email_code`, `email_link`,
         `reset_password_email_code`, `ticket`, `transfer` — sign-in /
-        sign-up.
+        sign-up first factor.
+      - `totp`, `backup_code` — sign-in second factor (`step: "second"`
+        only). Answer with `{ code: "123456" }` for `totp` (numeric,
+        6 digits, `±1 step` tolerance) or `{ code: "abcd-efgh" }` for
+        `backup_code` (single-use, hashed at rest).
       - `email_code`, `email_link` — email-address verification on a
         signed-in user.
       - `domain_dns_txt`, `email_code` — organization-domain
         verification.
 
-      Future strategies (TOTP, backup_code, SMS, OAuth, passkey) plug
-      in here without spec changes.
+      Future strategies (SMS, OAuth, passkey) plug in here without
+      spec changes.
     examples:
       - password
       - email_code
@@ -180,11 +194,11 @@ properties:
       - ticket
       - transfer
       - domain_dns_txt
+      - totp
+      - backup_code
       - oauth_google
       - phone_code
       - passkey
-      - totp
-      - backup_code
   status:
     type: string
     enum: [pending, verified, transferable, failed, expired]
@@ -287,3 +301,35 @@ examples:
     error: null
     created_at: 1714896900000
     updated_at: 1714896900000
+  - id: chal_01HKX9SY9V7H7TF8C8K7J9X4ZT
+    object: challenge
+    sign_in_id: sia_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    sign_up_id: null
+    email_address_id: null
+    organization_domain_id: null
+    step: second
+    strategy: totp
+    status: pending
+    attempts: 0
+    expire_at: 1714724000000
+    nonce: null
+    external_verification_redirect_url: null
+    error: null
+    created_at: 1714723000000
+    updated_at: 1714723000000
+  - id: chal_01HKX9SY9V7H7TF8C8K7J9X4ZU
+    object: challenge
+    sign_in_id: sia_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    sign_up_id: null
+    email_address_id: null
+    organization_domain_id: null
+    step: second
+    strategy: backup_code
+    status: verified
+    attempts: 1
+    expire_at: 1714724000000
+    nonce: null
+    external_verification_redirect_url: null
+    error: null
+    created_at: 1714723000000
+    updated_at: 1714723500000

--- a/components/schemas/ChallengeAnswerRequest.yaml
+++ b/components/schemas/ChallengeAnswerRequest.yaml
@@ -17,6 +17,13 @@ description: |
     result — `verified` if the TXT record was visible, `pending` if
     the lookup was queued. The server keeps polling DNS in the
     background regardless.
+  - `totp` — `{ code: "123456" }`. 6-digit numeric TOTP. Server checks
+    against the user's stored secret with a `±1 step` (30s) window.
+    Only legal on a `step: "second"` Challenge bound to a SignIn.
+  - `backup_code` — `{ code: "abcd-efgh" }`. Single-use recovery code
+    in `xxxx-xxxx` format. The matching row is marked consumed on
+    success and can never be reused. Only legal on a `step: "second"`
+    Challenge bound to a SignIn.
   - `signature` is reserved for v0.5 (passkey).
 
   On a `reset_password_email_code` answer the parent SignIn transitions
@@ -34,4 +41,5 @@ properties:
 examples:
   - { password: "correct horse battery staple" }
   - { code: "542178" }
+  - { code: "abcd-efgh" }
   - {}

--- a/components/schemas/ChallengeCreateRequest.yaml
+++ b/components/schemas/ChallengeCreateRequest.yaml
@@ -9,16 +9,22 @@ description: |
   The answer to the challenge is submitted separately via
   `POST .../challenges/{cid}/answer` with `ChallengeAnswerRequest`.
   Strategies that have nothing to issue (e.g. `password`,
-  `domain_dns_txt`) return a `pending` challenge straight away — for
-  `domain_dns_txt` the proof token is surfaced in `nonce`; for
-  `password` `nonce` stays `null` and the caller proceeds straight
-  to `answer`.
+  `domain_dns_txt`, `totp`, `backup_code`) return a `pending` challenge
+  straight away — for `domain_dns_txt` the proof token is surfaced in
+  `nonce`; for `password`, `totp`, and `backup_code` `nonce` stays
+  `null` and the caller proceeds straight to `answer`.
 
   Per-parent legal strategies:
 
-  - `SignIn` — `password`, `email_code`, `email_link`,
+  - `SignIn` (first factor) — `password`, `email_code`, `email_link`,
     `reset_password_email_code`, `ticket`, `transfer`.
+  - `SignIn` (second factor) — `totp`, `backup_code`. Only legal when
+    the parent SignIn is in `needs_second_factor`; the server narrows
+    `SignIn.supported_strategies` to the second-factor methods the
+    resolved user has enrolled. `step` on the resulting Challenge is
+    set to `"second"`.
   - `SignUp` — `email_code`, `email_link`, `ticket`, `transfer`.
+    Sign-up never gains a second factor.
   - `EmailAddress` — `email_code`, `email_link`.
   - `OrganizationDomain` — `domain_dns_txt`, `email_code`.
 required: [strategy]
@@ -27,10 +33,10 @@ properties:
   strategy:
     type: string
     description: |
-      v0.2 surface across all parents:
+      v0.3 surface across all parents:
       `password`, `email_code`, `email_link`, `reset_password_email_code`,
-      `ticket`, `transfer`, `domain_dns_txt`. Future strategies (TOTP,
-      backup_code, SMS, OAuth, passkey) plug in here without spec
+      `ticket`, `transfer`, `domain_dns_txt`, `totp`, `backup_code`.
+      Future strategies (SMS, OAuth, passkey) plug in here without spec
       changes.
     examples:
       - password
@@ -40,6 +46,8 @@ properties:
       - ticket
       - transfer
       - domain_dns_txt
+      - totp
+      - backup_code
   email_address_id:
     type: string
     description: |
@@ -47,10 +55,11 @@ properties:
       challenge. Must be one of `SignIn.supported_strategies`'s implied
       identifiers. Ignored for sign-up (the address comes from the
       attempt itself) and for the `EmailAddress` parent (the address is
-      the parent itself).
+      the parent itself). Not used by `totp` / `backup_code` — those
+      strategies are scoped to the resolved user, not an identifier.
   phone_number_id:
     type: string
-    description: Reserved for `phone_code` (v0.3+).
+    description: Reserved for `phone_code` (v0.4+).
   redirect_url:
     type: string
     format: uri
@@ -68,3 +77,5 @@ examples:
     email_address_id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE
   - { strategy: email_code }
   - { strategy: domain_dns_txt }
+  - { strategy: totp }
+  - { strategy: backup_code }

--- a/components/schemas/InstanceSettings.yaml
+++ b/components/schemas/InstanceSettings.yaml
@@ -19,6 +19,7 @@ required:
   - test_mode
   - signing_keys
   - organizations
+  - multi_factor
   - audit_log_retention_days
 additionalProperties: false
 properties:
@@ -217,6 +218,51 @@ properties:
       enabled:
         type: boolean
         default: false
+  multi_factor:
+    type: object
+    description: |
+      Per-environment MFA strategy gating. The FAPI consults these
+      flags before issuing a `totp` / `backup_code` Challenge or
+      accepting `POST /v1/me/totp` / `POST /v1/me/backup-codes`. A
+      strategy that's `enabled: false` is omitted from
+      `SignIn.supported_strategies` even if a user has stale
+      enrollment rows for it (the rows survive the toggle but can't
+      be used to complete sign-in).
+    additionalProperties: false
+    required: [totp, backup_codes]
+    properties:
+      totp:
+        type: object
+        additionalProperties: false
+        required: [enabled]
+        properties:
+          enabled:
+            type: boolean
+            default: true
+            description: |
+              When `false`, refuses new TOTP enrollments and excludes
+              `totp` from second-factor `supported_strategies`.
+      backup_codes:
+        type: object
+        additionalProperties: false
+        required: [enabled, default_count]
+        properties:
+          enabled:
+            type: boolean
+            default: true
+            description: |
+              When `false`, refuses backup-code generation and excludes
+              `backup_code` from second-factor `supported_strategies`.
+          default_count:
+            type: integer
+            minimum: 4
+            maximum: 24
+            default: 10
+            description: |
+              How many codes `POST /v1/me/backup-codes` mints per
+              regeneration request. Bounds chosen so the typical
+              printable card stays readable; raise for environments
+              that want more headroom.
   audit_log_retention_days:
     type: integer
     minimum: 1

--- a/components/schemas/InstanceUpdateRequest.yaml
+++ b/components/schemas/InstanceUpdateRequest.yaml
@@ -44,6 +44,30 @@ properties:
   signing_keys:
     type: object
     additionalProperties: true
+  multi_factor:
+    type: object
+    description: |
+      Patch any subset of the per-env MFA toggles. Same shape as
+      `InstanceSettings.multi_factor` — supply the strategy block(s)
+      you want to update; omitted blocks are left untouched. Setting
+      a strategy to `enabled: false` keeps existing enrollment rows
+      but stops them from completing sign-in.
+    additionalProperties: false
+    properties:
+      totp:
+        type: object
+        additionalProperties: false
+        properties:
+          enabled: { type: boolean }
+      backup_codes:
+        type: object
+        additionalProperties: false
+        properties:
+          enabled: { type: boolean }
+          default_count:
+            type: integer
+            minimum: 4
+            maximum: 24
   audit_log_retention_days:
     type: integer
     minimum: 1

--- a/components/schemas/SignIn.yaml
+++ b/components/schemas/SignIn.yaml
@@ -11,8 +11,9 @@ description: |
   exposing it changed.
 
   v0.1 ships `password` + `email_code` + `reset_password_email_code`
-  + `ticket`. v0.2 adds `email_link` (magic link). OAuth/SAML/passkey/TOTP
-  land in later milestones.
+  + `ticket`. v0.2 adds `email_link` (magic link). v0.3 layers MFA on
+  top via the `needs_second_factor` step. OAuth/SAML/passkey land in
+  later milestones.
 
   ### Magic-link cross-device polling (PLAN §9.10)
 
@@ -22,6 +23,39 @@ description: |
   The originating device polls the focused
   `GET /v1/client/sign-ins/{sid}/challenges/{cid}` resource (not the
   whole sign-in) — see the cross-device polling note on `Challenge`.
+
+  ### Second-factor flow (`needs_second_factor`) — v0.3
+
+  When the resolved user has at least one second factor enrolled
+  (`User.two_factor_enabled: true`), a successful first-factor
+  `Challenge` advances the SignIn to `needs_second_factor` instead of
+  `complete`. From there:
+
+  1. The server narrows `supported_strategies` to whichever of
+     `totp` / `backup_code` the user has actually enrolled
+     (`User.totp_enabled` and `User.backup_code_enabled` gate the
+     list independently). The list is empty when MFA is administratively
+     disabled mid-flow.
+  2. Client issues a second-factor `Challenge`:
+     `POST /v1/client/sign-ins/{sid}/challenges { strategy: "totp" | "backup_code" }`.
+     The server stamps `step: "second"` on the resulting Challenge.
+     Neither strategy needs an issue payload — `nonce` stays `null` and
+     the SDK proceeds straight to `answer`.
+  3. Client answers:
+     `POST /v1/client/sign-ins/{sid}/challenges/{cid}/answer { code: "…" }`.
+     `totp` accepts a 6-digit numeric code (`±1 step` window);
+     `backup_code` accepts an `xxxx-xxxx` recovery code (single-use,
+     hashed at rest). On success the Challenge flips to `verified` and
+     the SignIn advances to `complete` (or `needs_client_trust` if the
+     environment requires a device trust check).
+  4. Failed answers count against the standard brute-force bucket. The
+     SignIn stays in `needs_second_factor` until a fresh Challenge
+     succeeds or `abandon_at` passes.
+
+  Switching second-factor strategy mid-flow is allowed — issuing a
+  fresh `backup_code` Challenge after a `totp` Challenge has failed
+  expires the prior live challenge (`current_challenge_id` repoints to
+  the new one).
 required:
   - id
   - object
@@ -54,7 +88,11 @@ properties:
       - `needs_identifier` — caller must supply email/phone/username.
       - `needs_first_factor` — caller must `POST .../challenges` then
         `.../challenges/{cid}/answer`.
-      - `needs_second_factor` — first factor passed; second pending. v0.3+.
+      - `needs_second_factor` — first factor passed; second pending.
+        Caller issues a fresh Challenge with `strategy: "totp"` or
+        `"backup_code"` (the server stamps `step: "second"`) and answers
+        with `{ code: "…" }`. Reached only when the resolved user has
+        at least one second factor enrolled. v0.3+.
       - `needs_new_password` — `reset_password_email_code` succeeded; caller
         must create a fresh `Challenge` with `strategy: password` and
         answer it with the new password, which transitions the sign-in
@@ -74,14 +112,28 @@ properties:
     items: { type: string }
     description: |
       Strategies the client may issue next given the sign-in's current
-      state. The server narrows this list as the flow progresses — e.g.
-      after a first-factor `verified`, the list flips from first-factor
-      strategies to whatever second-factor strategies the user has
-      enrolled. v0.2 surface: `password`, `email_code`, `email_link`,
-      `reset_password_email_code`, `ticket`. Empty when the flow is
-      `complete` or `abandoned`.
+      state. The server narrows this list as the flow progresses:
+
+      - `needs_first_factor` — first-factor strategies the environment
+        + identifier support: `password`, `email_code`, `email_link`,
+        `reset_password_email_code`, `ticket`.
+      - `needs_second_factor` — narrowed to second-factor strategies
+        the resolved user has enrolled. v0.3 surface: `totp`,
+        `backup_code`. Each entry maps to whichever of
+        `User.totp_enabled` / `User.backup_code_enabled` is `true`.
+        Empty when the user has no second factor enrolled (the SignIn
+        wouldn't be in `needs_second_factor` in that case — see the
+        per-status notes).
+      - `needs_new_password` — `[password]`.
+      - `complete` / `abandoned` — empty.
+
+      Switching strategy mid-step is allowed — the server accepts any
+      currently-listed value on the next `POST .../challenges`.
     examples:
       - [password, email_code, email_link, reset_password_email_code]
+      - [totp, backup_code]
+      - [totp]
+      - [backup_code]
   current_challenge_id:
     description: |
       Pointer to the live `Challenge` if one's in flight. `null` when

--- a/components/schemas/TotpSecret.yaml
+++ b/components/schemas/TotpSecret.yaml
@@ -1,0 +1,106 @@
+type: object
+description: |
+  An enrolled TOTP (RFC 6238) shared secret bound to a `User`. A user
+  has at most one `TotpSecret` row at a time — re-enrolling overwrites
+  any existing unverified row in place.
+
+  ### Lifecycle
+
+  1. `POST /v1/me/totp` mints a fresh row with `verified_at: null`,
+     returns the plaintext `secret` (base32) plus the prefilled
+     `otpauth_uri` and a server-rendered `qr_code_data_url` so the SDK
+     can render the enrollment QR without a JS dependency. The plaintext
+     secret is **only ever returned in this response** — subsequent
+     reads through `GET /v1/me` surface `User.totp_enabled` but never
+     the secret itself, which is encrypted at rest.
+  2. `POST /v1/me/totp/verify` answers with the first generated code;
+     server checks it against the stored secret with a `±1 step`
+     window and stamps `verified_at`. The matching `User` flips
+     `totp_enabled: true`, and `mfa_enabled_at` is set if this is the
+     user's first second factor.
+  3. `DELETE /v1/me/totp` removes the row, flips `User.totp_enabled`
+     back to `false`, and stamps `mfa_disabled_at` if no other second
+     factor remains.
+
+  ### BAPI admin overrides
+
+  - `POST /v1/users/{user_id}/verify-totp` lets an operator stamp
+    `verified_at` after they've manually confirmed enrollment (e.g.
+    helping a user through a stuck enrollment).
+  - `DELETE /v1/users/{user_id}/mfa` clears the `TotpSecret` (and any
+    `BackupCode` rows) — used to reset MFA when a user has lost access
+    to their authenticator.
+
+  The plaintext `secret` is **not** returned by any BAPI endpoint;
+  operators never see the raw secret.
+required:
+  - id
+  - object
+  - user_id
+  - verified_at
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+    description: ULID with prefix `totp_`.
+  object:
+    type: string
+    const: totp_secret
+  user_id:
+    $ref: ./Id.yaml
+  secret:
+    type: [string, "null"]
+    description: |
+      Base32-encoded shared secret. **Only present in the
+      `POST /v1/me/totp` enrollment response.** Subsequent reads omit
+      this field (the secret is encrypted at rest and never re-surfaced).
+    examples:
+      - JBSWY3DPEHPK3PXP
+  otpauth_uri:
+    type: [string, "null"]
+    format: uri
+    description: |
+      `otpauth://totp/...` URI matching `secret`, suitable for direct
+      hand-off to an authenticator app. Only present alongside `secret`
+      on the enrollment response.
+    examples:
+      - "otpauth://totp/acme.authn.sh:jane%40acme.com?secret=JBSWY3DPEHPK3PXP&issuer=acme.authn.sh&algorithm=SHA1&digits=6&period=30"
+  qr_code_data_url:
+    type: [string, "null"]
+    description: |
+      `data:image/png;base64,…` payload encoding the `otpauth_uri` as a
+      QR code. Renderable in an `<img src>` without a client-side QR
+      library. Only present alongside `secret` on the enrollment
+      response.
+  verified_at:
+    type: [integer, "null"]
+    format: int64
+    minimum: 0
+    description: |
+      Unix-ms timestamp of the first successful TOTP verification.
+      `null` while the row is still in unverified-enrollment limbo.
+  created_at:
+    $ref: ./Timestamp.yaml
+  updated_at:
+    $ref: ./Timestamp.yaml
+examples:
+  - id: totp_01HKX9SY9V7H7TF8C8K7J9X4ZR
+    object: totp_secret
+    user_id: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    secret: JBSWY3DPEHPK3PXP
+    otpauth_uri: "otpauth://totp/acme.authn.sh:jane%40acme.com?secret=JBSWY3DPEHPK3PXP&issuer=acme.authn.sh&algorithm=SHA1&digits=6&period=30"
+    qr_code_data_url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAA…"
+    verified_at: null
+    created_at: 1714896900000
+    updated_at: 1714896900000
+  - id: totp_01HKX9SY9V7H7TF8C8K7J9X4ZR
+    object: totp_secret
+    user_id: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    secret: null
+    otpauth_uri: null
+    qr_code_data_url: null
+    verified_at: 1714897200000
+    created_at: 1714896900000
+    updated_at: 1714897200000

--- a/fapi.yaml
+++ b/fapi.yaml
@@ -134,6 +134,12 @@ paths:
     $ref: ./paths/fapi/me-password.yaml
   /v1/me/delete-self:
     $ref: ./paths/fapi/me-delete-self.yaml
+  /v1/me/totp:
+    $ref: ./paths/fapi/me-totp.yaml
+  /v1/me/totp/verify:
+    $ref: ./paths/fapi/me-totp-verify.yaml
+  /v1/me/backup-codes:
+    $ref: ./paths/fapi/me-backup-codes.yaml
   /v1/organizations:
     $ref: ./paths/fapi/organizations.yaml
   /v1/organizations/{organization_id}:
@@ -210,6 +216,9 @@ components:
     Challenge:                                 { $ref: ./components/schemas/Challenge.yaml }
     ChallengeCreateRequest:                    { $ref: ./components/schemas/ChallengeCreateRequest.yaml }
     ChallengeAnswerRequest:                    { $ref: ./components/schemas/ChallengeAnswerRequest.yaml }
+    TotpSecret:                                { $ref: ./components/schemas/TotpSecret.yaml }
+    BackupCode:                                { $ref: ./components/schemas/BackupCode.yaml }
+    BackupCodeBatch:                           { $ref: ./components/schemas/BackupCodeBatch.yaml }
     AttributeSetting:                          { $ref: ./components/schemas/AttributeSetting.yaml }
     PublicUserData:                            { $ref: ./components/schemas/PublicUserData.yaml }
     Organization:                              { $ref: ./components/schemas/Organization.yaml }

--- a/paths/bapi/instance.yaml
+++ b/paths/bapi/instance.yaml
@@ -80,6 +80,12 @@ get:
                   retire_window_seconds: 604800
                 organizations:
                   enabled: false
+                multi_factor:
+                  totp:
+                    enabled: true
+                  backup_codes:
+                    enabled: true
+                    default_count: 10
                 audit_log_retention_days: 365
     "401": { $ref: ../../components/responses/Unauthorized.yaml }
 

--- a/paths/bapi/user-mfa.yaml
+++ b/paths/bapi/user-mfa.yaml
@@ -1,0 +1,31 @@
+parameters:
+  - name: user_id
+    in: path
+    required: true
+    schema: { $ref: "../../components/schemas/Id.yaml" }
+
+delete:
+  operationId: deleteUserMfa
+  summary: Reset a user's MFA (operator override)
+  description: |
+    Operator-driven MFA reset. Deletes the user's `TotpSecret` (if any)
+    plus every unconsumed `BackupCode`, flips
+    `User.totp_enabled` / `User.backup_code_enabled` /
+    `User.two_factor_enabled` to `false`, and stamps
+    `User.mfa_disabled_at`.
+
+    Used by support to recover a user who's lost access to their
+    authenticator and exhausted their backup codes. Idempotent —
+    calling on a user with no MFA enrolled returns the user unchanged.
+
+    Emits `auth.mfa.totp_removed` and `auth.mfa.backup_codes_removed`
+    audit-log events as appropriate, attributed to the operator.
+  tags: [Users]
+  responses:
+    "200":
+      description: The updated `User` after the reset.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/User.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }

--- a/paths/bapi/user-verify-totp.yaml
+++ b/paths/bapi/user-verify-totp.yaml
@@ -1,0 +1,62 @@
+parameters:
+  - name: user_id
+    in: path
+    required: true
+    schema: { $ref: "../../components/schemas/Id.yaml" }
+
+post:
+  operationId: verifyTotp
+  summary: Verify a user's TOTP code (operator override)
+  description: |
+    Server-side TOTP check against the user's enrolled `TotpSecret`.
+    Returns `200 { verified: true }` on a valid code (within the
+    `±1 step` window), `200 { verified: false }` otherwise. Subject to
+    the standard rate-limit bucket; repeated mismatches eventually
+    return `429`.
+
+    Used by support tooling and SDK callers that need to gate
+    sensitive server-side actions on a fresh second-factor proof
+    without forcing the user back through the FAPI sign-in flow.
+    Returns `404` if the user has no enrolled `TotpSecret` and `422`
+    (`error_code: mfa_not_enabled`) when the instance has
+    `multi_factor.totp.enabled: false`.
+
+    This call does **not** stamp `TotpSecret.verified_at` on its own —
+    it's a verification check, not an enrollment confirmation. The
+    enrollment confirmation path is the FAPI
+    `POST /v1/me/totp/verify` endpoint.
+  tags: [Users]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [code]
+          additionalProperties: false
+          properties:
+            code:
+              type: string
+              minLength: 6
+              maxLength: 8
+              description: 6-digit numeric TOTP from the user's authenticator app.
+        examples:
+          basic: { value: { code: "542178" } }
+  responses:
+    "200":
+      description: Verification result.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [verified]
+            additionalProperties: false
+            properties:
+              verified: { type: boolean }
+          examples:
+            ok:    { value: { verified: true } }
+            wrong: { value: { verified: false } }
+    "401": { $ref: "../../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../../components/responses/NotFound.yaml" }
+    "422": { $ref: "../../components/responses/UnprocessableEntity.yaml" }
+    "429": { $ref: "../../components/responses/TooManyRequests.yaml" }

--- a/paths/fapi/me-backup-codes.yaml
+++ b/paths/fapi/me-backup-codes.yaml
@@ -1,0 +1,64 @@
+post:
+  operationId: createMyBackupCodes
+  summary: (Re)generate backup codes
+  description: |
+    Mint a fresh batch of single-use recovery codes for the calling
+    user. Returns the full plaintext `codes[]` exactly once — the
+    server hashes each code (Argon2id) before storage and discards the
+    plaintext when the response is sent. The default batch size comes
+    from `InstanceSettings.multi_factor.backup_codes.default_count`
+    (defaults to `10`).
+
+    Re-issuing this endpoint **replaces** every prior code on the
+    user — old codes are deleted server-side before the new batch is
+    stored, so previously-shown codes stop working immediately. Flips
+    `User.backup_code_enabled` to `true` if it wasn't already; if
+    this is the user's first second factor,
+    `User.two_factor_enabled` and `User.mfa_enabled_at` are also set.
+
+    Refused with `422` (`error_code: mfa_not_enabled`) when the
+    instance has `multi_factor.backup_codes.enabled: false`.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: |
+        The freshly-minted `BackupCodeBatch` with plaintext codes,
+        wrapped in the standard FAPI envelope. The codes are returned
+        only here — subsequent reads of the user's MFA state never
+        re-surface them.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }
+    "429": { $ref: ../../components/responses/TooManyRequests.yaml }
+
+delete:
+  operationId: deleteMyBackupCodes
+  summary: Remove backup codes from my account
+  description: |
+    Delete every unused `BackupCode` on the calling user and flip
+    `User.backup_code_enabled` to `false`. Already-consumed codes
+    are left intact for audit-log purposes. If no other second factor
+    remains, also flips `User.two_factor_enabled` to `false` and
+    stamps `User.mfa_disabled_at`.
+
+    Returns `200` with an empty deleted batch even if the user had no
+    unused codes — the call is idempotent.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: |
+        Confirmation envelope; the embedded `client.user.backup_code_enabled`
+        is now `false`. The body's `response` is a `BackupCodeBatch`
+        with `count: 0` and `codes: []` for shape consistency.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }

--- a/paths/fapi/me-totp-verify.yaml
+++ b/paths/fapi/me-totp-verify.yaml
@@ -1,0 +1,52 @@
+post:
+  operationId: verifyMyTotp
+  summary: Verify TOTP enrollment with the first code
+  description: |
+    Confirm the calling user can produce a valid TOTP from the
+    plaintext secret returned by `POST /v1/me/totp`. Server checks
+    `code` against the stored secret with a `±1 step` (30s) tolerance
+    window. On success:
+
+    - `TotpSecret.verified_at` is stamped.
+    - `User.totp_enabled` flips to `true`.
+    - If this is the user's first second factor,
+      `User.two_factor_enabled` flips to `true` and
+      `User.mfa_enabled_at` is stamped.
+
+    Returns `422` with `error_code: incorrect_code` if the code
+    doesn't validate. Excessive failures roll into the standard
+    brute-force lockout. Returns `404` if the user hasn't started
+    enrollment via `POST /v1/me/totp`.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [code]
+          additionalProperties: false
+          properties:
+            code:
+              type: string
+              minLength: 6
+              maxLength: 8
+              description: 6-digit numeric TOTP from the user's authenticator app.
+        examples:
+          basic: { value: { code: "542178" } }
+  responses:
+    "200":
+      description: |
+        The now-verified `TotpSecret` (with `verified_at` set, `secret`
+        / `otpauth_uri` / `qr_code_data_url` cleared), wrapped — the
+        embedded `client.user.totp_enabled` is now `true`.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }
+    "429": { $ref: ../../components/responses/TooManyRequests.yaml }

--- a/paths/fapi/me-totp.yaml
+++ b/paths/fapi/me-totp.yaml
@@ -1,0 +1,65 @@
+post:
+  operationId: createMyTotp
+  summary: Start TOTP enrollment
+  description: |
+    Mint a fresh `TotpSecret` for the calling user and return the
+    plaintext shared secret + `otpauth://` URI + a server-rendered
+    QR-code data URL. The row starts with `verified_at: null` — the
+    user must answer with the first generated code via
+    `POST /v1/me/totp/verify` before the secret becomes a usable
+    second factor.
+
+    Idempotent re-enrollment: calling this endpoint while an
+    unverified `TotpSecret` already exists overwrites the row
+    (regenerates `secret`, `otpauth_uri`, `qr_code_data_url`). Calling
+    it while a verified `TotpSecret` exists returns `409` — disable the
+    existing secret with `DELETE /v1/me/totp` first, or re-enroll
+    through the dashboard's reset MFA flow.
+
+    The plaintext `secret` is **only** returned by this endpoint;
+    subsequent reads of the user's MFA state never re-surface it.
+    Refused with `422` (`error_code: mfa_not_enabled`) when the
+    instance has `multi_factor.totp.enabled: false`.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: |
+        The freshly-minted `TotpSecret` with `secret`, `otpauth_uri`,
+        and `qr_code_data_url` populated, wrapped in the standard FAPI
+        envelope (the embedded `client.user.totp_enabled` is still
+        `false` until verify lands).
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "409": { $ref: ../../components/responses/Conflict.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }
+    "429": { $ref: ../../components/responses/TooManyRequests.yaml }
+
+delete:
+  operationId: deleteMyTotp
+  summary: Remove TOTP from my account
+  description: |
+    Delete the calling user's `TotpSecret` and flip
+    `User.totp_enabled` back to `false`. If no other second factor
+    remains, also flips `User.two_factor_enabled` to `false` and
+    stamps `User.mfa_disabled_at`. Existing `BackupCode` rows are
+    left untouched — call `DELETE /v1/me/backup-codes` separately to
+    fully disable MFA from the Account Portal.
+
+    Returns `404` if the user has no enrolled `TotpSecret`.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: The deleted `TotpSecret`, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }

--- a/paths/fapi/sign-in-challenges.yaml
+++ b/paths/fapi/sign-in-challenges.yaml
@@ -29,6 +29,12 @@ post:
     body) and then poll `getSignInChallenge` until `status` flips to
     `verified` or `transferable`. See the cross-device polling note on
     `Challenge`.
+
+    For `totp` and `backup_code` (v0.3+), the parent must already be in
+    `needs_second_factor` and `supported_strategies` must list the
+    chosen strategy. The server stamps `step: "second"` on the
+    resulting `Challenge` and the body needs no extra fields beyond
+    `strategy`. Answer with `{ code: "…" }`.
   tags: [Sign-Ins]
   security:
     - client_cookie: []


### PR DESCRIPTION
## Summary

Ships the full v0.3 MFA OpenAPI surface — TOTP + backup-code resources, the FAPI enrollment + management endpoints, the BAPI admin overrides, the second-factor SignIn flow, and the per-env strategy gating. Five tightly-coupled commits, one per issue.

Closes #31, #32, #33, #34, #35.

## Commits

| # | Issue | Commit |
|---|---|---|
| OA-1 | #31 | `Add TotpSecret + BackupCode schemas and second-factor Challenge variants` |
| OA-2 | #32 | `Add FAPI /v1/me/totp + /v1/me/backup-codes endpoints` |
| OA-3 | #33 | `Add BAPI POST /v1/users/{user_id}/verify-totp + DELETE /v1/users/{user_id}/mfa` |
| OA-4 | #34 | `Document SignIn second-factor flow` |
| OA-5 | #35 | `Add InstanceSettings.multi_factor block + InstanceUpdateRequest patch` |

## New schemas

- `TotpSecret` (`totp_` prefix) — one per User, exposes `secret` / `otpauth_uri` / `qr_code_data_url` only on the enrollment response.
- `BackupCode` (`bcc_` prefix) — single-use, hashed at rest, surfaces only in audit + admin views.
- `BackupCodeBatch` — one-time plaintext reveal envelope returned by `POST /v1/me/backup-codes`.

## New operationIds

- FAPI: `createMyTotp`, `verifyMyTotp`, `deleteMyTotp`, `createMyBackupCodes`, `deleteMyBackupCodes`.
- BAPI: `verifyTotp`, `deleteUserMfa`.

## Schema changes worth flagging downstream

- `Challenge.strategy` enum gains `totp` and `backup_code`. `step: "second"` becomes a real, documented value (was reserved). `ChallengeAnswerRequest` documents the `{ code: "abcd-efgh" }` shape for backup codes — same `code` field as `email_code`, no new payload field.
- `ChallengeCreateRequest` — second-factor variants (`{ strategy: "totp" }`, `{ strategy: "backup_code" }`) need no extra fields; `nonce` stays `null`, the SDK proceeds straight to `answer`.
- `SignIn.supported_strategies` now narrows to `[totp]`, `[backup_code]`, or `[totp, backup_code]` for `needs_second_factor`. Empty when MFA was disabled mid-flow.
- TOTP enrollment verification is **not** modelled as a Challenge — it's a direct `POST /v1/me/totp/verify` call against the enrolling user, not a sub-resource on a parent flow. Avoids overloading the Challenge sub-resource for self-service enrollment.
- `BackupCodeBatch` is the answer to "where do the plaintext codes live in the schema graph" — separate from `BackupCode` (which is the at-rest hashed row) so SDKs can type the one-time reveal cleanly.
- `InstanceSettings.multi_factor` is a new top-level required field. Toggling either strategy `enabled: false` keeps existing enrollment rows but drops the strategy from `supported_strategies` — downstream needs to honour this when implementing the SignIn state machine.
- URL paths follow kebab-case (`/v1/me/backup-codes`, `/v1/users/{user_id}/verify-totp`); path parameter names stay snake_case.

## Test plan

- [x] `npm run lint` clean for both bapi + fapi.
- [x] `npm run bundle` produces clean `dist/{bapi,fapi}.bundled.{yaml,json}`.
- [ ] CI green.