### PR TITLE
Add OauthProvider + OauthProviderRequest schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
 
 ### Added
 
+- **Social sign-in surface (v0.4) — schemas**.
+  - `OauthProvider` (`oauthp_` prefix) — per-environment social-IdP configuration with three kinds in a single shape: `preset` (bundled `google` / `github` / `apple` / `microsoft`), `custom_oidc` (workspace-registered OIDC IdP, populated by `/.well-known/openid-configuration` discovery), `custom_oauth2` (plain OAuth 2.0 IdP, operator supplies authorize / token / userinfo URLs and `userinfo_method` + `userinfo_auth`). Computed read-only `redirect_uri = https://<env_slug>.authn.sh/v1/oauth-callback/<provider_key>`. Per-provider `attribute_mapping` (`User` / `ExternalAccount` field → IdP claim or userinfo path). Per-provider `block_email_subaddresses` and `allow_sign_in` / `allow_sign_up` toggles.
+  - `OauthProviderRequest` — POST/PATCH body. `client_secret` is write-only (encrypted at rest, never returned). `provider_kind` and `provider_key` are immutable on PATCH.
+  - `Challenge.strategy` documents `oauth_<provider_key>` as a first-factor value; the IdP authorize URL is surfaced via `external_verification_redirect_url`.
+
 - **Multi-factor authentication surface (v0.3)**.
   - `TotpSecret` (one per `User`, `totp_` prefix) and `BackupCode` (`bcc_` prefix) resource schemas, plus `BackupCodeBatch` envelope for the one-time plaintext reveal.
   - `Challenge.strategy` enum gains `totp` and `backup_code`. `ChallengeCreateRequest` documents the second-factor variants (no extra fields needed beyond `strategy`); `ChallengeAnswerRequest` documents the `{ code }` answer shape for both.

--- a/bapi.yaml
+++ b/bapi.yaml
@@ -242,6 +242,8 @@ components:
     RoleCreateRequest:                         { $ref: ./components/schemas/RoleCreateRequest.yaml }
     RoleUpdateRequest:                         { $ref: ./components/schemas/RoleUpdateRequest.yaml }
     RolePermissionsRequest:                    { $ref: ./components/schemas/RolePermissionsRequest.yaml }
+    OauthProvider:                             { $ref: ./components/schemas/OauthProvider.yaml }
+    OauthProviderRequest:                      { $ref: ./components/schemas/OauthProviderRequest.yaml }
 
   responses:
     BadRequest:           { $ref: ./components/responses/BadRequest.yaml }

--- a/components/schemas/Challenge.yaml
+++ b/components/schemas/Challenge.yaml
@@ -170,11 +170,19 @@ properties:
   strategy:
     type: string
     description: |
-      How this challenge is being completed. v0.3 surface:
+      How this challenge is being completed.
 
       - `password`, `email_code`, `email_link`,
         `reset_password_email_code`, `ticket`, `transfer` — sign-in /
         sign-up first factor.
+      - `oauth_<provider_key>` — first-factor social sign-in / sign-up.
+        `<provider_key>` matches a row in the environment's
+        `OauthProvider` registry (`google`, `github`, `apple`,
+        `microsoft`, or any workspace-registered `custom_oidc` /
+        `custom_oauth2` slug). The challenge surfaces the IdP's
+        authorize URL on `external_verification_redirect_url`; the SDK
+        redirects the browser there and resumes via
+        `/v1/oauth-callback/<provider_key>`.
       - `totp`, `backup_code` — sign-in second factor (`step: "second"`
         only). Answer with `{ code: "123456" }` for `totp` (numeric,
         6 digits, `±1 step` tolerance) or `{ code: "abcd-efgh" }` for
@@ -184,8 +192,7 @@ properties:
       - `domain_dns_txt`, `email_code` — organization-domain
         verification.
 
-      Future strategies (SMS, OAuth, passkey) plug in here without
-      spec changes.
+      Future strategies (passkey) plug in here without spec changes.
     examples:
       - password
       - email_code

