### PR TITLE
Document phone_code strategy + InstanceSettings.multi_factor.phone_code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
 
 ### Added
 
+- **`phone_code` strategy + phone-MFA settings (v0.4)**.
+  - `Challenge.strategy` documents `phone_code` for sign-up first-factor (env's `attributes.phone_number != "off"`), sign-in second-factor (`step: "second"` SMS MFA), and `PhoneNumber` verification on a signed-in user. `ChallengeCreateRequest.phone_number_id` is a documented field (was reserved); `ChallengeCreateRequest.strategy` lists `phone_code` and `oauth_<provider_key>`.
+  - `InstanceSettings.multi_factor` gains a required `phone_code: { enabled }` block (default `false` — opt-in due to SMS cost + SIM-swap risk). `InstanceUpdateRequest.multi_factor` accepts the matching patch.
+  - `Environment.auth_config.identifier_requirements.{email_address, phone_number, username}` enums shift from `[required, used_for_first_factor, off]` to `[required, optional, off]` for the v0.4 SDK vocabulary. `first_factors[]` / `second_factors[]` descriptions document the per-env narrowing rules.
+
 - **Social sign-in surface (v0.4) — schemas**.
   - `OauthProvider` (`oauthp_` prefix) — per-environment social-IdP configuration with three kinds in a single shape: `preset` (bundled `google` / `github` / `apple` / `microsoft`), `custom_oidc` (workspace-registered OIDC IdP, populated by `/.well-known/openid-configuration` discovery), `custom_oauth2` (plain OAuth 2.0 IdP, operator supplies authorize / token / userinfo URLs and `userinfo_method` + `userinfo_auth`). Computed read-only `redirect_uri = https://<env_slug>.authn.sh/v1/oauth-callback/<provider_key>`. Per-provider `attribute_mapping` (`User` / `ExternalAccount` field → IdP claim or userinfo path). Per-provider `block_email_subaddresses` and `allow_sign_in` / `allow_sign_up` toggles.
   - `OauthProviderRequest` — POST/PATCH body. `client_secret` is write-only (encrypted at rest, never returned). `provider_kind` and `provider_key` are immutable on PATCH.

--- a/components/schemas/Challenge.yaml
+++ b/components/schemas/Challenge.yaml
@@ -183,6 +183,19 @@ properties:
         authorize URL on `external_verification_redirect_url`; the SDK
         redirects the browser there and resumes via
         `/v1/oauth-callback/<provider_key>`.
+      - `phone_code` — SMS code, served two ways:
+          - **First factor on sign-up** (`step: "single"`) when the
+            env's `attributes.phone_number != "off"` and the user
+            supplied a phone in the `SignUp` attempt.
+          - **Second factor on sign-in** (`step: "second"`) when the
+            user has at least one `PhoneNumber` row with
+            `reserved_for_second_factor: true` and the env has
+            `multi_factor.phone_code.enabled: true`.
+          - **Phone-number verification on a signed-in user**
+            (`step: "single"`) issued against a parent
+            `phone_number_id`, mirroring `email_code` against an
+            `EmailAddress`.
+        Answer with `{ code: "123456" }` (numeric, 6 digits).
       - `totp`, `backup_code` — sign-in second factor (`step: "second"`
         only). Answer with `{ code: "123456" }` for `totp` (numeric,
         6 digits, `±1 step` tolerance) or `{ code: "abcd-efgh" }` for

--- a/components/schemas/ChallengeCreateRequest.yaml
+++ b/components/schemas/ChallengeCreateRequest.yaml
@@ -17,15 +17,24 @@ description: |
   Per-parent legal strategies:
 
   - `SignIn` (first factor) — `password`, `email_code`, `email_link`,
+    `phone_code`, `oauth_<provider_key>`,
     `reset_password_email_code`, `ticket`, `transfer`.
-  - `SignIn` (second factor) — `totp`, `backup_code`. Only legal when
-    the parent SignIn is in `needs_second_factor`; the server narrows
-    `SignIn.supported_strategies` to the second-factor methods the
-    resolved user has enrolled. `step` on the resulting Challenge is
-    set to `"second"`.
-  - `SignUp` — `email_code`, `email_link`, `ticket`, `transfer`.
-    Sign-up never gains a second factor.
+  - `SignIn` (second factor) — `totp`, `backup_code`, `phone_code`.
+    Only legal when the parent SignIn is in `needs_second_factor`; the
+    server narrows `SignIn.supported_strategies` to the second-factor
+    methods the resolved user has enrolled. `step` on the resulting
+    Challenge is set to `"second"`. `phone_code` here defaults to the
+    user's `default_second_factor` phone, falling back to
+    `User.primary_phone_number_id`; supply `phone_number_id`
+    explicitly to target a different reserved-for-MFA row.
+  - `SignUp` — `email_code`, `email_link`, `phone_code`,
+    `oauth_<provider_key>`, `ticket`, `transfer`. Sign-up never gains
+    a second factor — the `phone_code` here is the first-factor phone-
+    attribute path.
   - `EmailAddress` — `email_code`, `email_link`.
+  - `PhoneNumber` — `phone_code`. Used by FAPI
+    `/v1/me/phone-numbers/{id}/challenges` to verify additional phone
+    numbers on an already-signed-in user.
   - `OrganizationDomain` — `domain_dns_txt`, `email_code`.
 required: [strategy]
 additionalProperties: false
@@ -33,15 +42,17 @@ properties:
   strategy:
     type: string
     description: |
-      v0.3 surface across all parents:
-      `password`, `email_code`, `email_link`, `reset_password_email_code`,
-      `ticket`, `transfer`, `domain_dns_txt`, `totp`, `backup_code`.
-      Future strategies (SMS, OAuth, passkey) plug in here without spec
-      changes.
+      Strategy across all parents:
+      `password`, `email_code`, `email_link`, `phone_code`,
+      `oauth_<provider_key>`, `reset_password_email_code`, `ticket`,
+      `transfer`, `domain_dns_txt`, `totp`, `backup_code`. Future
+      strategies (passkey) plug in here without spec changes.
     examples:
       - password
       - email_code
       - email_link
+      - phone_code
+      - oauth_google
       - reset_password_email_code
       - ticket
       - transfer
@@ -59,14 +70,28 @@ properties:
       strategies are scoped to the resolved user, not an identifier.
   phone_number_id:
     type: string
-    description: Reserved for `phone_code` (v0.4+).
+    description: |
+      For `phone_code`, the `PhoneNumber` to send the SMS to.
+      Required when verifying a specific row in
+      `/v1/me/phone-numbers/{id}/challenges`'s context (the parent
+      `PhoneNumber.id` is implicit in the URL but supplying it
+      again here makes the body symmetric with `email_address_id`).
+      Optional on `SignIn` / `SignUp` parents — the server defaults
+      to:
+        - first-factor sign-up — the phone supplied in the
+          `SignUp` attempt;
+        - second-factor sign-in — the user's `default_second_factor`
+          phone, falling back to `User.primary_phone_number_id`.
+      Supply explicitly to target a non-default reserved-for-MFA row.
   redirect_url:
     type: string
     format: uri
     description: |
       For `email_link`, the URL the magic link bounces back to after
       `clientHandshake` consumes the ticket. Must be on the redirect-URL
