### PR TITLE
Add BAPI /v1/oauth-providers (CRUD + test)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,11 @@
 - **Social sign-in surface (v0.4) — schemas**.
   - `OauthProvider` (`oauthp_` prefix) — per-environment social-IdP configuration with three kinds in a single shape: `preset` (bundled `google` / `github` / `apple` / `microsoft`), `custom_oidc` (workspace-registered OIDC IdP, populated by `/.well-known/openid-configuration` discovery), `custom_oauth2` (plain OAuth 2.0 IdP, operator supplies authorize / token / userinfo URLs and `userinfo_method` + `userinfo_auth`). Computed read-only `redirect_uri = https://<env_slug>.authn.sh/v1/oauth-callback/<provider_key>`. Per-provider `attribute_mapping` (`User` / `ExternalAccount` field → IdP claim or userinfo path). Per-provider `block_email_subaddresses` and `allow_sign_in` / `allow_sign_up` toggles.
   - `OauthProviderRequest` — POST/PATCH body. `client_secret` is write-only (encrypted at rest, never returned). `provider_kind` and `provider_key` are immutable on PATCH.
+  - `OauthProviderTestResult` — return shape of the BAPI dry-run probe.
   - `Challenge.strategy` documents `oauth_<provider_key>` as a first-factor value; the IdP authorize URL is surfaced via `external_verification_redirect_url`.
+
+- **BAPI `/v1/oauth-providers` (v0.4)**.
+  - `GET /v1/oauth-providers` (`listOauthProviders`), `POST /v1/oauth-providers` (`createOauthProvider`), `GET /v1/oauth-providers/{id}` (`getOauthProvider`), `PATCH /v1/oauth-providers/{id}` (`updateOauthProvider`), `DELETE /v1/oauth-providers/{id}` (`deleteOauthProvider`), `POST /v1/oauth-providers/{id}/test` (`testOauthProvider`). Soft-delete refuses (`409 oauth_provider_in_use`) when `ExternalAccount` rows still link to the provider. `test` returns `200` with `OauthProviderTestResult { authorize_url, userinfo_status, errors }` even when probes fail.
 
 - **Multi-factor authentication surface (v0.3)**.
   - `TotpSecret` (one per `User`, `totp_` prefix) and `BackupCode` (`bcc_` prefix) resource schemas, plus `BackupCodeBatch` envelope for the one-time plaintext reveal.

--- a/bapi.yaml
+++ b/bapi.yaml
@@ -61,6 +61,8 @@ tags:
     description: URLs allowed as post-flow redirect targets.
   - name: Instance
     description: Per-environment settings (`InstanceSetting`).
+  - name: OAuth Providers
+    description: Per-environment social-IdP configuration (`OauthProvider`).
   - name: Webhooks
     description: Webhook endpoints, deliveries, and the event envelope.
 
@@ -162,6 +164,12 @@ paths:
     $ref: ./paths/bapi/instance-restrictions.yaml
   /v1/instance/organization-settings:
     $ref: ./paths/bapi/instance-organization-settings.yaml
+  /v1/oauth-providers:
+    $ref: ./paths/bapi/oauth-providers.yaml
+  /v1/oauth-providers/{oauth_provider_id}:
+    $ref: ./paths/bapi/oauth-provider.yaml
+  /v1/oauth-providers/{oauth_provider_id}/test:
+    $ref: ./paths/bapi/oauth-provider-test.yaml
   /v1/webhooks/endpoints:
     $ref: ./paths/bapi/webhook-endpoints.yaml
   /v1/webhooks/endpoints/{endpoint_id}:
@@ -244,6 +252,7 @@ components:
     RolePermissionsRequest:                    { $ref: ./components/schemas/RolePermissionsRequest.yaml }
     OauthProvider:                             { $ref: ./components/schemas/OauthProvider.yaml }
     OauthProviderRequest:                      { $ref: ./components/schemas/OauthProviderRequest.yaml }
+    OauthProviderTestResult:                   { $ref: ./components/schemas/OauthProviderTestResult.yaml }
 
   responses:
     BadRequest:           { $ref: ./components/responses/BadRequest.yaml }