--- a/components/schemas/OauthProvider.yaml
+++ b/components/schemas/OauthProvider.yaml
@@ -1,0 +1,348 @@
+type: object
+description: |
+  Per-environment social-IdP configuration. The SDK reads `OauthProvider`
+  rows to render `<SocialButtons />`; the server reads them to drive the
+  `oauth_<provider_key>` first-factor `Challenge` strategy. Three kinds
+  share a single shape:
+
+  - `preset` — bundled IdPs the platform ships with (`google`, `github`,
+    `apple`, `microsoft`). The OIDC discovery fields and default scope
+    set are filled in by the platform on create; the operator only
+    supplies `client_id`, `client_secret`, and any toggles
+    (`enabled`, `allow_sign_in`, …).
+  - `custom_oidc` — workspace-registered OpenID Connect IdP. The
+    operator supplies an `issuer` URL; the server fetches and caches
+    `<issuer>/.well-known/openid-configuration` and populates the OIDC
+    endpoint fields automatically. `discovery_endpoint`,
+    `authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`,
+    `jwks_uri`, `id_token_signing_algs[]` are read-only when populated
+    by discovery, but admin-overridable for self-host edge cases where
+    discovery is unreachable.
+  - `custom_oauth2` — workspace-registered plain OAuth 2.0 IdP without
+    OIDC. The operator supplies `authorization_endpoint`,
+    `token_endpoint`, and `userinfo_endpoint` directly, plus
+    `userinfo_method` (`GET` / `POST`) and `userinfo_auth` (`bearer` /
+    `basic` / `query`) so the server knows how to call the userinfo
+    endpoint.
+
+  ### Secret handling
+
+  `client_secret` is **write-only**. It's accepted on
+  `POST /v1/oauth-providers` and `PATCH /v1/oauth-providers/{id}` (see
+  `OauthProviderRequest`), encrypted at rest, and never returned in any
+  response. The public payload exposes `client_id` only.
+
+  ### Computed redirect_uri
+
+  `redirect_uri` is computed server-side as
+  `https://<env_slug>.authn.sh/v1/oauth-callback/<provider_key>` and is
+  read-only. It's the value the operator must register with the IdP.
+
+  ### attribute_mapping
+
+  Map of authn.sh `User` / `ExternalAccount` fields to IdP claim or
+  userinfo paths. Presets ship with sensible defaults
+  (`email_address` → `email`, `first_name` → `given_name`,
+  `last_name` → `family_name`, …); operators can override per row to
+  match a non-standard IdP.
+
+  ### Identifier
+
+  ID prefix `oauthp_` (e.g. `oauthp_01HKX9SY9V7H7TF8C8K7J9X4ZA`).
+required:
+  - id
+  - object
+  - provider_kind
+  - provider_key
+  - name
+  - enabled
+  - allow_sign_in
+  - allow_sign_up
+  - block_email_subaddresses
+  - client_id
+  - scopes
+  - additional_authorization_params
+  - attribute_mapping
+  - redirect_uri
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: oauth_provider
+  provider_kind:
+    type: string
+    enum: [preset, custom_oidc, custom_oauth2]
+    description: |
+      Discriminates which subset of fields applies. Immutable after
+      create.
+  provider_key:
+    type: string
+    pattern: "^[a-z][a-z0-9_]*$"
+    maxLength: 64
+    description: |
+      Stable slug used in the `oauth_<provider_key>` `Challenge.strategy`
+      and in the computed `redirect_uri`. For `provider_kind: "preset"`
+      this is one of the bundled values (`google`, `github`, `apple`,
+      `microsoft`). For `custom_oidc` / `custom_oauth2` it's a
+      workspace-chosen slug, unique per environment.
+    examples:
+      - google
+      - github
+      - apple
+      - microsoft
+      - acme_corp_sso
+  name:
+    type: string
+    maxLength: 100
+    description: Human-readable label rendered in `<SocialButtons />`.
+  enabled:
+    type: boolean
+    description: |
+      When `false`, the provider is hidden from the SDK and the
+      `oauth_<provider_key>` strategy is rejected by the FAPI. The row
+      survives the toggle so existing `ExternalAccount` links remain
+      valid.
+  allow_sign_in:
+    type: boolean
+    description: |
+      When `true`, an unsigned-in user can authenticate with this
+      provider via the `oauth_<provider_key>` strategy on a `SignIn`.
+  allow_sign_up:
+    type: boolean
+    description: |
+      When `true`, a first-time visitor can complete a `SignUp` via
+      this provider. With `allow_sign_in: true` and `allow_sign_up: false`
+      the provider is sign-in-only — the callback rejects unknown
+      identifiers instead of creating a `User`.
+  block_email_subaddresses:
+    type: boolean
+    description: |
+      When `true`, addresses with a `+tag` segment returned by the IdP
+      are refused at sign-up under this provider. Mirrors the
+      instance-level `restrictions.block_email_subaddresses` knob but
+      scoped per-provider.
+  client_id:
+    type: string
+    maxLength: 255
+    description: |
+      OAuth 2.0 client identifier issued by the IdP. Public — sent on
+      every `/authorize` redirect.
+  scopes:
+    type: array
+    items:
+      type: string
+    description: |
+      Scope set requested on the `/authorize` redirect. Presets ship
+      with a sensible default (`openid email profile` for OIDC presets;
+      `read:user user:email` for GitHub; etc.); operators can add
+      provider-specific scopes here without spec changes.
+    examples:
+      - ["openid", "email", "profile"]
+  additional_authorization_params:
+    type: object
+    description: |
+      Free-form `key=value` pairs merged into the `/authorize` query
+      string after the standard params (`client_id`, `redirect_uri`,
+      `scope`, `state`, …). Useful for IdP-specific knobs like Google's
+      `prompt=select_account` or Microsoft's `tenant=common`.
+    additionalProperties:
+      type: string
+  attribute_mapping:
+    type: object
+    description: |
+      Map of authn.sh field names (keys) to IdP claim or userinfo paths
+      (values). Keys are the standard `User` / `ExternalAccount` field
+      names: `email_address`, `first_name`, `last_name`,
+      `profile_image_url`, `provider_user_id`. Values are dot-separated
+      JSON paths into the OIDC ID token claims (or userinfo body for
+      OAuth 2.0).
+    additionalProperties:
+      type: string
+    examples:
+      - email_address: email
+        first_name: given_name
+        last_name: family_name
+        profile_image_url: picture
+        provider_user_id: sub
+  redirect_uri:
+    type: string
+    format: uri
+    readOnly: true
+    description: |
+      Server-computed callback URL the IdP must redirect to after the
+      authorization code grant. Format:
+      `https://<env_slug>.authn.sh/v1/oauth-callback/<provider_key>`.
+      Operators register this exact value with the IdP's developer
+      console.
+    examples:
+      - https://acme.authn.sh/v1/oauth-callback/google
+  issuer:
+    type: [string, "null"]
+    format: uri
+    description: |
+      OIDC issuer URL. Required for `provider_kind: "custom_oidc"` (the
+      server fetches `<issuer>/.well-known/openid-configuration` from
+      this base). Set by the platform for `preset` rows. `null` for
+      `custom_oauth2`.
+  discovery_endpoint:
+    type: [string, "null"]
+    format: uri
+    description: |
+      Resolved OIDC discovery document URL. Populated by the server
+      from `issuer` for `preset` and `custom_oidc` rows; admin-
+      overridable for self-host edge cases where the standard
+      `/.well-known/openid-configuration` path is wrong. `null` for
+      `custom_oauth2`.
+  authorization_endpoint:
+    type: [string, "null"]
+    format: uri
+    description: |
+      `/authorize` URL. Populated by discovery for `preset` /
+      `custom_oidc`; supplied directly by the operator for
+      `custom_oauth2`.
+  token_endpoint:
+    type: [string, "null"]
+    format: uri
+    description: |
+      Token exchange URL. Populated by discovery for `preset` /
+      `custom_oidc`; supplied directly by the operator for
+      `custom_oauth2`.
+  userinfo_endpoint:
+    type: [string, "null"]
+    format: uri
+    description: |
+      Userinfo URL. Populated by discovery for `preset` /
+      `custom_oidc`; supplied directly by the operator for
+      `custom_oauth2`. `null` is allowed for OIDC providers that ship
+      every required claim in the ID token (the server falls back to
+      ID-token claims when this is `null`).
+  jwks_uri:
+    type: [string, "null"]
+    format: uri
+    description: |
+      JWKS URL used to verify the OIDC ID token signature. Populated
+      by discovery for `preset` / `custom_oidc`; admin-overridable.
+      `null` for `custom_oauth2`.
+  id_token_signing_algs:
+    type: array
+    items:
+      type: string
+    description: |
+      Algorithms the IdP advertises for ID token signing (e.g. `RS256`,
+      `ES256`). Populated by discovery for `preset` / `custom_oidc`;
+      empty for `custom_oauth2`.
+    examples:
+      - ["RS256"]
+  userinfo_method:
+    type: [string, "null"]
+    enum: [GET, POST, null]
+    description: |
+      HTTP method used to call `userinfo_endpoint`. Required for
+      `provider_kind: "custom_oauth2"`; `null` for OIDC kinds (those
+      always use `GET` per the OIDC core spec).
+  userinfo_auth:
+    type: [string, "null"]
+    enum: [bearer, basic, query, null]
+    description: |
+      How the access token is presented when calling
+      `userinfo_endpoint`. `bearer` — `Authorization: Bearer <token>`
+      header. `basic` — HTTP Basic with the access token as the
+      username. `query` — `?access_token=<token>` query string.
+      Required for `provider_kind: "custom_oauth2"`; `null` for OIDC
+      kinds (those always use `bearer`).
+  created_at:
+    $ref: ./Timestamp.yaml
+  updated_at:
+    $ref: ./Timestamp.yaml
+examples:
+  - id: oauthp_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    object: oauth_provider
+    provider_kind: preset
+    provider_key: google
+    name: Google
+    enabled: true
+    allow_sign_in: true
+    allow_sign_up: true
+    block_email_subaddresses: false
+    client_id: 123456789012-abc.apps.googleusercontent.com
+    scopes: [openid, email, profile]
+    additional_authorization_params:
+      prompt: select_account
+    attribute_mapping:
+      email_address: email
+      first_name: given_name
+      last_name: family_name
+      profile_image_url: picture
+      provider_user_id: sub
+    redirect_uri: https://acme.authn.sh/v1/oauth-callback/google
+    issuer: https://accounts.google.com
+    discovery_endpoint: https://accounts.google.com/.well-known/openid-configuration
+    authorization_endpoint: https://accounts.google.com/o/oauth2/v2/auth
+    token_endpoint: https://oauth2.googleapis.com/token
+    userinfo_endpoint: https://openidconnect.googleapis.com/v1/userinfo
+    jwks_uri: https://www.googleapis.com/oauth2/v3/certs
+    id_token_signing_algs: [RS256]
+    userinfo_method: null
+    userinfo_auth: null
+    created_at: 1714723000000
+    updated_at: 1714723000000
+  - id: oauthp_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    object: oauth_provider
+    provider_kind: custom_oidc
+    provider_key: acme_corp_sso
+    name: Acme Corp SSO
+    enabled: true
+    allow_sign_in: true
+    allow_sign_up: false
+    block_email_subaddresses: true
+    client_id: acme-authn-prod
+    scopes: [openid, email, profile, groups]
+    additional_authorization_params: {}
+    attribute_mapping:
+      email_address: email
+      first_name: given_name
+      last_name: family_name
+      provider_user_id: sub
+    redirect_uri: https://acme.authn.sh/v1/oauth-callback/acme_corp_sso
+    issuer: https://sso.acme.example
+    discovery_endpoint: https://sso.acme.example/.well-known/openid-configuration
+    authorization_endpoint: https://sso.acme.example/authorize
+    token_endpoint: https://sso.acme.example/token
+    userinfo_endpoint: https://sso.acme.example/userinfo
+    jwks_uri: https://sso.acme.example/jwks
+    id_token_signing_algs: [RS256, ES256]
+    userinfo_method: null
+    userinfo_auth: null
+    created_at: 1714723000000
+    updated_at: 1714723000000
+  - id: oauthp_01HKX9SY9V7H7TF8C8K7J9X4ZC
+    object: oauth_provider
+    provider_kind: custom_oauth2
+    provider_key: legacy_idp
+    name: Legacy IdP
+    enabled: true
+    allow_sign_in: true
+    allow_sign_up: true
+    block_email_subaddresses: false
+    client_id: legacy-client
+    scopes: [read_profile, read_email]
+    additional_authorization_params: {}
+    attribute_mapping:
+      email_address: email
+      provider_user_id: id
+    redirect_uri: https://acme.authn.sh/v1/oauth-callback/legacy_idp
+    issuer: null
+    discovery_endpoint: null
+    authorization_endpoint: https://idp.legacy.example/oauth/authorize
+    token_endpoint: https://idp.legacy.example/oauth/token
+    userinfo_endpoint: https://idp.legacy.example/api/me
+    jwks_uri: null
+    id_token_signing_algs: []
+    userinfo_method: GET
+    userinfo_auth: bearer
+    created_at: 1714723000000
+    updated_at: 1714723000000