-      allowlist. Also used by OAuth strategies (v0.4+).
+      allowlist. Also used by `oauth_<provider_key>` strategies as the
+      `redirectUrlComplete` the SDK is bounced to once the parent
+      flow finishes.
 examples:
   - { strategy: password }
   - { strategy: email_code, email_address_id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE }
@@ -76,6 +101,11 @@ examples:
   - strategy: reset_password_email_code
     email_address_id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE
   - { strategy: email_code }
+  - { strategy: phone_code }
+  - strategy: phone_code
+    phone_number_id: phn_01HKX9SY9V7H7TF8C8K7J9X4ZA
+  - strategy: oauth_google
+    redirect_url: https://app.acme.com/dashboard
   - { strategy: domain_dns_txt }
   - { strategy: totp }
   - { strategy: backup_code }

--- a/components/schemas/Environment.yaml
+++ b/components/schemas/Environment.yaml
@@ -50,35 +50,51 @@ properties:
   auth_config:
     type: object
     description: |
-      Allowed authentication strategies and identifier requirements.
-      v0.1 returns the password + email-code subset; broader provider
-      lists ship in v0.4.
+      Allowed authentication strategies and identifier requirements
+      surfaced to the SDK at boot.
     additionalProperties: false
     properties:
       first_factors:
         type: array
         items:
           type: string
-        examples: [["password", "email_code", "reset_password_email_code", "ticket"]]
+        description: |
+          First-factor strategies the SDK should render. Server-narrowed
+          per-env from `InstanceSettings.attribute_settings` and the
+          enabled `OauthProvider` rows. Includes `phone_code` when
+          `attributes.phone_number != "off"` and includes
+          `oauth_<provider_key>` for each enabled `OauthProvider` row.
+        examples: [["password", "email_code", "phone_code", "oauth_google", "reset_password_email_code", "ticket"]]
       second_factors:
         type: array
         items:
           type: string