--- a/components/schemas/OauthProviderTestResult.yaml
+++ b/components/schemas/OauthProviderTestResult.yaml
@@ -1,0 +1,49 @@
+type: object
+description: |
+  Result of `POST /v1/oauth-providers/{id}/test`. The dashboard uses
+  this shape to render a per-provider health indicator on the Social
+  providers configuration page. Always returned with HTTP `200` even
+  when probes fail — inspect `errors[]` to decide pass/fail.
+required: [authorize_url, userinfo_status, errors]
+additionalProperties: false
+properties:
+  authorize_url:
+    type: string
+    description: |
+      The fully-formed `/authorize` URL the SDK would redirect a user
+      to right now (with a synthetic `state` and the registered
+      `redirect_uri`). Empty string when the server could not build
+      it (e.g. OIDC discovery refresh failed and no cached endpoint
+      exists).
+    examples:
+      - "https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=123-abc.apps.googleusercontent.com&redirect_uri=https%3A%2F%2Facme.authn.sh%2Fv1%2Foauth-callback%2Fgoogle&scope=openid+email+profile&state=test_01HKX9SY9V7H7TF8C8K7J9X4ZA"
+  userinfo_status:
+    type: [integer, "null"]
+    minimum: 100
+    maximum: 599
+    description: |
+      HTTP status code returned by the unauthenticated probe of
+      `userinfo_endpoint` (the server sends a token-less HEAD/GET and
+      records what came back). `401` / `403` are healthy — the
+      endpoint is reachable and refused the missing token. `5xx` and
+      timeouts surface a problem on the IdP side. `null` when the
+      provider has no `userinfo_endpoint` (some OIDC IdPs ship every
+      claim in the ID token).
+  errors:
+    type: array
+    description: |
+      Collected probe errors. Empty when every check passed. Each
+      entry uses the standard `Error` shape (`code` is a stable
+      machine-readable token; SDKs match on it).
+    items:
+      $ref: ./Error.yaml
+examples:
+  - authorize_url: "https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=123-abc.apps.googleusercontent.com&redirect_uri=https%3A%2F%2Facme.authn.sh%2Fv1%2Foauth-callback%2Fgoogle&scope=openid+email+profile&state=test_01HKX9SY9V7H7TF8C8K7J9X4ZA"
+    userinfo_status: 401
+    errors: []
+  - authorize_url: ""
+    userinfo_status: null
+    errors:
+      - code: oauth_discovery_refresh_failed
+        message: "Could not refresh /.well-known/openid-configuration"
+        long_message: "The cached OIDC discovery document is older than 24h and a refresh attempt timed out. Verify the issuer URL and that the discovery endpoint is reachable from authn.sh."

--- a/paths/bapi/oauth-provider-test.yaml
+++ b/paths/bapi/oauth-provider-test.yaml
@@ -1,0 +1,64 @@
+parameters:
+  - name: oauth_provider_id
+    in: path
+    required: true
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+post:
+  operationId: testOauthProvider
+  summary: Dry-run an OAuth provider
+  description: |
+    Probe the provider's configuration without redirecting any user.
+    The dashboard runs this on save to surface broken endpoints up
+    front, instead of letting an operator find out at sign-in time.
+
+    The server:
+
+    - Builds the `/authorize` URL the SDK would redirect to (using a
+      synthetic `state` and `redirect_uri = OauthProvider.redirect_uri`)
+      and returns it on `authorize_url`.
+    - Optionally HEAD-probes `userinfo_endpoint` (without an access
+      token, expecting `401`/`403`) to confirm the URL is reachable
+      and surfaces any DNS / TLS / 5xx issues. The HTTP status code
+      is returned on `userinfo_status`; `null` when the provider has
+      no `userinfo_endpoint` configured (some OIDC IdPs ship every
+      claim in the ID token).
+    - Collects any errors (validation, OIDC discovery refresh, network
+      timeouts) into `errors[]`.
+
+    Always returns `200` — even when probes fail. The caller inspects
+    `errors[]` to decide whether to surface a red dot in the UI.
+  tags: [OAuth Providers]
+  responses:
+    "200":
+      description: Probe result. Inspect `errors[]` to decide pass/fail.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/OauthProviderTestResult.yaml }
+          examples:
+            healthy:
+              summary: All probes passed
+              value:
+                authorize_url: "https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=123-abc.apps.googleusercontent.com&redirect_uri=https%3A%2F%2Facme.authn.sh%2Fv1%2Foauth-callback%2Fgoogle&scope=openid+email+profile&state=test_01HKX9SY9V7H7TF8C8K7J9X4ZA&prompt=select_account"
+                userinfo_status: 401
+                errors: []
+            misconfigured_userinfo:
+              summary: Userinfo endpoint returns 5xx
+              value:
+                authorize_url: "https://idp.legacy.example/oauth/authorize?response_type=code&client_id=legacy-client&redirect_uri=https%3A%2F%2Facme.authn.sh%2Fv1%2Foauth-callback%2Flegacy_idp&scope=read_profile+read_email&state=test_01HKX9SY9V7H7TF8C8K7J9X4ZA"
+                userinfo_status: 502
+                errors:
+                  - code: oauth_userinfo_unreachable
+                    message: "userinfo_endpoint returned 502 Bad Gateway"
+                    long_message: "The IdP's userinfo endpoint returned a 502. Check the IdP's status page or your firewall rules and re-test."
+            stale_discovery:
+              summary: OIDC discovery cache expired and refresh failed
+              value:
+                authorize_url: ""
+                userinfo_status: null
+                errors:
+                  - code: oauth_discovery_refresh_failed
+                    message: "Could not refresh /.well-known/openid-configuration"
+                    long_message: "The cached OIDC discovery document is older than 24h and a refresh attempt timed out. Verify the issuer URL and that the discovery endpoint is reachable from authn.sh."
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }

