### PR TITLE
OA-9: BAPI /v1/phone-numbers + /v1/external-accounts admin paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@
   - `OauthProviderTestResult` — return shape of the BAPI dry-run probe.
   - `Challenge.strategy` documents `oauth_<provider_key>` as a first-factor value; the IdP authorize URL is surfaced via `external_verification_redirect_url`.
 
+- **BAPI `/v1/phone-numbers` + `/v1/external-accounts` (v0.4)**.
+  - `/v1/phone-numbers` (list/create/get/update/delete) — admin CRUD for phones, filterable by `user_id`. `created` supports `verified: true` + `primary: true` BAPI-privileged shortcuts. `delete` returns `409 phone_reserved_for_second_factor` when the row is committed to MFA.
+  - `/v1/external-accounts` (list/get/delete) — admin read + unlink. `list` filterable by `user_id` + `oauth_provider_id`. `delete` does best-effort IdP `revocation_endpoint` call, then drops the row.
+  - Resolves the SP-2 scope cut (PhoneNumbersManager + ExternalAccountsManager were deferred in the initial v0.4 cut for lack of these paths).
+
 - **BAPI `/v1/oauth-providers` (v0.4)**.
   - `GET /v1/oauth-providers` (`listOauthProviders`), `POST /v1/oauth-providers` (`createOauthProvider`), `GET /v1/oauth-providers/{id}` (`getOauthProvider`), `PATCH /v1/oauth-providers/{id}` (`updateOauthProvider`), `DELETE /v1/oauth-providers/{id}` (`deleteOauthProvider`), `POST /v1/oauth-providers/{id}/test` (`testOauthProvider`). Soft-delete refuses (`409 oauth_provider_in_use`) when `ExternalAccount` rows still link to the provider. `test` returns `200` with `OauthProviderTestResult { authorize_url, userinfo_status, errors }` even when probes fail.
 

--- a/bapi.yaml
+++ b/bapi.yaml
@@ -37,6 +37,10 @@ tags:
     description: End-user identities.
   - name: Email Addresses
     description: User-owned email identifiers and their verification state.
+  - name: Phone Numbers
+    description: User-owned phone identifiers, their verification state, and MFA-reserve flags.
+  - name: External Accounts
+    description: Per-user links to social-IdP `OauthProvider` connections.
   - name: Sessions
     description: Live authenticated sessions across devices (admin view).
   - name: Organizations
@@ -100,6 +104,14 @@ paths:
     $ref: ./paths/bapi/email-addresses.yaml
   /v1/email-addresses/{email_address_id}:
     $ref: ./paths/bapi/email-address.yaml
+  /v1/phone-numbers:
+    $ref: ./paths/bapi/phone-numbers.yaml
+  /v1/phone-numbers/{phone_number_id}:
+    $ref: ./paths/bapi/phone-number.yaml
+  /v1/external-accounts:
+    $ref: ./paths/bapi/external-accounts.yaml
+  /v1/external-accounts/{external_account_id}:
+    $ref: ./paths/bapi/external-account.yaml
   /v1/sessions:
     $ref: ./paths/bapi/sessions.yaml
   /v1/sessions/{session_id}:

--- a/paths/bapi/external-account.yaml
+++ b/paths/bapi/external-account.yaml
@@ -1,0 +1,35 @@
+parameters:
+  - name: external_account_id
+    in: path
+    required: true
+    description: ID of the external account.
+    schema: { $ref: "../../components/schemas/Id.yaml" }
+
+get:
+  operationId: getExternalAccount
+  summary: Get an external account
+  description: Fetch a single `ExternalAccount` by ID.
+  tags: [External Accounts]
+  responses:
+    "200":
+      description: The external account.
+      content:
+        application/json:
+          schema: { $ref: "../../components/schemas/ExternalAccount.yaml" }
+    "401": { $ref: "../../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../../components/responses/NotFound.yaml" }
+
+delete:
+  operationId: deleteExternalAccount
+  summary: Delete an external account
+  description: |
+    Admin unlink — best-effort revoke against the IdP's
+    `revocation_endpoint` when one is configured on the
+    corresponding `OauthProvider`, then drop the local row.
+    Revocation failures don't block deletion.
+  tags: [External Accounts]
+  responses:
+    "204":
+      description: Deleted.
+    "401": { $ref: "../../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../../components/responses/NotFound.yaml" }

--- a/paths/bapi/external-accounts.yaml
+++ b/paths/bapi/external-accounts.yaml
@@ -1,0 +1,35 @@
+get:
+  operationId: listExternalAccounts
+  summary: List external accounts
+  description: |
+    Every `ExternalAccount` row in the environment. Filterable by
+    `user_id` and `oauth_provider_id` so admins can scope to a single
+    user or audit which users are linked to a specific provider.
+  tags: [External Accounts]
+  parameters:
+    - name: user_id
+      in: query
+      required: false
+      description: Filter to external accounts owned by this user.
+      schema: { $ref: "../../components/schemas/Id.yaml" }
+    - name: oauth_provider_id
+      in: query
+      required: false
+      description: Filter to external accounts created via this provider.
+      schema: { $ref: "../../components/schemas/Id.yaml" }
+    - $ref: "../../components/parameters/LimitParam.yaml"
+    - $ref: "../../components/parameters/OffsetParam.yaml"
+  responses:
+    "200":
+      description: Paginated list of external accounts.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [data, total_count]
+            properties:
+              data:
+                type: array
+                items: { $ref: "../../components/schemas/ExternalAccount.yaml" }
+              total_count: { type: integer }
+    "401": { $ref: "../../components/responses/Unauthorized.yaml" }