--- a/components/schemas/OauthProviderRequest.yaml
+++ b/components/schemas/OauthProviderRequest.yaml
@@ -1,0 +1,169 @@
+type: object
+description: |
+  Request body for `POST /v1/oauth-providers` and
+  `PATCH /v1/oauth-providers/{id}`. Mirrors `OauthProvider` minus the
+  server-computed fields (`id`, `object`, `redirect_uri`, `created_at`,
+  `updated_at`) and adds the write-only `client_secret`.
+
+  ### POST vs PATCH
+
+  - On `POST`, `provider_kind`, `provider_key`, `name`, and `client_id`
+    are required. For `provider_kind: "custom_oidc"` the operator must
+    also supply `issuer`. For `provider_kind: "custom_oauth2"` the
+    operator must supply `authorization_endpoint`, `token_endpoint`,
+    `userinfo_endpoint`, `userinfo_method`, and `userinfo_auth`.
+    `client_secret` is required on `POST` for every kind except where
+    the IdP does not issue one (rare; PKCE-only flows).
+  - On `PATCH`, every field is optional and only the keys present in
+    the body are updated. `provider_kind` and `provider_key` are
+    immutable — sending a different value returns `422`.
+
+  ### client_secret
+
+  Write-only string. Accepted on POST/PATCH, encrypted at rest, and
+  never returned in any response. Sending an empty string or omitting
+  the key on PATCH leaves the stored value unchanged. Sending `null`
+  on PATCH clears the stored secret (e.g. when migrating to a PKCE-
+  only flow).
+additionalProperties: false
+properties:
+  provider_kind:
+    type: string
+    enum: [preset, custom_oidc, custom_oauth2]
+    description: |
+      Required on `POST`; immutable on `PATCH`. Discriminates which
+      subset of fields applies on this row.
+  provider_key:
+    type: string
+    pattern: "^[a-z][a-z0-9_]*$"
+    maxLength: 64
+    description: |
+      Required on `POST`; immutable on `PATCH`. For `preset` rows must
+      be one of `google` / `github` / `apple` / `microsoft`.
+  name:
+    type: string
+    maxLength: 100
+  enabled:
+    type: boolean
+    default: true
+  allow_sign_in:
+    type: boolean
+    default: true
+  allow_sign_up:
+    type: boolean
+    default: true
+  block_email_subaddresses:
+    type: boolean
+    default: false
+  client_id:
+    type: string
+    maxLength: 255
+  client_secret:
+    type: [string, "null"]
+    writeOnly: true
+    maxLength: 1024
+    description: |
+      Write-only. Encrypted at rest; never returned by any GET.
+      Omit on PATCH to leave the stored value untouched; send `null`
+      to clear it.
+  scopes:
+    type: array
+    items:
+      type: string
+    description: |
+      Overrides the preset-default scope set when supplied. Omit on
+      `POST` for `preset` rows to use the platform-default scopes.
+  additional_authorization_params:
+    type: object
+    additionalProperties:
+      type: string
+  attribute_mapping:
+    type: object
+    additionalProperties:
+      type: string
+  issuer:
+    type: [string, "null"]
+    format: uri
+    description: |
+      Required on `POST` for `provider_kind: "custom_oidc"`. The server
+      runs OIDC discovery from this base and populates the endpoint
+      fields. Ignored for `custom_oauth2`.
+  discovery_endpoint:
+    type: [string, "null"]
+    format: uri
+    description: |
+      Optional override for `<issuer>/.well-known/openid-configuration`.
+      Only used by `preset` / `custom_oidc` rows that need a non-
+      standard discovery URL.
+  authorization_endpoint:
+    type: [string, "null"]
+    format: uri
+    description: |
+      Required on `POST` for `provider_kind: "custom_oauth2"`. Admin
+      override for OIDC kinds when discovery cannot reach the IdP.
+  token_endpoint:
+    type: [string, "null"]
+    format: uri
+    description: |
+      Required on `POST` for `provider_kind: "custom_oauth2"`. Admin
+      override for OIDC kinds.
+  userinfo_endpoint:
+    type: [string, "null"]
+    format: uri
+    description: |
+      Required on `POST` for `provider_kind: "custom_oauth2"`. Optional
+      for OIDC kinds that ship every required claim in the ID token.
+  jwks_uri:
+    type: [string, "null"]
+    format: uri
+  id_token_signing_algs:
+    type: array
+    items:
+      type: string
+  userinfo_method:
+    type: [string, "null"]
+    enum: [GET, POST, null]
+    description: |
+      Required on `POST` for `provider_kind: "custom_oauth2"`. `null`
+      for OIDC kinds.
+  userinfo_auth:
+    type: [string, "null"]
+    enum: [bearer, basic, query, null]
+    description: |
+      Required on `POST` for `provider_kind: "custom_oauth2"`. `null`
+      for OIDC kinds.
+examples:
+  - provider_kind: preset
+    provider_key: google
+    name: Google
+    enabled: true
+    allow_sign_in: true
+    allow_sign_up: true
+    block_email_subaddresses: false
+    client_id: 123456789012-abc.apps.googleusercontent.com
+    client_secret: GOCSPX-xxxxxxxxxxxxxxxxxxxxxxxxx
+    additional_authorization_params:
+      prompt: select_account
+  - provider_kind: custom_oidc
+    provider_key: acme_corp_sso
+    name: Acme Corp SSO
+    client_id: acme-authn-prod
+    client_secret: shhhh
+    issuer: https://sso.acme.example
+    scopes: [openid, email, profile, groups]
+    allow_sign_up: false
+    block_email_subaddresses: true
+  - provider_kind: custom_oauth2
+    provider_key: legacy_idp
+    name: Legacy IdP
+    client_id: legacy-client
+    client_secret: legacy-secret
+    authorization_endpoint: https://idp.legacy.example/oauth/authorize
+    token_endpoint: https://idp.legacy.example/oauth/token
+    userinfo_endpoint: https://idp.legacy.example/api/me
+    userinfo_method: GET
+    userinfo_auth: bearer
+    scopes: [read_profile, read_email]
+    attribute_mapping:
+      email_address: email
+      provider_user_id: id