--- a/paths/bapi/oauth-provider.yaml
+++ b/paths/bapi/oauth-provider.yaml
@@ -1,0 +1,79 @@
+parameters:
+  - name: oauth_provider_id
+    in: path
+    required: true
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+get:
+  operationId: getOauthProvider
+  summary: Get an OAuth provider
+  description: Fetch a single `OauthProvider` row. `client_secret` is never included.
+  tags: [OAuth Providers]
+  responses:
+    "200":
+      description: The OAuth provider.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/OauthProvider.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+
+patch:
+  operationId: updateOauthProvider
+  summary: Update an OAuth provider
+  description: |
+    Partial update. `provider_kind` and `provider_key` are immutable —
+    sending a different value returns `422`. Every other field is
+    optional; omitted keys are left untouched. Sending
+    `client_secret: null` clears the stored secret (e.g. when migrating
+    to a PKCE-only flow).
+
+    Patching `enabled` to `false` keeps existing `ExternalAccount`
+    rows but prevents new sign-ins via this provider. Patching
+    `allow_sign_in: false` and `allow_sign_up: false` together has the
+    same effect as `enabled: false`.
+  tags: [OAuth Providers]
+  parameters:
+    - $ref: ../../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../../components/schemas/OauthProviderRequest.yaml }
+        examples:
+          disable:
+            summary: Pause without deleting
+            value: { enabled: false }
+          rotate_secret:
+            summary: Rotate the IdP client secret
+            value: { client_secret: GOCSPX-yyyyyyyyyyyyyyyyyyyyyyyyy }
+          tighten_signups:
+            summary: Sign-in only — refuse new accounts via this provider
+            value: { allow_sign_up: false }
+  responses:
+    "200":
+      description: The updated OAuth provider.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/OauthProvider.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }
+
+delete:
+  operationId: deleteOauthProvider
+  summary: Delete an OAuth provider
+  description: |
+    Soft delete. Refuses (`409 oauth_provider_in_use`) when any
+    `ExternalAccount` rows still link to this provider — operators
+    must migrate or unlink those users first to keep the audit trail
+    of past sign-ins intact. Once deleted, the
+    `oauth_<provider_key>` strategy on `Challenge` is rejected for
+    this environment.
+  tags: [OAuth Providers]
+  responses:
+    "204":
+      description: Deleted.
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "409": { $ref: ../../components/responses/Conflict.yaml }

