### PR TITLE
Document FAPI OAuth sign-in / sign-up + /v1/oauth-callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@
 - **BAPI `/v1/oauth-providers` (v0.4)**.
   - `GET /v1/oauth-providers` (`listOauthProviders`), `POST /v1/oauth-providers` (`createOauthProvider`), `GET /v1/oauth-providers/{id}` (`getOauthProvider`), `PATCH /v1/oauth-providers/{id}` (`updateOauthProvider`), `DELETE /v1/oauth-providers/{id}` (`deleteOauthProvider`), `POST /v1/oauth-providers/{id}/test` (`testOauthProvider`). Soft-delete refuses (`409 oauth_provider_in_use`) when `ExternalAccount` rows still link to the provider. `test` returns `200` with `OauthProviderTestResult { authorize_url, userinfo_status, errors }` even when probes fail.
 
+- **FAPI OAuth sign-in / sign-up flow (v0.4)**.
+  - `ChallengeCreateRequest` documents the `oauth_<provider_key>` variant — required `redirect_url` (failure landing) and `redirect_url_complete` (success landing), both validated against the redirect-URL allowlist. Server stamps `step: "first"`; OAuth never serves as second factor.
+  - New FAPI path `GET /v1/oauth-callback/{provider_key}` (`oauthCallback`). Hosted on the FAPI server but lives outside `/v1/client/...` — the IdP redirect is a top-level browser navigation. Always responds `302`; the SDK reads the result off the returning URL.
+  - `SignIn` / `SignUp` describe the OAuth flow end-to-end: identifier-less Challenge issuance, `external_verification_redirect_url` carrying the IdP authorize URL, `transferable` cross-flow (sign-in for unknown identity → bounce to sign-up; sign-up for existing identity → bounce to sign-in). `supported_strategies[]` documents the per-provider narrowing: one `oauth_<provider_key>` entry per enabled `OauthProvider`, gated by `allow_sign_in` / `allow_sign_up`.
+
 - **Multi-factor authentication surface (v0.3)**.
   - `TotpSecret` (one per `User`, `totp_` prefix) and `BackupCode` (`bcc_` prefix) resource schemas, plus `BackupCodeBatch` envelope for the one-time plaintext reveal.
   - `Challenge.strategy` enum gains `totp` and `backup_code`. `ChallengeCreateRequest` documents the second-factor variants (no extra fields needed beyond `strategy`); `ChallengeAnswerRequest` documents the `{ code }` answer shape for both.

--- a/components/schemas/ChallengeCreateRequest.yaml
+++ b/components/schemas/ChallengeCreateRequest.yaml
@@ -19,6 +19,11 @@ description: |
   - `SignIn` (first factor) — `password`, `email_code`, `email_link`,
     `phone_code`, `oauth_<provider_key>`,
     `reset_password_email_code`, `ticket`, `transfer`.
+    `oauth_<provider_key>` requires `redirect_url` and
+    `redirect_url_complete` — the server bakes them into the IdP
+    `state` and surfaces the IdP's authorize URL on
+    `external_verification_redirect_url`. `step` is server-assigned
+    `first`; OAuth never serves as second factor.
   - `SignIn` (second factor) — `totp`, `backup_code`, `phone_code`.
     Only legal when the parent SignIn is in `needs_second_factor`; the
     server narrows `SignIn.supported_strategies` to the second-factor
@@ -29,8 +34,9 @@ description: |
     explicitly to target a different reserved-for-MFA row.
   - `SignUp` — `email_code`, `email_link`, `phone_code`,
     `oauth_<provider_key>`, `ticket`, `transfer`. Sign-up never gains
-    a second factor — the `phone_code` here is the first-factor phone-
-    attribute path.
+    a second factor — the `phone_code` here is the first-factor
+    phone-attribute path; `oauth_<provider_key>` is the first-factor
+    social-sign-up path (subject to `OauthProvider.allow_sign_up`).
   - `EmailAddress` — `email_code`, `email_link`.
   - `PhoneNumber` — `phone_code`. Used by FAPI
     `/v1/me/phone-numbers/{id}/challenges` to verify additional phone
@@ -45,14 +51,18 @@ properties:
       Strategy across all parents:
       `password`, `email_code`, `email_link`, `phone_code`,
       `oauth_<provider_key>`, `reset_password_email_code`, `ticket`,
