### PR TITLE
Add ExternalAccount resource schema (ext_ prefix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
   - `PhoneNumberUpdateRequest` — `{ is_primary?, reserved_for_second_factor?, default_second_factor? }` patch body. The phone-number value itself is immutable (re-add a new row to change).
   - `User.phone_numbers` resolves to a real `PhoneNumber` array (was a `[]`-only placeholder); `User.primary_phone_number_id` description tightened (no longer "always `null` in v0.1").
 
+- **External-account surface (v0.4) — schema**.
+  - `ExternalAccount` (`ext_` prefix) — per-user link to an `OauthProvider` connection. Carries `provider`, `provider_key`, `provider_user_id`, `email_address`, `scopes`, `public_metadata` (raw IdP claims that didn't map to `User` / `ExternalAccount` fields), `verified` (mapped from the IdP's `email_verified` claim), `linked_at`, `last_signed_in_at`. The IdP-issued `access_token` / `refresh_token` / `id_token` are encrypted at rest and never appear in any payload.
+  - `User.external_accounts[]` resolves to a real `ExternalAccount` array (was a `[]`-only placeholder).
+
 - **Social sign-in surface (v0.4) — schemas**.
   - `OauthProvider` (`oauthp_` prefix) — per-environment social-IdP configuration with three kinds in a single shape: `preset` (bundled `google` / `github` / `apple` / `microsoft`), `custom_oidc` (workspace-registered OIDC IdP, populated by `/.well-known/openid-configuration` discovery), `custom_oauth2` (plain OAuth 2.0 IdP, operator supplies authorize / token / userinfo URLs and `userinfo_method` + `userinfo_auth`). Computed read-only `redirect_uri = https://<env_slug>.authn.sh/v1/oauth-callback/<provider_key>`. Per-provider `attribute_mapping` (`User` / `ExternalAccount` field → IdP claim or userinfo path). Per-provider `block_email_subaddresses` and `allow_sign_in` / `allow_sign_up` toggles.
   - `OauthProviderRequest` — POST/PATCH body. `client_secret` is write-only (encrypted at rest, never returned). `provider_kind` and `provider_key` are immutable on PATCH.

--- a/bapi.yaml
+++ b/bapi.yaml
@@ -208,6 +208,7 @@ components:
     BackupCode:                                { $ref: ./components/schemas/BackupCode.yaml }
     BackupCodeBatch:                           { $ref: ./components/schemas/BackupCodeBatch.yaml }
     EmailAddress:                              { $ref: ./components/schemas/EmailAddress.yaml }
+    ExternalAccount:                           { $ref: ./components/schemas/ExternalAccount.yaml }
     PhoneNumber:                               { $ref: ./components/schemas/PhoneNumber.yaml }
     User:                                      { $ref: ./components/schemas/User.yaml }
     UserCreateRequest:                         { $ref: ./components/schemas/UserCreateRequest.yaml }

--- a/components/schemas/ExternalAccount.yaml
+++ b/components/schemas/ExternalAccount.yaml
@@ -1,0 +1,174 @@
+type: object
+description: |
+  A `User`'s persistent link to a social-IdP connection driven by an
+  `OauthProvider` row. Created by `/v1/oauth-callback/<provider_key>`
+  on the first successful authorization-code exchange and reused on
+  every subsequent sign-in via the same provider. Powers the
+  `<ConnectedAccountsPanel />` UI on `<UserProfile />`.
+
+  ### Public surface only
+
+  The IdP-issued `access_token`, `refresh_token`, and `id_token` are
+  encrypted at rest server-side and **never** appear in any payload.
+  The SDK has no way to read them — server-side resolvers fetch
+  fresh userinfo against the stored tokens internally. Sign-in
+  resumption uses the platform's own session cookie, not the IdP's
+  tokens.
+
+  ### What the IdP told us
+
+  - `provider_user_id` — the IdP's stable identifier for this user
+    (`sub` for OIDC, `id` for plain OAuth 2.0). Unique per
+    `OauthProvider` row; the resolver matches incoming callbacks
+    against this column.
+  - `email_address` — the email the IdP returned for this user.
+    Stored verbatim. May or may not match a verified
+    `EmailAddress` on the parent `User` (the resolver de-dupes
+    when the IdP confirms the address as verified — see
+    `verified` below).
+  - `scopes` — what the IdP actually granted. May be a subset of
+    `OauthProvider.scopes` (the user can decline scopes on the
+    consent screen).
+  - `public_metadata` — free-form bag of raw IdP claims that did
+    not map to any `User` / `ExternalAccount` field via
+    `OauthProvider.attribute_mapping`. Useful for IdP-specific
+    extras (e.g. `groups[]` from a workforce IdP).
+
+  ### Identifier
+
+  ID prefix `ext_` (e.g. `ext_01HKX9SY9V7H7TF8C8K7J9X4ZA`).
+required:
+  - id
+  - object
+  - provider
+  - provider_key
+  - provider_user_id
+  - email_address
+  - scopes
+  - public_metadata
+  - verified
+  - linked_at
+  - last_signed_in_at
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: external_account
+  provider:
+    type: string
+    maxLength: 100
+    description: |
+      Human-readable IdP label, copied from `OauthProvider.name` at
+      link time (e.g. `"Google"`, `"GitHub"`, `"Acme Corp SSO"`).
+      Frozen on the row — renaming the `OauthProvider` does not
+      retroactively update existing `ExternalAccount` rows so the SDK
+      can render history correctly.
+  provider_key:
+    type: string
+    pattern: "^[a-z][a-z0-9_]*$"
+    maxLength: 64
+    description: |
+      Stable slug matching `OauthProvider.provider_key`. Same shape on
+      both ends so the SDK can correlate. Survives provider deletion
+      — the row stays so audit trails remain readable, but
+      sign-in via that provider stops working.
+    examples:
+      - google
+      - github
+      - acme_corp_sso
+  provider_user_id:
+    type: string
+    maxLength: 255
+    description: |
+      The IdP's stable identifier for this user (OIDC `sub`, OAuth 2.0
+      `id`). Unique per `OauthProvider` row.
+  email_address:
+    type: [string, "null"]
+    format: email
+    maxLength: 254
+    description: |
+      Email the IdP returned for this user. `null` for IdPs that
+      don't ship an email claim (rare; some workforce IdPs).
+  scopes:
+    type: array
+    items:
+      type: string
+    description: |
+      Scopes the IdP actually granted. May be a subset of the requested
+      `OauthProvider.scopes` if the user declined some on the consent
+      screen.
+    examples:
+      - ["openid", "email", "profile"]
+  public_metadata:
+    $ref: ./Metadata.yaml
+  verified:
+    type: boolean
+    description: |
+      `true` when the IdP confirmed the email as verified — mapped
+      from the OIDC `email_verified` claim (or the equivalent
+      OAuth 2.0 userinfo field, depending on
+      `OauthProvider.attribute_mapping`). When `true`, the resolver
+      will attach the email to the parent `User`'s
+      `email_addresses[]` automatically.
+  linked_at:
+    $ref: ./Timestamp.yaml
+  last_signed_in_at:
+    description: |
+      Timestamp of the most recent sign-in via this external account.
+      `null` until the second sign-in (the first is captured by
+      `linked_at`).
+    oneOf:
+      - $ref: ./Timestamp.yaml
+      - type: "null"
+  created_at:
+    $ref: ./Timestamp.yaml
+  updated_at:
+    $ref: ./Timestamp.yaml
+examples:
+  - id: ext_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    object: external_account
+    provider: Google
+    provider_key: google
+    provider_user_id: "112233445566778899001"
+    email_address: alice@example.com
+    scopes: [openid, email, profile]
+    public_metadata:
+      hd: example.com
+      locale: en
+    verified: true
+    linked_at: 1714723000000
+    last_signed_in_at: 1714896500000
+    created_at: 1714723000000
+    updated_at: 1714896500000
+  - id: ext_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    object: external_account
+    provider: GitHub
+    provider_key: github
+    provider_user_id: "1742554"
+    email_address: alice@example.com
+    scopes: [read:user, user:email]
+    public_metadata:
+      login: alice-github
+    verified: true
+    linked_at: 1714724000000
+    last_signed_in_at: null
+    created_at: 1714724000000
+    updated_at: 1714724000000
+  - id: ext_01HKX9SY9V7H7TF8C8K7J9X4ZC
+    object: external_account
+    provider: Acme Corp SSO
+    provider_key: acme_corp_sso
+    provider_user_id: alice@acme.example
+    email_address: alice@acme.example
+    scopes: [openid, email, profile, groups]
+    public_metadata:
+      groups: [engineering, sso-admins]
+    verified: true
+    linked_at: 1714725000000
+    last_signed_in_at: 1714900000000
+    created_at: 1714725000000
+    updated_at: 1714900000000

