### PR TITLE
Add PhoneNumber resource schema (phn_ prefix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
   - `InstanceSettings.multi_factor` gains a required `phone_code: { enabled }` block (default `false` — opt-in due to SMS cost + SIM-swap risk). `InstanceUpdateRequest.multi_factor` accepts the matching patch.
   - `Environment.auth_config.identifier_requirements.{email_address, phone_number, username}` enums shift from `[required, used_for_first_factor, off]` to `[required, optional, off]` for the v0.4 SDK vocabulary. `first_factors[]` / `second_factors[]` descriptions document the per-env narrowing rules.
 
+- **Phone-number identifier surface (v0.4) — schemas**.
+  - `PhoneNumber` (`phn_` prefix) — flat shape with `verified` + `current_challenge_id` (mirrors `EmailAddress` post-v0.2). Carries `is_primary`, `reserved_for_second_factor`, `default_second_factor`, and `linked_to_external_account_id` for SMS-MFA + external-account integrations.
+  - `PhoneNumberCreateRequest` — `{ phone_number }` body. Server normalises to E.164.
+  - `PhoneNumberUpdateRequest` — `{ is_primary?, reserved_for_second_factor?, default_second_factor? }` patch body. The phone-number value itself is immutable (re-add a new row to change).
+  - `User.phone_numbers` resolves to a real `PhoneNumber` array (was a `[]`-only placeholder); `User.primary_phone_number_id` description tightened (no longer "always `null` in v0.1").
+
 - **Social sign-in surface (v0.4) — schemas**.
   - `OauthProvider` (`oauthp_` prefix) — per-environment social-IdP configuration with three kinds in a single shape: `preset` (bundled `google` / `github` / `apple` / `microsoft`), `custom_oidc` (workspace-registered OIDC IdP, populated by `/.well-known/openid-configuration` discovery), `custom_oauth2` (plain OAuth 2.0 IdP, operator supplies authorize / token / userinfo URLs and `userinfo_method` + `userinfo_auth`). Computed read-only `redirect_uri = https://<env_slug>.authn.sh/v1/oauth-callback/<provider_key>`. Per-provider `attribute_mapping` (`User` / `ExternalAccount` field → IdP claim or userinfo path). Per-provider `block_email_subaddresses` and `allow_sign_in` / `allow_sign_up` toggles.
   - `OauthProviderRequest` — POST/PATCH body. `client_secret` is write-only (encrypted at rest, never returned). `provider_kind` and `provider_key` are immutable on PATCH.

--- a/bapi.yaml
+++ b/bapi.yaml
@@ -208,6 +208,7 @@ components:
     BackupCode:                                { $ref: ./components/schemas/BackupCode.yaml }
     BackupCodeBatch:                           { $ref: ./components/schemas/BackupCodeBatch.yaml }
     EmailAddress:                              { $ref: ./components/schemas/EmailAddress.yaml }
+    PhoneNumber:                               { $ref: ./components/schemas/PhoneNumber.yaml }
     User:                                      { $ref: ./components/schemas/User.yaml }
     UserCreateRequest:                         { $ref: ./components/schemas/UserCreateRequest.yaml }
     UserUpdateRequest:                         { $ref: ./components/schemas/UserUpdateRequest.yaml }

--- a/components/schemas/PhoneNumber.yaml
+++ b/components/schemas/PhoneNumber.yaml
@@ -1,0 +1,155 @@
+type: object
+description: |
+  A phone identifier owned by a `User`. A user may have many phone
+  numbers; exactly one is the primary (referenced by
+  `User.primary_phone_number_id`). A new number starts unverified and
+  becomes a usable identifier once `verified` flips to `true` —
+  typically by issuing and answering a `phone_code` `Challenge`
+  against `/v1/me/phone-numbers/{id}/challenges`.
+
+  ### Shape parity with `EmailAddress`
+
+  Mirrors the v0.2 `EmailAddress` resource: flat `verified: bool` plus
+  `current_challenge_id: ?Id` rather than a nested `verification`
+  blob (the standalone `Verification` schema was removed in v0.2).
+
+  ### Phone-number value
+
+  `phone_number` is stored in **E.164** form — a leading `+`, the
+  country-code digits, and the subscriber digits with no separators
+  (e.g. `+15555550100`). The server normalises submitted values; the
+  request body for `POST /v1/me/phone-numbers` accepts any input the
+  underlying parser can normalise but the stored value is always
+  E.164.
+
+  ### Second-factor flags
+
+  - `reserved_for_second_factor` — when `true`, this phone is committed
+    to MFA and cannot be unlinked without first nuking the user's MFA
+    state. The FAPI returns `409` on `DELETE /v1/me/phone-numbers/{id}`
+    while this flag is set.
+  - `default_second_factor` — when `true`, the SDK's default second-
+    factor picker prefers `phone_code` against this phone over `totp`
+    on `needs_second_factor`. At most one phone per user can carry
+    this flag (the server enforces uniqueness).
+
+  ### Identifier
+
+  ID prefix `phn_` (e.g. `phn_01HKX9SY9V7H7TF8C8K7J9X4ZA`).
+required:
+  - id
+  - object
+  - phone_number
+  - verified
+  - current_challenge_id
+  - is_primary
+  - reserved_for_second_factor
+  - default_second_factor
+  - linked_to_external_account_id
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: "./Id.yaml"
+  object:
+    type: string
+    const: phone_number
+  phone_number:
+    type: string
+    pattern: "^\\+[1-9][0-9]{1,14}$"
+    maxLength: 16
+    description: |
+      The number itself in E.164 form: leading `+`, country-code
+      digits, subscriber digits with no separators.
+    examples:
+      - "+15555550100"
+      - "+5511999990001"
+  verified:
+    type: boolean
+    description: |
+      `true` once a `phone_code` Challenge against this number has
+      reached `status: verified`, or the number was minted verified
+      via BAPI with `verified: true`.
+  current_challenge_id:
+    description: |
+      Pointer to the live `Challenge` if a `phone_code` verification
+      is in flight against this number. `null` when no challenge has
+      been issued yet, the previous one was answered to a terminal
+      status, or the number was created already verified.
+    oneOf:
+      - $ref: "./Id.yaml"
+      - type: "null"
+  is_primary:
+    type: boolean
+    description: |
+      `true` when this row is the user's primary phone — i.e.
+      `User.primary_phone_number_id == id`. Convenience flag; the
+      pointer on `User` is the source of truth.
+  reserved_for_second_factor:
+    type: boolean
+    description: |
+      `true` when this phone is committed to second-factor MFA.
+      `DELETE /v1/me/phone-numbers/{id}` is refused (`409`) while this
+      flag is set — the user must first disable phone-MFA via
+      `PATCH` (clearing `reserved_for_second_factor`) or via the
+      operator-driven `DELETE /v1/users/{id}/mfa`.
+  default_second_factor:
+    type: boolean
+    description: |
+      `true` when this phone is the user's default second factor.
+      At most one phone per user carries this flag. The SDK uses it
+      to pre-select `phone_code` over `totp` on
+      `needs_second_factor` when both are available.
+  linked_to_external_account_id:
+    description: |
+      Pointer to the `ExternalAccount` that surfaced this number, if
+      any. `null` for numbers added directly by the user via
+      `POST /v1/me/phone-numbers`.
+    oneOf:
+      - $ref: "./Id.yaml"
+      - type: "null"
+  reserved:
+    type: boolean
+    default: false
+    description: |
+      `true` when the number is held by an `AllowlistIdentifier` /
+      `Invitation` and is not yet attached to a user account.
+  created_at:
+    $ref: "./Timestamp.yaml"
+  updated_at:
+    $ref: "./Timestamp.yaml"
+examples:
+  - id: phn_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    object: phone_number
+    phone_number: "+15555550100"
+    verified: true
+    current_challenge_id: null
+    is_primary: true
+    reserved_for_second_factor: false
+    default_second_factor: false
+    linked_to_external_account_id: null
+    created_at: 1714723000000
+    updated_at: 1714723000000
+  - id: phn_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    object: phone_number
+    phone_number: "+15555550101"
+    verified: false
+    current_challenge_id: chal_01HKX9SY9V7H7TF8C8K7J9X4ZE
+    is_primary: false
+    reserved_for_second_factor: false
+    default_second_factor: false
+    linked_to_external_account_id: null
+    created_at: 1714723000000
+    updated_at: 1714723000000
+  - id: phn_01HKX9SY9V7H7TF8C8K7J9X4ZC
+    object: phone_number
+    phone_number: "+15555550102"
+    verified: true
+    current_challenge_id: null
+    is_primary: false
+    reserved_for_second_factor: true
+    default_second_factor: true
+    linked_to_external_account_id: null
+    created_at: 1714723000000
+    updated_at: 1714723000000

--- a/components/schemas/PhoneNumberCreateRequest.yaml
+++ b/components/schemas/PhoneNumberCreateRequest.yaml
@@ -1,0 +1,23 @@
+type: object
+description: |
+  Body for `POST /v1/me/phone-numbers`. Mirrors `EmailAddressCreateRequest`
+  in shape — only the raw value is supplied; the server normalises
+  to E.164, mints the row in `verified: false`, and the SDK then
+  issues a `phone_code` `Challenge` against it.
+
+  Operators can also create rows admin-side via BAPI (covered by
+  `SP-2` / a future BAPI path); that body adds `user_id`, `verified`,
+  and `primary` knobs analogous to `EmailAddressCreateRequest`.
+required: [phone_number]
+additionalProperties: false
+properties:
+  phone_number:
+    type: string
+    maxLength: 32
+    description: |
+      Submitted phone number. Accepts any input the server-side parser
+      can normalise to E.164 (leading `+`, country-code digits,
+      subscriber digits). The stored value is always E.164.
+    examples:
+      - "+15555550100"
+      - "+55 11 99999-0100"

--- a/components/schemas/PhoneNumberUpdateRequest.yaml
+++ b/components/schemas/PhoneNumberUpdateRequest.yaml
@@ -1,0 +1,40 @@
+type: object
+description: |
+  Body for `PATCH /v1/me/phone-numbers/{id}`. Only the supplied keys
+  are updated. The phone-number value itself is **not** patchable —
+  to change a number, add a new row and remove the old one (mirrors
+  `EmailAddress`).
+
+  ### Flag interactions
+
+  - Setting `is_primary: true` flips this row to the user's primary
+    phone (and clears `is_primary` on every other row). Setting
+    `is_primary: false` is rejected when this row is the only
+    verified primary candidate.
+  - Setting `reserved_for_second_factor: false` while
+    `default_second_factor` is `true` also clears
+    `default_second_factor` (a phone can only be the default second
+    factor while reserved for MFA).
+  - Setting `default_second_factor: true` requires
+    `reserved_for_second_factor: true` (either already set, or set in
+    the same patch); the server returns `422` otherwise. Only one
+    phone per user can carry `default_second_factor: true` — flipping
+    the flag on a new row clears it on every other row.
+additionalProperties: false
+properties:
+  is_primary:
+    type: boolean
+    description: |
+      When `true`, make this row the user's primary phone. The number
+      must be `verified: true`.
+  reserved_for_second_factor:
+    type: boolean
+    description: |
+      When `true`, commit this phone to second-factor MFA. The number
+      must be `verified: true`.
+  default_second_factor:
+    type: boolean
+    description: |
+      When `true`, prefer this phone as the user's default second
+      factor on `needs_second_factor`. Requires
+      `reserved_for_second_factor: true`.

--- a/components/schemas/User.yaml
+++ b/components/schemas/User.yaml
@@ -6,10 +6,10 @@ description: |
   (banned, locked), the lifecycle timestamps, and the three flavours of
   metadata.
 
-  Phone numbers, external accounts, enterprise accounts, and passkeys
-  are present in the shape today (as empty arrays in v0.1) so SDKs can
-  generate stable types up front; the corresponding endpoints land in
-  later milestones (v0.4 / v0.5 / v0.6).
+  External accounts, enterprise accounts, and passkeys are present in
+  the shape today (as empty arrays before their respective milestones
+  ship) so SDKs can generate stable types up front; the corresponding
+  endpoints land in later milestones (v0.5 / v0.6).
 required:
   - id
   - object
@@ -73,19 +73,16 @@ properties:
   primary_phone_number_id:
     type: [string, "null"]
     description: |
-      Pointer into `phone_numbers[]`. v0.1 always returns `null` (phone
-      identifiers ship in v0.4).
+      Pointer into `phone_numbers[]`. `null` for users with no verified
+      phone (e.g. email-only accounts).
   email_addresses:
     type: array
     items:
       $ref: "./EmailAddress.yaml"
   phone_numbers:
     type: array
-    description: |
-      Reserved for v0.4. Always returned as `[]` in v0.1.
     items:
-      type: object
-      additionalProperties: true
+      $ref: "./PhoneNumber.yaml"
   external_accounts:
     type: array
     description: |

--- a/fapi.yaml
+++ b/fapi.yaml
@@ -205,6 +205,7 @@ components:
     Error:                                     { $ref: ./components/schemas/Error.yaml }
     ErrorResponse:                             { $ref: ./components/schemas/ErrorResponse.yaml }
     EmailAddress:                              { $ref: ./components/schemas/EmailAddress.yaml }
+    PhoneNumber:                               { $ref: ./components/schemas/PhoneNumber.yaml }
     User:                                      { $ref: ./components/schemas/User.yaml }
     Client:                                    { $ref: ./components/schemas/Client.yaml }
     ClientResponseEnvelope:                    { $ref: ./components/schemas/ClientResponseEnvelope.yaml }


### PR DESCRIPTION
## Summary

- New `PhoneNumber` schema mirroring `EmailAddress`'s post-v0.2 shape: flat `verified` + `current_challenge_id` (no nested verification blob). Carries `is_primary`, `reserved_for_second_factor`, `default_second_factor`, and `linked_to_external_account_id` for SMS-MFA + external-account integrations. ID prefix `phn_`.
- New `PhoneNumberCreateRequest` (`{ phone_number }`) and `PhoneNumberUpdateRequest` (`{ is_primary?, reserved_for_second_factor?, default_second_factor? }`) bodies. The phone-number value itself is immutable (re-add a new row to change).
- `User.phone_numbers[]` now resolves to a real `PhoneNumber` array (was a `[]`-only placeholder); `User.primary_phone_number_id` description tightened (no longer "always `null` in v0.1").
- BAPI + FAPI roots register the schema (User refs `PhoneNumber` on both surfaces).

Closes #41

## Test plan

- [x] `npm run lint` clean (BAPI + FAPI).
- [x] `npm run bundle` succeeds.
- [x] Bundled `User.phone_numbers.items` resolves to `#/components/schemas/PhoneNumber` on both surfaces.