-      `transfer`, `domain_dns_txt`, `totp`, `backup_code`. Future
-      strategies (passkey) plug in here without spec changes.
+      `transfer`, `domain_dns_txt`, `totp`, `backup_code`.
+      `oauth_<provider_key>` resolves against the environment's
+      `OauthProvider` registry — `<provider_key>` matches
+      `^[a-z][a-z0-9_]*$`. Future strategies (passkey) plug in here
+      without spec changes.
     examples:
       - password
       - email_code
       - email_link
       - phone_code
       - oauth_google
+      - oauth_acme_corp_sso
       - reset_password_email_code
       - ticket
       - transfer
@@ -88,24 +98,38 @@ properties:
     format: uri
     description: |
       For `email_link`, the URL the magic link bounces back to after
-      `clientHandshake` consumes the ticket. Must be on the redirect-URL
-      allowlist. Also used by `oauth_<provider_key>` strategies as the
-      `redirectUrlComplete` the SDK is bounced to once the parent
-      flow finishes.
+      `clientHandshake` consumes the ticket. For
+      `oauth_<provider_key>`, the URL the SDK should land the user on
+      if the IdP redirect comes back with `error` (cancellation,
+      consent denied, scope refused). Must be on the redirect-URL
+      allowlist on both surfaces.
+  redirect_url_complete:
+    type: string
+    format: uri
+    description: |
+      For `oauth_<provider_key>`, the URL the SDK should land the
+      user on after the parent flow finishes successfully (or flips
+      to `transferable`). Must be on the redirect-URL allowlist.
+      Required when `strategy` starts with `oauth_`; ignored
+      otherwise.
 examples:
   - { strategy: password }
   - { strategy: email_code, email_address_id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE }
   - strategy: email_link
     email_address_id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE
     redirect_url: https://app.acme.com/dashboard
+  - strategy: oauth_google
+    redirect_url: https://app.acme.com/sign-in
+    redirect_url_complete: https://app.acme.com/dashboard
+  - strategy: oauth_acme_corp_sso
+    redirect_url: https://app.acme.com/sign-in
+    redirect_url_complete: https://app.acme.com/dashboard
   - strategy: reset_password_email_code
     email_address_id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE
   - { strategy: email_code }
   - { strategy: phone_code }
   - strategy: phone_code
     phone_number_id: phn_01HKX9SY9V7H7TF8C8K7J9X4ZA
-  - strategy: oauth_google
-    redirect_url: https://app.acme.com/dashboard
   - { strategy: domain_dns_txt }
   - { strategy: totp }
   - { strategy: backup_code }

--- a/components/schemas/SignIn.yaml
+++ b/components/schemas/SignIn.yaml
@@ -12,8 +12,42 @@ description: |
 
   v0.1 ships `password` + `email_code` + `reset_password_email_code`
   + `ticket`. v0.2 adds `email_link` (magic link). v0.3 layers MFA on
-  top via the `needs_second_factor` step. OAuth/SAML/passkey land in
-  later milestones.
+  top via the `needs_second_factor` step. v0.4 adds
+  `oauth_<provider_key>` for first-factor social sign-in (see below).
+  SAML / passkey land in later milestones.
+
+  ### OAuth first-factor flow (v0.4, PLAN §9.3 + §9.4)
+
+  `oauth_<provider_key>` is identifier-less — the SDK skips
+  `needs_identifier` and goes straight to issuing a Challenge:
+
+  1. Client `POST .../challenges { strategy: "oauth_<provider_key>",
+     redirect_url, redirect_url_complete }`. The server mints a
+     Challenge with `external_verification_redirect_url` set to the
+     IdP's `/authorize` URL (with a server-signed `state` baked in)
+     and `current_challenge_id` repointed.
+  2. SDK performs a top-level browser navigation to that URL. The
+     server-side handshake of the IdP redirect lands at
+     `/v1/oauth-callback/{provider_key}` — the URL operators register
+     with the IdP. That endpoint flips the Challenge to `verified`
+     (or `transferable`) and 302s the browser back to
+     `redirect_url_complete`.
+  3. SDK reads the parent SignIn from the returning URL and either
+     completes (`status: "complete"`, `created_session_id` set) or
+     follows the cross-flow bounce on `transferable`.
+
+  ### Cross-flow `transferable` (PLAN §9.4)
+
+  - **OAuth sign-in for an unknown identifier** — IdP returned an
+    identity that has no matching `User` and the parent
+    `OauthProvider.allow_sign_up` is `true`. Challenge flips to
+    `transferable`; SDK posts
+    `POST /v1/client/sign-ups { transfer: true }` to mint a SignUp
+    that completes synchronously off the same external account. With
+    `allow_sign_up: false`, the Challenge instead lands `failed` with
+    `oauth_account_does_not_exist`.
+  - **Magic-link sign-in for an unknown identifier** (v0.2) — same
+    `transferable` cross-flow as before.
 
   ### Magic-link cross-device polling (PLAN §9.10)
 
