### PR TITLE
Add BAPI /v1/sms-templates + Environment.sms + v0.4 webhook events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@
   - `GET /v1/me/phone-numbers` (`listMyPhoneNumbers`), `POST /v1/me/phone-numbers` (`createMyPhoneNumber`), `GET /v1/me/phone-numbers/{id}` (`getMyPhoneNumber`), `PATCH /v1/me/phone-numbers/{id}` (`updateMyPhoneNumber`), `DELETE /v1/me/phone-numbers/{id}` (`deleteMyPhoneNumber`). Delete refuses (`409 phone_reserved_for_second_factor`) while the row is committed to MFA — clear the flag first. Verification of an unverified row is driven by issuing a `phone_code` `Challenge` against the parent sign-in / sign-up flow.
   - `GET /v1/me/external-accounts` (`listMyExternalAccounts`), `GET /v1/me/external-accounts/{id}` (`getMyExternalAccount`), `DELETE /v1/me/external-accounts/{id}` (`deleteMyExternalAccount`). No `POST` — `ExternalAccount` rows are created exclusively by the OAuth callback flow. Delete makes a best-effort revocation against the IdP's `revocation_endpoint` (when present); failure does not block local deletion.
 
+- **SMS infrastructure + v0.4 webhook events (v0.4)**.
+  - `SmsTemplate` (`tmpl_` prefix) — per-environment SMS body customization for `verification_code` / `reset_password_code` / `invitation` slugs. Each row carries a Liquid-style `body`, a `delivered_by_us` toggle (`false` hands sending off to the operator's webhook), and a per-template `from_number_override`.
+  - `SmsTemplateRequest` — PATCH body. All keys optional.
+  - BAPI `GET /v1/sms-templates` (`listSmsTemplates`), `GET /v1/sms-templates/{slug}` (`getSmsTemplate`), `PATCH /v1/sms-templates/{slug}` (`updateSmsTemplate`), `POST /v1/sms-templates/{slug}/revert` (`revertSmsTemplate` — reset body + flags to platform defaults).
+  - `Environment.sms` block — `driver` (`twilio` / `vonage` / `null`), `from_number` (E.164), and per-driver credentials. `auth_token` (Twilio) / `api_secret` (Vonage) are write-only; encrypted at rest, never returned by any GET on either surface. The FAPI bootstrap strips the per-driver credential blocks entirely.
+  - `WebhookEvent.type` enum gains `oauthProvider.{created,updated,deleted}` (payload: `OauthProvider`, `client_secret` stripped), `externalAccount.{connected,unlinked}` (payload: `ExternalAccount`, IdP tokens stripped), `phoneNumber.{created,verified,removed}` (payload: `PhoneNumber`).
+
 - **Multi-factor authentication surface (v0.3)**.
   - `TotpSecret` (one per `User`, `totp_` prefix) and `BackupCode` (`bcc_` prefix) resource schemas, plus `BackupCodeBatch` envelope for the one-time plaintext reveal.
   - `Challenge.strategy` enum gains `totp` and `backup_code`. `ChallengeCreateRequest` documents the second-factor variants (no extra fields needed beyond `strategy`); `ChallengeAnswerRequest` documents the `{ code }` answer shape for both.

--- a/bapi.yaml
+++ b/bapi.yaml
@@ -63,6 +63,8 @@ tags:
     description: Per-environment settings (`InstanceSetting`).
   - name: OAuth Providers
     description: Per-environment social-IdP configuration (`OauthProvider`).
+  - name: SMS Templates
+    description: Per-environment outbound SMS body customization (`SmsTemplate`).
   - name: Webhooks
     description: Webhook endpoints, deliveries, and the event envelope.
 
@@ -170,6 +172,12 @@ paths:
     $ref: ./paths/bapi/oauth-provider.yaml
   /v1/oauth-providers/{oauth_provider_id}/test:
     $ref: ./paths/bapi/oauth-provider-test.yaml
+  /v1/sms-templates:
+    $ref: ./paths/bapi/sms-templates.yaml
+  /v1/sms-templates/{sms_template_slug}:
+    $ref: ./paths/bapi/sms-template.yaml
+  /v1/sms-templates/{sms_template_slug}/revert:
+    $ref: ./paths/bapi/sms-template-revert.yaml
   /v1/webhooks/endpoints:
     $ref: ./paths/bapi/webhook-endpoints.yaml
   /v1/webhooks/endpoints/{endpoint_id}:
@@ -255,6 +263,8 @@ components:
     OauthProvider:                             { $ref: ./components/schemas/OauthProvider.yaml }
     OauthProviderRequest:                      { $ref: ./components/schemas/OauthProviderRequest.yaml }
     OauthProviderTestResult:                   { $ref: ./components/schemas/OauthProviderTestResult.yaml }
+    SmsTemplate:                               { $ref: ./components/schemas/SmsTemplate.yaml }
+    SmsTemplateRequest:                        { $ref: ./components/schemas/SmsTemplateRequest.yaml }
 
   responses:
     BadRequest:           { $ref: ./components/responses/BadRequest.yaml }

--- a/components/schemas/Environment.yaml
+++ b/components/schemas/Environment.yaml
@@ -14,6 +14,7 @@ required:
   - captcha
   - localization
   - oauth_providers
+  - sms
   - paths
   - sessions
   - created_at
@@ -209,3 +210,78 @@ properties:
     items:
       type: object
       additionalProperties: true
+  sms:
+    type: object
+    description: |
+      Per-environment outbound SMS configuration. The FAPI bootstrap
+      strips every credential field — `auth_token` and `api_secret`
+      are write-only on BAPI's `Environment` patch and never appear
+      in any GET response (BAPI or FAPI). The FAPI surface only
+      exposes `driver` + `from_number` so the SDK can render the
+      correct UI affordances (e.g. show the phone-MFA toggle only
+      when a driver is configured).
+
+      `driver: null` means SMS sends are dropped with a no-op
+      audit-log entry — useful in dev environments that don't have a
+      Twilio / Vonage account wired up.
+    additionalProperties: false
+    required: [driver, from_number]
+    properties:
+      driver:
+        type: [string, "null"]
+        enum: [twilio, vonage, null]
+        description: |
+          Which carrier driver to use. `null` disables sends.
+      from_number:
+        type: [string, "null"]
+        pattern: "^\\+[1-9][0-9]{1,14}$"
+        maxLength: 16
+        description: |
+          E.164 number / short code messages are sent from. Falls
+          through to per-template `from_number_override` when set.
+      twilio:
+        type: [object, "null"]
+        additionalProperties: false
+        description: |
+          Twilio credentials. Returned on BAPI `GET /v1/instance` with
+          `auth_token` redacted; the FAPI bootstrap omits this block
+          entirely. `null` when `driver != "twilio"`.
+        properties:
+          account_sid:
+            type: string
+            maxLength: 64
+            description: Twilio Account SID. Public — safe to read.
+          auth_token:
+            type: [string, "null"]
+            writeOnly: true
+            maxLength: 64
+            description: |
+              Twilio Auth Token. Write-only — accepted on
+              `PATCH /v1/instance`, encrypted at rest, never returned
+              by any GET. Send `null` to clear the stored token.
+          messaging_service_sid:
+            type: [string, "null"]
+            maxLength: 64
+            description: |
+              Optional Twilio Messaging Service SID. When set, Twilio
+              uses the service's pool of numbers instead of
+              `from_number`.
+      vonage:
+        type: [object, "null"]
+        additionalProperties: false
+        description: |
+          Vonage (Nexmo) credentials. Same write-only / read-stripping
+          rules as `twilio`. `null` when `driver != "vonage"`.
+        properties:
+          api_key:
+            type: string
+            maxLength: 64
+            description: Vonage API key. Public — safe to read.
+          api_secret:
+            type: [string, "null"]
+            writeOnly: true
+            maxLength: 64
+            description: |
+              Vonage API secret. Write-only — accepted on
+              `PATCH /v1/instance`, encrypted at rest, never returned
+              by any GET. Send `null` to clear the stored secret.

--- a/components/schemas/SmsTemplate.yaml
+++ b/components/schemas/SmsTemplate.yaml
@@ -1,0 +1,121 @@
+type: object
+description: |
+  Per-environment SMS body customization for one of a fixed set of
+  outbound message slugs (verification codes, password resets,
+  invitations). Each environment is seeded with a default row per slug
+  on creation; operators edit the body or flip `delivered_by_us` to
+  hand off sending to their own webhook.
+
+  ### Slugs
+
+  - `verification_code` — first-factor sign-up phone verification
+    + standalone `PhoneNumber` verification + second-factor SMS MFA.
+    The `phone_code` strategy renders this template.
+  - `reset_password_code` — SMS variant of the password-reset flow
+    (when the env's `reset_password` strategy is configured to use
+    SMS rather than email). Reserved for v0.5; the row exists in
+    v0.4 so operators can prep their copy.
+  - `invitation` — operator-driven invitation SMS. Mirrors
+    `Invitation` (v0.1) but for phone-based invites; reserved for
+    v0.5.
+
+  ### Body templating
+
+  `body` is a Liquid-style template with `{{placeholder}}`
+  interpolation. Standard placeholders:
+
+  - `{{otp_code}}` — the 6-digit numeric code (verification +
+    reset).
+  - `{{app.name}}` — the environment's `display_config.application_name`.
+  - `{{app.url}}` — the environment's `display_config.home_url`.
+  - `{{user.first_name}}` / `{{user.last_name}}` — when the message
+    has a known recipient.
+  - `{{ttl_minutes}}` — how long the code remains valid (currently
+    fixed at 10 minutes for `verification_code`).
+
+  Unknown placeholders render as the empty string.
+
+  ### `delivered_by_us`
+
+  When `true` (default), authn.sh's SMS engine sends the message via
+  the env's `Environment.sms.driver`. When `false`, the engine emits
+  an `sms.queued` audit-log entry and a webhook event but does not
+  call any driver — the operator's webhook handler is expected to
+  take over and send the SMS through their own carrier relationship.
+
+  ### Identifier
+
+  ID prefix `tmpl_` (e.g. `tmpl_01HKX9SY9V7H7TF8C8K7J9X4ZA`). Shared
+  with future `EmailTemplate` rows.
+required:
+  - id
+  - object
+  - slug
+  - body
+  - delivered_by_us
+  - from_number_override
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: sms_template
+  slug:
+    type: string
+    enum: [verification_code, reset_password_code, invitation]
+    description: |
+      Stable identifier the SMS engine looks up at send time.
+      Immutable on the row.
+  body:
+    type: string
+    maxLength: 1600
+    description: |
+      Liquid-style template body. The 1600-char ceiling matches the
+      multi-segment SMS upper bound; messages over 160 chars
+      auto-split into multiple segments at the carrier.
+    examples:
+      - "Your {{app.name}} verification code is {{otp_code}}. It expires in {{ttl_minutes}} minutes."
+      - "{{user.first_name}}, your one-time code: {{otp_code}}"
+  delivered_by_us:
+    type: boolean
+    default: true
+    description: |
+      When `true` (the default), authn.sh sends the SMS via the env's
+      `Environment.sms.driver`. When `false`, the operator handles
+      sending via webhook — the server emits an `sms.queued` event
+      but does not call any driver.
+  from_number_override:
+    type: [string, "null"]
+    pattern: "^\\+[1-9][0-9]{1,14}$"
+    maxLength: 16
+    description: |
+      Per-template override of `Environment.sms.from_number` in E.164
+      form. Useful when `verification_code` should send from a
+      branded short code while `invitation` uses a long-form number.
+      `null` falls through to the env default.
+    examples:
+      - "+15555550100"
+  created_at:
+    $ref: ./Timestamp.yaml
+  updated_at:
+    $ref: ./Timestamp.yaml
+examples:
+  - id: tmpl_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    object: sms_template
+    slug: verification_code
+    body: "Your {{app.name}} verification code is {{otp_code}}. It expires in {{ttl_minutes}} minutes."
+    delivered_by_us: true
+    from_number_override: null
+    created_at: 1714723000000
+    updated_at: 1714723000000
+  - id: tmpl_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    object: sms_template
+    slug: invitation
+    body: "{{user.first_name}}, you've been invited to {{app.name}}. Tap to join: {{app.url}}/accept-invite"
+    delivered_by_us: false
+    from_number_override: "+15555550111"
+    created_at: 1714723000000
+    updated_at: 1714896500000

--- a/components/schemas/SmsTemplateRequest.yaml
+++ b/components/schemas/SmsTemplateRequest.yaml
@@ -1,0 +1,34 @@
+type: object
+description: |
+  Body for `PATCH /v1/sms-templates/{slug}`. All fields optional —
+  only the supplied keys are updated. `slug` itself is immutable
+  (it's the URL parameter); `id`, `created_at`, and `updated_at` are
+  computed.
+additionalProperties: false
+properties:
+  body:
+    type: string
+    maxLength: 1600
+    description: |
+      Liquid-style template body. Multi-segment SMS upper bound;
+      messages over 160 chars auto-split into multiple segments at
+      the carrier.
+  delivered_by_us:
+    type: boolean
+    description: |
+      When `false`, the operator handles sending via webhook —
+      authn.sh emits the `sms.queued` event but does not call any
+      driver.
+  from_number_override:
+    type: [string, "null"]
+    pattern: "^\\+[1-9][0-9]{1,14}$"
+    maxLength: 16
+    description: |
+      Per-template override of `Environment.sms.from_number` in
+      E.164. `null` clears the override and falls through to the env
+      default.
+examples:
+  - body: "Your {{app.name}} code: {{otp_code}}"
+  - delivered_by_us: false
+  - body: "{{user.first_name}}, your one-time code: {{otp_code}}"
+    from_number_override: "+15555550100"

--- a/components/schemas/WebhookEvent.yaml
+++ b/components/schemas/WebhookEvent.yaml
@@ -52,10 +52,11 @@ properties:
     description: |
       Stable event type identifier. v0.1 shipped the `user.*`,
       `session.*`, `email.*`, and `invitation.*` events. v0.2 adds the
-      organization, role, and permission events listed below.
+      organization, role, and permission events. v0.4 adds the
+      social-IdP, external-account, and phone-number events.
 
-      Future surfaces (OAuth, enterprise SSO, SCIM) will be added
-      additively under their own milestones.
+      Future surfaces (enterprise SSO, SCIM) will be added additively
+      under their own milestones.
     enum:
       # v0.1
       - user.created
@@ -92,6 +93,15 @@ properties:
       - permission.created
       - permission.updated
       - permission.deleted
+      # v0.4
+      - oauthProvider.created
+      - oauthProvider.updated
+      - oauthProvider.deleted
+      - externalAccount.connected
+      - externalAccount.unlinked
+      - phoneNumber.created
+      - phoneNumber.verified
+      - phoneNumber.removed
   data:
     description: |
       The resource snapshot. Concrete shape depends on `type`:
@@ -110,6 +120,12 @@ properties:
       - `role.*` → `Role`
       - `permission.*` → `Permission` (custom permissions only —
         system permissions are seeded and don't emit lifecycle events)
+      - `oauthProvider.*` → `OauthProvider` (`client_secret` is never
+        in the payload — encrypted at rest, write-only)
+      - `externalAccount.*` → `ExternalAccount` (the IdP-issued
+        `access_token` / `refresh_token` / `id_token` are never in the
+        payload either)
+      - `phoneNumber.*` → `PhoneNumber`
     oneOf:
       - $ref: ./User.yaml
       - $ref: ./Session.yaml
@@ -122,6 +138,9 @@ properties:
       - $ref: ./OrganizationMembershipRequest.yaml
       - $ref: ./Role.yaml
       - $ref: ./Permission.yaml
+      - $ref: ./OauthProvider.yaml
+      - $ref: ./ExternalAccount.yaml
+      - $ref: ./PhoneNumber.yaml
   timestamp:
     $ref: ./Timestamp.yaml
   instance_id:

--- a/paths/bapi/sms-template-revert.yaml
+++ b/paths/bapi/sms-template-revert.yaml
@@ -1,0 +1,27 @@
+parameters:
+  - name: sms_template_slug
+    in: path
+    required: true
+    schema:
+      type: string
+      enum: [verification_code, reset_password_code, invitation]
+
+post:
+  operationId: revertSmsTemplate
+  summary: Revert an SMS template to default
+  description: |
+    Reset `body`, `delivered_by_us`, and `from_number_override` to
+    the platform-shipped defaults for this slug. Useful when an
+    operator wants to undo customization without retyping the
+    original copy.
+  tags: [SMS Templates]
+  parameters:
+    - $ref: ../../components/parameters/IdempotencyKeyHeader.yaml
+  responses:
+    "200":
+      description: The reverted SMS template.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/SmsTemplate.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }

--- a/paths/bapi/sms-template.yaml
+++ b/paths/bapi/sms-template.yaml
@@ -1,0 +1,62 @@
+parameters:
+  - name: sms_template_slug
+    in: path
+    required: true
+    description: |
+      The template slug. One of `verification_code`,
+      `reset_password_code`, `invitation`. Convention copied from
+      `/v1/email-templates/{email_template_slug}` (when that ships).
+    schema:
+      type: string
+      enum: [verification_code, reset_password_code, invitation]
+
+get:
+  operationId: getSmsTemplate
+  summary: Get an SMS template
+  description: Fetch a single SMS template by slug.
+  tags: [SMS Templates]
+  responses:
+    "200":
+      description: The SMS template.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/SmsTemplate.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+
+patch:
+  operationId: updateSmsTemplate
+  summary: Update an SMS template
+  description: |
+    Patch any of `body`, `delivered_by_us`, or `from_number_override`.
+    Omitted keys are left untouched. The slug is immutable — to "switch
+    template", use `PATCH` to overwrite the body in place. To restore
+    the seeded default, use `revertSmsTemplate`.
+  tags: [SMS Templates]
+  parameters:
+    - $ref: ../../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../../components/schemas/SmsTemplateRequest.yaml }
+        examples:
+          edit_body:
+            summary: Customize the verification-code copy
+            value:
+              body: "Your {{app.name}} login code is {{otp_code}}. Valid for {{ttl_minutes}} minutes."
+          handoff:
+            summary: Stop authn.sh from sending; operator's webhook will handle it
+            value: { delivered_by_us: false }
+          set_from_number:
+            summary: Send from a branded short code
+            value: { from_number_override: "+15555550100" }
+  responses:
+    "200":
+      description: The updated SMS template.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/SmsTemplate.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }

--- a/paths/bapi/sms-templates.yaml
+++ b/paths/bapi/sms-templates.yaml
@@ -1,0 +1,18 @@
+get:
+  operationId: listSmsTemplates
+  summary: List SMS templates
+  description: |
+    All `SmsTemplate` rows for the current environment. Each
+    environment is seeded with one row per slug
+    (`verification_code`, `reset_password_code`, `invitation`) on
+    creation — list always returns exactly those rows, in slug order.
+  tags: [SMS Templates]
+  responses:
+    "200":
+      description: The environment's SMS templates.
+      content:
+        application/json:
+          schema:
+            type: array
+            items: { $ref: ../../components/schemas/SmsTemplate.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }


### PR DESCRIPTION
## Summary

- New `SmsTemplate` schema (`tmpl_` prefix) — per-environment SMS body customization for `verification_code` / `reset_password_code` / `invitation` slugs. Liquid-style `body`, `delivered_by_us` toggle (when `false`, operator handles sending via webhook), per-template `from_number_override`.
- New `SmsTemplateRequest` PATCH body. All fields optional.
- BAPI paths: `listSmsTemplates`, `getSmsTemplate`, `updateSmsTemplate`, `revertSmsTemplate`. Slug is immutable; `revert` resets body + flags to platform defaults.
- `Environment.sms` block — `driver` (`twilio` / `vonage` / `null`), `from_number` (E.164), per-driver credential blocks. `auth_token` / `api_secret` are write-only, encrypted at rest, and never returned by any GET; the FAPI bootstrap strips the per-driver blocks entirely.
- `WebhookEvent.type` gains `oauthProvider.{created,updated,deleted}` (payload: `OauthProvider`, secret stripped), `externalAccount.{connected,unlinked}` (payload: `ExternalAccount`, IdP tokens never present), `phoneNumber.{created,verified,removed}` (payload: `PhoneNumber`).
- New "SMS Templates" tag wired into `bapi.yaml`.

Closes #46

## Test plan

- [x] `npm run lint` clean (BAPI + FAPI).
- [x] `npm run bundle` succeeds.
- [x] Bundled `bapi.bundled.json` contains all four operations: `listSmsTemplates` / `getSmsTemplate` / `updateSmsTemplate` / `revertSmsTemplate`.
- [x] Bundled `fapi.bundled.json` `Environment.sms` block has `required: [driver, from_number]` and `twilio.auth_token` / `vonage.api_secret` marked `writeOnly: true`.
- [x] Bundled `WebhookEvent.type` enum includes the eight v0.4 event types.