### PR DESCRIPTION
## Summary

- New `OauthProvider` schema covering all three `provider_kind`s in a single shape: `preset` (bundled `google` / `github` / `apple` / `microsoft`), `custom_oidc` (workspace IdP populated by OIDC discovery), `custom_oauth2` (operator-supplied authorize / token / userinfo URLs plus `userinfo_method` + `userinfo_auth`). ID prefix `oauthp_`. `redirect_uri` is server-computed and read-only.
- New `OauthProviderRequest` body for POST/PATCH. `client_secret` is write-only — encrypted at rest, never returned. `provider_kind` and `provider_key` are immutable on PATCH.
- `Challenge.strategy` now documents `oauth_<provider_key>` as a first-factor value (was a "future" placeholder).
- CHANGELOG `[Unreleased]` gets a v0.4 social-sign-in entry.

Both schemas are registered in `bapi.yaml`'s `components.schemas` map. The path file that consumes them lands in OA-4.

Closes #39

## Test plan

- [x] `npm run lint` clean (BAPI + FAPI).
- [x] `npm run bundle` produces `dist/bapi.bundled.json` containing `OauthProvider` and `OauthProviderRequest` schemas.
- [x] `npm run stats:bapi` succeeds.
- [x] Bundled `Challenge.strategy.description` mentions `oauth_<provider_key>`.