@@ -116,7 +150,12 @@ properties:
 
       - `needs_first_factor` — first-factor strategies the environment
         + identifier support: `password`, `email_code`, `email_link`,
-        `reset_password_email_code`, `ticket`.
+        `reset_password_email_code`, `ticket`, plus an
+        `oauth_<provider_key>` entry for every enabled `OauthProvider`
+        row with `allow_sign_in: true` (e.g. `oauth_google`,
+        `oauth_acme_corp_sso`). The OAuth entries surface
+        independently of the supplied `identifier` — they're
+        identifier-less.
       - `needs_second_factor` — narrowed to second-factor strategies
         the resolved user has enrolled. v0.3 surface: `totp`,
         `backup_code`. Each entry maps to whichever of
@@ -131,6 +170,7 @@ properties:
       currently-listed value on the next `POST .../challenges`.
     examples:
       - [password, email_code, email_link, reset_password_email_code]
+      - [password, email_code, oauth_google, oauth_github]
       - [totp, backup_code]
       - [totp]
       - [backup_code]

--- a/components/schemas/SignUp.yaml
+++ b/components/schemas/SignUp.yaml
@@ -12,8 +12,28 @@ description: |
   only have `step: single` challenges — no MFA layered on top.
 
   v0.1 supports email + password sign-ups via `email_code`. v0.2 adds
-  `email_link` (magic link). Phone, OAuth, SAML, and passkey sign-ups
-  ship in later milestones.
+  `email_link` (magic link). v0.4 adds `oauth_<provider_key>` —
+  identifier-less social sign-up that mints a `User` +
+  `ExternalAccount` together. SAML and passkey sign-ups ship in later
+  milestones.
+
+  ### OAuth sign-up flow (v0.4, PLAN §9.3 + §9.4)
+
+  Mirrors the SignIn OAuth flow:
+
+  1. Client `POST .../challenges { strategy: "oauth_<provider_key>",
+     redirect_url, redirect_url_complete }`.
+  2. Server mints a Challenge with
+     `external_verification_redirect_url` set to the IdP authorize
+     URL and `current_challenge_id` repointed.
+  3. SDK navigates the browser to that URL. The IdP redirects back to
+     `/v1/oauth-callback/{provider_key}`, which on success creates the
+     `User` + `ExternalAccount`, advances the SignUp to `complete`,
+     and 302s back to `redirect_url_complete`.
+
+  Subject to `OauthProvider.allow_sign_up` — when `false`, the
+  Challenge lands `failed` with `oauth_account_does_not_exist`
+  instead of creating a new `User`.
 
   ### Magic-link cross-device polling (PLAN §9.10)
 
@@ -64,8 +84,9 @@ properties:
       - `transferable` — the verified identity belongs in the opposite
         flow. v0.2: a sign-up `email_link` was clicked for an address
         that already has a `User` — the SDK should bounce to sign-in
-        with `POST /v1/client/sign-ins { transfer: true }`. v0.4
-        extends this to OAuth.
+        with `POST /v1/client/sign-ins { transfer: true }`. v0.4: a
+        sign-up via `oauth_<provider_key>` returned an IdP identity
+        that already has an `ExternalAccount` — same bounce.
       - `abandoned` — `abandon_at` passed.
   required_fields:
     type: array
@@ -91,11 +112,15 @@ properties:
     items: { type: string }
     description: |
       Strategies the client may issue next given the sign-up's current