-        description: Empty in v0.1 (MFA ships v0.3).
+        description: |
+          Second-factor strategies the SDK should consider on
+          `needs_second_factor`. Server-narrowed per-env from
+          `InstanceSettings.multi_factor.*.enabled`. Includes `totp`,
+          `backup_code`, `phone_code` when their respective
+          `enabled: true`.
       identifier_requirements:
         type: object
         additionalProperties: false
         properties:
           email_address:
             type: string
-            enum: [required, used_for_first_factor, off]
+            enum: [required, optional, off]
           phone_number:
             type: string
-            enum: [required, used_for_first_factor, off]
+            enum: [required, optional, off]
             default: off
+            description: |
+              Mirrors `InstanceSettings.attribute_settings.phone_number`.
+              `optional` means the SDK renders the phone field as
+              optional at sign-up; `required` means sign-up cannot
+              complete without a verified phone; `off` hides the field
+              entirely.
           username:
             type: string
-            enum: [required, used_for_first_factor, off]
+            enum: [required, optional, off]
             default: off
       sign_up_modes:
         type: array

--- a/components/schemas/InstanceSettings.yaml
+++ b/components/schemas/InstanceSettings.yaml
@@ -222,14 +222,17 @@ properties:
     type: object
     description: |
       Per-environment MFA strategy gating. The FAPI consults these
-      flags before issuing a `totp` / `backup_code` Challenge or
-      accepting `POST /v1/me/totp` / `POST /v1/me/backup-codes`. A
-      strategy that's `enabled: false` is omitted from
+      flags before issuing a `totp` / `backup_code` / `phone_code`
+      Challenge or accepting the corresponding enrollment endpoint
+      (`POST /v1/me/totp`, `POST /v1/me/backup-codes`,
+      `PATCH /v1/me/phone-numbers/{id}` with
+      `reserved_for_second_factor: true`). A strategy that's
+      `enabled: false` is omitted from
       `SignIn.supported_strategies` even if a user has stale
       enrollment rows for it (the rows survive the toggle but can't
       be used to complete sign-in).
     additionalProperties: false
-    required: [totp, backup_codes]
+    required: [totp, backup_codes, phone_code]
     properties:
       totp:
         type: object
@@ -263,6 +266,24 @@ properties:
               regeneration request. Bounds chosen so the typical
               printable card stays readable; raise for environments
               that want more headroom.
+      phone_code:
+        type: object
+        additionalProperties: false
+        required: [enabled]
+        properties:
+          enabled:
+            type: boolean
+            default: false
+            description: |
+              When `false` (the default), refuses flipping
+              `PhoneNumber.reserved_for_second_factor` to `true` and
+              excludes `phone_code` from second-factor
+              `supported_strategies`. Existing
+              `reserved_for_second_factor` rows survive the toggle but
+              cannot complete sign-in until the env re-enables phone
+              MFA. Defaults to `false` because SMS MFA carries real
+              cost (carrier fees) and SIM-swap risk — operators opt
+              in explicitly.
   audit_log_retention_days:
     type: integer
     minimum: 1

--- a/components/schemas/InstanceUpdateRequest.yaml
+++ b/components/schemas/InstanceUpdateRequest.yaml
@@ -68,6 +68,11 @@ properties:
             type: integer
             minimum: 4
             maximum: 24
+      phone_code:
+        type: object
+        additionalProperties: false
+        properties:
+          enabled: { type: boolean }
   audit_log_retention_days:
     type: integer
     minimum: 1


### PR DESCRIPTION
## Summary

- `Challenge.strategy` + `ChallengeCreateRequest.strategy` describe `phone_code` across three legal contexts: first-factor sign-up phone-attribute path, second-factor SMS MFA (`step: "second"`), and `PhoneNumber` verification on a signed-in user. `phone_number_id` is now a documented field on the create request (was reserved). The strategy enum lists `phone_code` and `oauth_<provider_key>`.
- `InstanceSettings.multi_factor` gains a required `phone_code: { enabled }` block, defaulting to `false` so operators opt in before SMS cost + SIM-swap risk land in their flow. `InstanceUpdateRequest` accepts the matching patch shape.
- `Environment.auth_config.identifier_requirements.{email_address, phone_number, username}` switch enums from `[required, used_for_first_factor, off]` to `[required, optional, off]` for the v0.4 SDK vocabulary. `first_factors[]` / `second_factors[]` descriptions document the server-side narrowing rules.

Closes #45

## Test plan

- [x] `npm run lint` clean (BAPI + FAPI).
- [x] `npm run bundle` succeeds.
- [x] Bundled `Challenge.strategy` description includes `phone_code`.
- [x] Bundled `InstanceSettings.multi_factor.required` is `[totp, backup_codes, phone_code]` and the `phone_code` block exists.