--- a/components/schemas/User.yaml
+++ b/components/schemas/User.yaml
@@ -85,11 +85,8 @@ properties:
       $ref: "./PhoneNumber.yaml"
   external_accounts:
     type: array
-    description: |
-      Reserved for v0.4 (OAuth connections). Always `[]` in v0.1.
     items:
-      type: object
-      additionalProperties: true
+      $ref: "./ExternalAccount.yaml"
   enterprise_accounts:
     type: array
     description: |

--- a/fapi.yaml
+++ b/fapi.yaml
@@ -205,6 +205,7 @@ components:
     Error:                                     { $ref: ./components/schemas/Error.yaml }
     ErrorResponse:                             { $ref: ./components/schemas/ErrorResponse.yaml }
     EmailAddress:                              { $ref: ./components/schemas/EmailAddress.yaml }
+    ExternalAccount:                           { $ref: ./components/schemas/ExternalAccount.yaml }
     PhoneNumber:                               { $ref: ./components/schemas/PhoneNumber.yaml }
     User:                                      { $ref: ./components/schemas/User.yaml }
     Client:                                    { $ref: ./components/schemas/Client.yaml }


### PR DESCRIPTION
## Summary

- New `ExternalAccount` schema (`ext_` prefix) — per-user link to an `OauthProvider` connection, created on first successful authorization-code exchange and reused on subsequent sign-ins. Carries the IdP's view of the user (`provider_user_id`, `email_address`, `scopes`, `public_metadata`) plus `verified`, `linked_at`, `last_signed_in_at`.
- Public surface only — `access_token`, `refresh_token`, `id_token` are encrypted at rest server-side and never appear in any payload. The schema description spells this out explicitly.
- `User.external_accounts[]` now resolves to a real `ExternalAccount` array (was a `[]`-only placeholder).
- BAPI + FAPI roots register the schema (User refs `ExternalAccount` on both surfaces).

Depends on #47 (OA-1) — references `OauthProvider.provider_key` shape, but no direct schema cross-ref. Safe to land independently.

Closes #40

## Test plan

- [x] `npm run lint` clean (BAPI + FAPI).
- [x] `npm run bundle` succeeds.
- [x] Bundled `User.external_accounts.items` resolves to `#/components/schemas/ExternalAccount` on both surfaces.