-      state. The server narrows this list as the flow progresses. v0.2
-      surface: `email_code`, `email_link`. Empty when the flow is
-      `complete` or `abandoned`.
+      state. The server narrows this list as the flow progresses.
+      `email_code`, `email_link` — verify the supplied
+      `email_address`. `oauth_<provider_key>` — identifier-less
+      social sign-up; one entry per enabled `OauthProvider` row with
+      `allow_sign_up: true`. Empty when the flow is `complete` or
+      `abandoned`.
     examples:
       - [email_code, email_link]
+      - [email_code, oauth_google, oauth_github]
   current_challenge_id:
     description: |
       Pointer to the live `Challenge` if one's in flight. `null` when

--- a/fapi.yaml
+++ b/fapi.yaml
@@ -80,6 +80,8 @@ paths:
     $ref: ./paths/fapi/client.yaml
   /v1/client/handshake:
     $ref: ./paths/fapi/client-handshake.yaml
+  /v1/oauth-callback/{provider_key}:
+    $ref: ./paths/fapi/oauth-callback.yaml
   /v1/client/sign-ins:
     $ref: ./paths/fapi/sign-ins.yaml
   /v1/client/sign-ins/{sign_in_id}:

--- a/paths/fapi/oauth-callback.yaml
+++ b/paths/fapi/oauth-callback.yaml
@@ -1,0 +1,155 @@
+parameters:
+  - name: provider_key
+    in: path
+    required: true
+    description: |
+      `OauthProvider.provider_key` for the IdP that's redirecting the
+      user back. For presets one of `google` / `github` / `apple` /
+      `microsoft`; for `custom_oidc` / `custom_oauth2` rows the
+      workspace-chosen slug.
+    schema:
+      type: string
+      pattern: "^[a-z][a-z0-9_]*$"
+      maxLength: 64
+
+get:
+  operationId: oauthCallback
+  summary: OAuth IdP redirect target
+  description: |
+    The URL operators register with the IdP — an environment-scoped
+    redirect target hosted at
+    `https://<env_slug>.authn.sh/v1/oauth-callback/<provider_key>`
+    (this exact value is surfaced as `OauthProvider.redirect_uri`).
+    Hosted on the FAPI server but lives outside `/v1/client/...` —
+    the IdP redirect is a top-level browser navigation, not an SDK
+    fetch (PLAN §8.1).
+
+    The server:
+
+    1. Decodes `state` to recover the parent `Client` + the live
+       `Challenge` it bound on
+       `POST .../challenges { strategy: "oauth_<provider_key>" }`.
+       Rejects with `__authn_error=oauth_state_invalid` on any
+       mismatch (replay, cross-environment leak, expired Challenge).
+    2. On `error` / `error_description`, marks the Challenge `failed`
+       and 302s back to the SDK-supplied `redirect_url` with
+       `__authn_error=oauth_user_cancelled` (or the IdP-specific
+       `error` token) and `__authn_error_description` URL-encoded.
+    3. On `code`, exchanges it at the IdP's `token_endpoint`, fetches
+       `userinfo_endpoint` (or reads ID-token claims when the IdP
+       ships everything in the JWT), and runs the
+       find-or-create-by-`provider_user_id` resolver:
+       - **Existing `ExternalAccount`** — flips the parent `SignIn`
+         Challenge to `verified` and advances the parent flow.
+       - **No `ExternalAccount`, but the verified email matches a
+         `User`** — creates the link, then advances the parent
+         `SignIn`.
+       - **No match, parent is `SignUp`** — creates a `User` +
+         `ExternalAccount`, advances the parent `SignUp` to
+         `complete`. Subject to `OauthProvider.allow_sign_up`.
+       - **No match, parent is `SignIn`** — flips Challenge to
+         `transferable`. The SDK reads the parent and bounces to
+         sign-up via `POST /v1/client/sign-ups { transfer: true }`
+         (PLAN §9.4). Subject to `OauthProvider.allow_sign_up`.
+       - **Match exists, parent is `SignUp`** — flips Challenge to
+         `transferable`. The SDK bounces to sign-in via
+         `POST /v1/client/sign-ins { transfer: true }`.
+    4. Always responds with a `302` redirect — to
+       `redirect_url_complete` on success / `transferable` (the SDK
+       resumes the parent flow from there) or to `redirect_url` on
+       failure (with `__authn_error` query params the SDK reads off
+       the URL).
+
+    Security notes: `state` is signed by the env's session key with a
+    60s TTL, binding `client_id` + `sign_in_id` / `sign_up_id` +
+    `verification_id` so a leaked authorize URL cannot be replayed
+    against a different flow.
+  tags: [Sign-Ins]
+  security: []
+  parameters:
+    - name: state
+      in: query
+      required: true
+      description: |
+        Server-issued nonce binding `client_id` + parent attempt id +
+        challenge id. Signed by the environment's session key with a
+        60-second TTL.
+      schema:
+        type: string
+        maxLength: 2048
+    - name: code
+      in: query
+      required: false
+      description: |
+        Authorization code returned by the IdP on success. Mutually
+        exclusive with `error` — exactly one is set per callback.
+      schema:
+        type: string
+        maxLength: 2048
+    - name: error
+      in: query
+      required: false
+      description: |
+        IdP-supplied error token (e.g. `access_denied`,
+        `unauthorized_client`). Triggers a redirect to `redirect_url`
+        with `__authn_error=oauth_user_cancelled`.
+      schema:
+        type: string
+        maxLength: 256
+    - name: error_description
+      in: query
+      required: false
+      description: Human-readable error detail; surfaced to the SDK URL-encoded.
+      schema:
+        type: string
+        maxLength: 1024
+  responses:
+    "200":
+      description: |
+        Fallback rendering when the request `Accept`s
+        `application/json` (e.g. an SSR proxy or a debugging curl).
+        The body carries the same redirect target the browser case
+        gets via `Location`. Not the typical browser path — see the
+        `302` response.
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            required: [object, redirect_url]
+            properties:
+              object:
+                type: string
+                const: oauth_callback_result
+              redirect_url:
+                type: string
+                format: uri
+                description: Where the SDK should bounce the user next.
+    "302":
+      description: |
+        Browser case — redirect to the SDK-supplied URL. `Location`
+        is the resolved `redirect_url_complete` on success /
+        `transferable`, or the `redirect_url` (carrying
+        `__authn_error` + `__authn_status` query params) on failure.
+      headers:
+        Location:
+          description: |
+            Where to bounce the browser. Always an HTTPS URL on the
+            redirect-URL allowlist; never the IdP again.
+          required: true
+          schema:
+            type: string
+            format: uri
+    "400":
+      description: Malformed callback (missing `state`, neither `code` nor `error`, …).
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ErrorResponse.yaml }
+    "404":
+      description: |
+        The `provider_key` does not resolve to an enabled
+        `OauthProvider` row on this environment. Operators landing
+        here should re-check their IdP-side redirect-URI registration.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ErrorResponse.yaml }