--- a/paths/bapi/phone-number.yaml
+++ b/paths/bapi/phone-number.yaml
@@ -1,0 +1,66 @@
+parameters:
+  - name: phone_number_id
+    in: path
+    required: true
+    description: ID of the phone number.
+    schema: { $ref: "../../components/schemas/Id.yaml" }
+
+get:
+  operationId: getPhoneNumber
+  summary: Get a phone number
+  description: Fetch a single `PhoneNumber` by ID.
+  tags: [Phone Numbers]
+  responses:
+    "200":
+      description: The phone number.
+      content:
+        application/json:
+          schema: { $ref: "../../components/schemas/PhoneNumber.yaml" }
+    "401": { $ref: "../../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../../components/responses/NotFound.yaml" }
+
+patch:
+  operationId: updatePhoneNumber
+  summary: Update a phone number
+  description: |
+    Mark the phone verified server-side, toggle MFA flags, or promote
+    it to the user's primary phone. Sending an empty body is a no-op.
+  tags: [Phone Numbers]
+  parameters:
+    - $ref: "../../components/parameters/IdempotencyKeyHeader.yaml"
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          allOf:
+            - $ref: "../../components/schemas/PhoneNumberUpdateRequest.yaml"
+            - type: object
+              properties:
+                verified:
+                  type: boolean
+                  description: When `true`, marks the phone verified (BAPI privilege).
+  responses:
+    "200":
+      description: The updated phone number.
+      content:
+        application/json:
+          schema: { $ref: "../../components/schemas/PhoneNumber.yaml" }
+    "401": { $ref: "../../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../../components/responses/NotFound.yaml" }
+    "422": { $ref: "../../components/responses/UnprocessableEntity.yaml" }
+
+delete:
+  operationId: deletePhoneNumber
+  summary: Delete a phone number
+  description: |
+    Hard-delete the phone number. Returns `409` with
+    `phone_reserved_for_second_factor` when the row is currently
+    committed to MFA — clear `reserved_for_second_factor` first.
+  tags: [Phone Numbers]
+  responses:
+    "204":
+      description: Deleted.
+    "401": { $ref: "../../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../../components/responses/NotFound.yaml" }
+    "409": { $ref: "../../components/responses/Conflict.yaml" }

--- a/paths/bapi/phone-numbers.yaml
+++ b/paths/bapi/phone-numbers.yaml
@@ -1,0 +1,65 @@
+get:
+  operationId: listPhoneNumbers
+  summary: List phone numbers
+  description: |
+    Every `PhoneNumber` row in the environment. Filterable by `user_id`
+    so admins can scope down to a single user's phones.
+  tags: [Phone Numbers]
+  parameters:
+    - name: user_id
+      in: query
+      required: false
+      description: Filter to phone numbers belonging to this user.
+      schema: { $ref: "../../components/schemas/Id.yaml" }
+    - $ref: "../../components/parameters/LimitParam.yaml"
+    - $ref: "../../components/parameters/OffsetParam.yaml"
+  responses:
+    "200":
+      description: Paginated list of phone numbers.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [data, total_count]
+            properties:
+              data:
+                type: array
+                items: { $ref: "../../components/schemas/PhoneNumber.yaml" }
+              total_count: { type: integer }
+    "401": { $ref: "../../components/responses/Unauthorized.yaml" }
+
+post:
+  operationId: createPhoneNumber
+  summary: Create a phone number
+  description: |
+    Attach a new phone to a user. By default the row is unverified and
+    `current_challenge_id` is `null`. Pass `verified: true` to mint it
+    already verified — the BAPI is privileged.
+  tags: [Phone Numbers]
+  parameters:
+    - $ref: "../../components/parameters/IdempotencyKeyHeader.yaml"
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          allOf:
+            - $ref: "../../components/schemas/PhoneNumberCreateRequest.yaml"
+            - type: object
+              required: [user_id]
+              properties:
+                user_id: { $ref: "../../components/schemas/Id.yaml" }
+                verified:
+                  type: boolean
+                  description: When `true`, the BAPI marks the row verified immediately. Default `false`.
+                primary:
+                  type: boolean
+                  description: When `true`, promote the new row to the user's primary phone. Default `false`.
+  responses:
+    "201":
+      description: The new phone number.
+      content:
+        application/json:
+          schema: { $ref: "../../components/schemas/PhoneNumber.yaml" }
+    "401": { $ref: "../../components/responses/Unauthorized.yaml" }
+    "422": { $ref: "../../components/responses/UnprocessableEntity.yaml" }


### PR DESCRIPTION
Closes #55.

## Summary

Adds the missing admin-side spec paths so the sdk-php PhoneNumbersManager + ExternalAccountsManager can ship (originally deferred from SP-2).

- `/v1/phone-numbers`: list (filter by `user_id`) + create (BAPI-privileged `verified`/`primary` shortcuts)
- `/v1/phone-numbers/{id}`: get / patch / delete (409 on `reserved_for_second_factor`)
- `/v1/external-accounts`: list (filter by `user_id` + `oauth_provider_id`)
- `/v1/external-accounts/{id}`: get / delete (best-effort IdP revocation)
- Two new BAPI tags: Phone Numbers, External Accounts.

## Test plan
- [x] redocly lint + bundle clean
- [ ] CI green