### PR TITLE
Cut CHANGELOG entry for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - TOTP enrollment-verify is documented as a dedicated endpoint (`POST /v1/me/totp/verify`), distinct from the Challenge sub-resource (which is reserved for parent-bound flows: SignIn / SignUp / EmailAddress / OrganizationDomain).
 
-## [Unreleased]
+## [0.4.0] — 2026-05-11
 
 ### Added
 


### PR DESCRIPTION
Rename `[Unreleased]` → `[0.4.0] — 2026-05-11`. Tag dance follows after merge.