### PR DESCRIPTION
## Summary

- `ChallengeCreateRequest` describes the `oauth_<provider_key>` variant — required `redirect_url` (failure landing) and `redirect_url_complete` (success landing). Server stamps `step: "first"`; OAuth never serves as second factor.
- New FAPI path `GET /v1/oauth-callback/{provider_key}` (`oauthCallback`). Hosted on the FAPI server but lives outside `/v1/client/...` — the IdP redirect is a top-level browser navigation, not an SDK fetch. Documented response shapes: `200` (JSON fallback) + `302` (browser redirect to the SDK-supplied URL) + `400` / `404`.
- `SignIn` / `SignUp` describe the OAuth flow end-to-end: identifier-less Challenge issuance, `external_verification_redirect_url` carrying the IdP authorize URL, `transferable` cross-flow (sign-in for unknown identity → bounce to sign-up; sign-up for existing identity → bounce to sign-in). `supported_strategies[]` gains one `oauth_<provider_key>` entry per enabled `OauthProvider`, gated by `allow_sign_in` / `allow_sign_up`.

The `200` response on `oauthCallback` is a fallback for non-browser callers (`Accept: application/json`); the typical browser path returns `302`. Both are documented so the redocly `operation-2xx-response` rule passes without suppression.

Closes #43

## Test plan

- [x] `npm run lint` clean (BAPI + FAPI).
- [x] `npm run bundle` succeeds.
- [x] Bundled `fapi.bundled.json` has `oauthCallback` under `/v1/oauth-callback/{provider_key}`, tagged `Sign-Ins`.
- [x] Bundled `Challenge.strategy` description includes `oauth_<provider_key>`.