--- a/paths/bapi/oauth-providers.yaml
+++ b/paths/bapi/oauth-providers.yaml
@@ -1,0 +1,106 @@
+get:
+  operationId: listOauthProviders
+  summary: List OAuth providers
+  description: |
+    Paginated list of every `OauthProvider` row configured on the
+    environment, regardless of `enabled` state. The dashboard renders
+    the rows in this order; reorder by re-creating with a different
+    `created_at` (no separate `position` column).
+  tags: [OAuth Providers]
+  parameters:
+    - $ref: ../../components/parameters/LimitParam.yaml
+    - $ref: ../../components/parameters/OffsetParam.yaml
+  responses:
+    "200":
+      description: A page of OAuth providers.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: ../../components/schemas/PaginatedList.yaml
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: ../../components/schemas/OauthProvider.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+
+post:
+  operationId: createOauthProvider
+  summary: Create an OAuth provider
+  description: |
+    Register a social-IdP connection on this environment. Three kinds:
+
+    - `preset` — bundled IdP. Operator only supplies `provider_key`
+      (one of `google`, `github`, `apple`, `microsoft`), `client_id`,
+      and `client_secret`; the platform fills in OIDC discovery,
+      default scopes, and the standard `attribute_mapping`.
+    - `custom_oidc` — workspace IdP. Operator supplies `provider_key`,
+      `client_id`, `client_secret`, and `issuer`; the server fetches
+      `<issuer>/.well-known/openid-configuration` and populates the
+      endpoint fields automatically.
+    - `custom_oauth2` — plain OAuth 2.0 IdP. Operator supplies
+      `provider_key`, `client_id`, `client_secret`,
+      `authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`,
+      `userinfo_method`, and `userinfo_auth`.
+
+    `client_secret` is encrypted at rest and never returned by any GET.
+    The computed `redirect_uri` (the URL the IdP must redirect to) is
+    surfaced in the response — register that exact value with the IdP.
+  tags: [OAuth Providers]
+  parameters:
+    - $ref: ../../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../../components/schemas/OauthProviderRequest.yaml }
+        examples:
+          preset_google:
+            summary: Google preset (minimal POST body)
+            value:
+              provider_kind: preset
+              provider_key: google
+              name: Google
+              client_id: 123456789012-abc.apps.googleusercontent.com
+              client_secret: GOCSPX-xxxxxxxxxxxxxxxxxxxxxxxxx
+              additional_authorization_params:
+                prompt: select_account
+          custom_oidc_acme:
+            summary: Workspace OIDC IdP
+            value:
+              provider_kind: custom_oidc
+              provider_key: acme_corp_sso
+              name: Acme Corp SSO
+              client_id: acme-authn-prod
+              client_secret: shhhh
+              issuer: https://sso.acme.example
+              scopes: [openid, email, profile, groups]
+              allow_sign_up: false
+              block_email_subaddresses: true
+          custom_oauth2_legacy:
+            summary: Plain OAuth 2.0 IdP (no OIDC discovery)
+            value:
+              provider_kind: custom_oauth2
+              provider_key: legacy_idp
+              name: Legacy IdP
+              client_id: legacy-client
+              client_secret: legacy-secret
+              authorization_endpoint: https://idp.legacy.example/oauth/authorize
+              token_endpoint: https://idp.legacy.example/oauth/token
+              userinfo_endpoint: https://idp.legacy.example/api/me
+              userinfo_method: GET
+              userinfo_auth: bearer
+              scopes: [read_profile, read_email]
+              attribute_mapping:
+                email_address: email
+                provider_user_id: id
+  responses:
+    "201":
+      description: The created OAuth provider.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/OauthProvider.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "409": { $ref: ../../components/responses/Conflict.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }


### PR DESCRIPTION
## Summary

- New BAPI surface for managing per-environment `OauthProvider` rows: `listOauthProviders`, `createOauthProvider`, `getOauthProvider`, `updateOauthProvider`, `deleteOauthProvider` plus the `testOauthProvider` dry-run probe.
- New `OauthProviderTestResult` schema — return shape of the dry-run probe. Always returns `200`; the caller inspects `errors[]` to decide pass/fail. Carries the fully-formed `authorize_url` the SDK would redirect to and the HTTP status code from a token-less HEAD/GET against `userinfo_endpoint`.
- Soft-delete refuses (`409 oauth_provider_in_use`) when `ExternalAccount` rows still link to the provider, keeping past sign-ins auditable.
- New "OAuth Providers" tag wired into `bapi.yaml`.

Closes #42

## Test plan

- [x] `npm run lint` clean (BAPI + FAPI).
- [x] `npm run bundle` succeeds.
- [x] Bundled `bapi.bundled.json` contains all six operations under the BAPI server (`listOauthProviders`, `createOauthProvider`, `getOauthProvider`, `updateOauthProvider`, `deleteOauthProvider`, `testOauthProvider`).
- [x] All paths use kebab-case segments; path params (`{oauth_provider_id}`) stay snake_case.