### PR TITLE
OA-1: Passkey resource shape + User.passkeys[] / passkey_count

### DIFF
--- a/bapi.yaml
+++ b/bapi.yaml
@@ -230,6 +230,7 @@ components:
     EmailAddress:                              { $ref: ./components/schemas/EmailAddress.yaml }
     ExternalAccount:                           { $ref: ./components/schemas/ExternalAccount.yaml }
     PhoneNumber:                               { $ref: ./components/schemas/PhoneNumber.yaml }
+    Passkey:                                   { $ref: ./components/schemas/Passkey.yaml }
     User:                                      { $ref: ./components/schemas/User.yaml }
     UserCreateRequest:                         { $ref: ./components/schemas/UserCreateRequest.yaml }
     UserUpdateRequest:                         { $ref: ./components/schemas/UserUpdateRequest.yaml }

--- a/components/schemas/Challenge.yaml
+++ b/components/schemas/Challenge.yaml
@@ -204,8 +204,12 @@ properties:
         signed-in user.
       - `domain_dns_txt`, `email_code` — organization-domain
         verification.
-
-      Future strategies (passkey) plug in here without spec changes.
+      - `passkey` — WebAuthn assertion against an enrolled `Passkey`.
+        First factor on `SignIn` (`step: "first"`). The challenge
+        surfaces the server-issued PublicKeyCredentialRequestOptions
+        (allowed credentials, RP id, user-verification policy) on
+        creation; the SDK runs `navigator.credentials.get(...)` and
+        answers with the attestation response.
     examples:
       - password
       - email_code

--- a/components/schemas/Passkey.yaml
+++ b/components/schemas/Passkey.yaml
@@ -1,0 +1,115 @@
+type: object
+description: |
+  A WebAuthn authenticator credential registered against a `User`. One
+  row per registered authenticator — a user with a hardware key plus a
+  platform authenticator (e.g. Touch ID) has two `Passkey` rows.
+
+  ### Public surface only
+
+  The raw `credential_id` bytes, the COSE-encoded `public_key`, and the
+  authenticator's `sign_count` never appear in any payload. Those are
+  the secret/operational fields the WebAuthn server library reads
+  directly from the database during assertion verification; they're
+  stored encrypted at rest and exposed only inside the server.
+
+  What the SDK sees is the human-facing surface: a `nickname` the user
+  picked, the `transports[]` the authenticator advertised at
+  registration (so the browser can hint the right discovery flow), and
+  an opaque `aaguid` that surfaces the authenticator model when the
+  authenticator chose to attest it.
+
+  ### Identifier
+
+  ID prefix `pkey_` (e.g. `pkey_01HKX9SY9V7H7TF8C8K7J9X4ZA`).
+
+  ### Verification
+
+  A `Passkey` row is created in the unverified state by the registration
+  ceremony's `options` step and flipped to `verified: true` once the
+  matching attestation response is accepted. Unverified rows are
+  garbage-collected if the ceremony is never completed.
+required:
+  - id
+  - object
+  - nickname
+  - transports
+  - aaguid
+  - verified
+  - last_used_at
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: passkey
+  nickname:
+    type: string
+    maxLength: 100
+    description: |
+      User-supplied label so the user can tell their authenticators
+      apart in `<UserProfile />` (`"YubiKey 5C"`, `"MacBook Touch ID"`).
+      Defaults to a server-generated string at registration time if the
+      caller does not supply one.
+  transports:
+    type: array
+    items:
+      type: string
+      enum: [usb, nfc, ble, internal, hybrid]
+    description: |
+      Transports the authenticator advertised at registration. Surfaced
+      verbatim to the browser at assertion time so the WebAuthn UI can
+      hint the right discovery flow (e.g. `internal` for platform
+      authenticators, `usb` for roaming security keys, `hybrid` for
+      cross-device passkey flows). May be empty if the authenticator
+      did not declare any transports.
+  aaguid:
+    type: [string, "null"]
+    format: uuid
+    description: |
+      The Authenticator Attestation GUID — a 128-bit identifier the
+      authenticator chose to disclose, surfacing the authenticator
+      model (e.g. a specific YubiKey SKU, an iCloud Keychain device).
+      `null` when the authenticator returned the zero AAGUID (the
+      common case for platform authenticators that decline to attest a
+      model).
+  verified:
+    type: boolean
+    description: |
+      `true` once the registration ceremony's attestation response was
+      accepted (mirrors `verified_at IS NOT NULL` on the row). `false`
+      while a ceremony is in flight; such rows are garbage-collected if
+      the ceremony is abandoned.
+  last_used_at:
+    description: |
+      Most recent successful assertion (sign-in or step-up) against
+      this credential. `null` until the first successful use after
+      registration.
+    oneOf:
+      - $ref: ./Timestamp.yaml
+      - type: "null"
+  created_at:
+    $ref: ./Timestamp.yaml
+  updated_at:
+    $ref: ./Timestamp.yaml
+examples:
+  - id: pkey_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    object: passkey
+    nickname: YubiKey 5C
+    transports: [usb, nfc]
+    aaguid: ee882879-721c-4913-9775-3dfcce97072a
+    verified: true
+    last_used_at: 1714896500000
+    created_at: 1714723000000
+    updated_at: 1714896500000
+  - id: pkey_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    object: passkey
+    nickname: MacBook Touch ID
+    transports: [internal, hybrid]
+    aaguid: null
+    verified: true
+    last_used_at: null
+    created_at: 1714724000000
+    updated_at: 1714724000000

--- a/components/schemas/SignIn.yaml
+++ b/components/schemas/SignIn.yaml
@@ -14,7 +14,8 @@ description: |
   + `ticket`. v0.2 adds `email_link` (magic link). v0.3 layers MFA on
   top via the `needs_second_factor` step. v0.4 adds
   `oauth_<provider_key>` for first-factor social sign-in (see below).
-  SAML / passkey land in later milestones.
+  v0.5 adds `passkey` (WebAuthn) as an identifier-less first-factor
+  strategy alongside OAuth. SAML lands in a later milestone.
 
   ### OAuth first-factor flow (v0.4, PLAN §9.3 + §9.4)
 
@@ -153,7 +154,8 @@ properties:
         `reset_password_email_code`, `ticket`, plus an
         `oauth_<provider_key>` entry for every enabled `OauthProvider`
         row with `allow_sign_in: true` (e.g. `oauth_google`,
-        `oauth_acme_corp_sso`). The OAuth entries surface
+        `oauth_acme_corp_sso`), plus `passkey` when the environment
+        has WebAuthn enabled. The OAuth and `passkey` entries surface
         independently of the supplied `identifier` — they're
         identifier-less.
       - `needs_second_factor` — narrowed to second-factor strategies
@@ -170,7 +172,7 @@ properties:
       currently-listed value on the next `POST .../challenges`.
     examples:
       - [password, email_code, email_link, reset_password_email_code]
-      - [password, email_code, oauth_google, oauth_github]
+      - [password, email_code, oauth_google, oauth_github, passkey]
       - [totp, backup_code]
       - [totp]
       - [backup_code]

--- a/components/schemas/SignUp.yaml
+++ b/components/schemas/SignUp.yaml
@@ -14,8 +14,10 @@ description: |
   v0.1 supports email + password sign-ups via `email_code`. v0.2 adds
   `email_link` (magic link). v0.4 adds `oauth_<provider_key>` —
   identifier-less social sign-up that mints a `User` +
-  `ExternalAccount` together. SAML and passkey sign-ups ship in later
-  milestones.
+  `ExternalAccount` together. v0.5 adds `passkey` as a documented
+  strategy on completed sign-ups so SDKs can prompt the new user to
+  enroll a passkey immediately. SAML sign-ups land in a later
+  milestone.
 
   ### OAuth sign-up flow (v0.4, PLAN §9.3 + §9.4)
 
@@ -116,8 +118,9 @@ properties:
       `email_code`, `email_link` — verify the supplied
       `email_address`. `oauth_<provider_key>` — identifier-less
       social sign-up; one entry per enabled `OauthProvider` row with
-      `allow_sign_up: true`. Empty when the flow is `complete` or
-      `abandoned`.
+      `allow_sign_up: true`. `passkey` — surfaced post-completion so
+      SDKs can chain a passkey enrollment ceremony on the freshly
+      minted `User`. Empty when the flow is `abandoned`.
     examples:
       - [email_code, email_link]
       - [email_code, oauth_google, oauth_github]

--- a/components/schemas/User.yaml
+++ b/components/schemas/User.yaml
@@ -6,10 +6,10 @@ description: |
   (banned, locked), the lifecycle timestamps, and the three flavours of
   metadata.
 
-  External accounts, enterprise accounts, and passkeys are present in
-  the shape today (as empty arrays before their respective milestones
-  ship) so SDKs can generate stable types up front; the corresponding
-  endpoints land in later milestones (v0.5 / v0.6).
+  External accounts and passkeys are populated by their respective
+  endpoints (`/v1/me/external-accounts`, `/v1/me/passkeys`). Enterprise
+  accounts is reserved for v0.6 and stays an empty array until that
+  milestone ships.
 required:
   - id
   - object
@@ -18,6 +18,7 @@ required:
   - external_accounts
   - enterprise_accounts
   - passkeys
+  - passkey_count
   - has_image
   - password_enabled
   - two_factor_enabled
@@ -97,10 +98,19 @@ properties:
   passkeys:
     type: array
     description: |
-      Reserved for v0.5 (WebAuthn). Always `[]` in v0.1.
+      WebAuthn credentials registered against this user. One row per
+      authenticator — a user with a hardware key plus a platform
+      authenticator (e.g. Touch ID) has two entries. Empty until the
+      user enrolls their first passkey via `/v1/me/passkeys`.
     items:
-      type: object
-      additionalProperties: true
+      $ref: "./Passkey.yaml"
+  passkey_count:
+    type: integer
+    minimum: 0
+    description: |
+      Count of `passkeys[]`. Surfaced separately so UI badges
+      (`<UserButton />`, `<UserProfile />` security tab) can render
+      without forcing the full list to be loaded on cold paths.
   password_enabled:
     type: boolean
     description: |

--- a/fapi.yaml
+++ b/fapi.yaml
@@ -136,6 +136,8 @@ paths:
     $ref: ./paths/fapi/me-external-accounts.yaml
   /v1/me/external-accounts/{external_account_id}:
     $ref: ./paths/fapi/me-external-account.yaml
+  /v1/me/passkeys:
+    $ref: ./paths/fapi/me-passkeys.yaml
   /v1/me/sessions:
     $ref: ./paths/fapi/me-sessions.yaml
   /v1/me/change-password:
@@ -216,6 +218,7 @@ components:
     ErrorResponse:                             { $ref: ./components/schemas/ErrorResponse.yaml }
     EmailAddress:                              { $ref: ./components/schemas/EmailAddress.yaml }
     ExternalAccount:                           { $ref: ./components/schemas/ExternalAccount.yaml }
+    Passkey:                                   { $ref: ./components/schemas/Passkey.yaml }
     PhoneNumber:                               { $ref: ./components/schemas/PhoneNumber.yaml }
     PhoneNumberCreateRequest:                  { $ref: ./components/schemas/PhoneNumberCreateRequest.yaml }
     PhoneNumberUpdateRequest:                  { $ref: ./components/schemas/PhoneNumberUpdateRequest.yaml }

--- a/paths/bapi/user.yaml
+++ b/paths/bapi/user.yaml
@@ -43,6 +43,7 @@ get:
                 external_accounts: []
                 enterprise_accounts: []
                 passkeys: []
+                passkey_count: 0
                 password_enabled: true
                 two_factor_enabled: false
                 totp_enabled: false

--- a/paths/bapi/users.yaml
+++ b/paths/bapi/users.yaml
@@ -129,6 +129,7 @@ get:
                     external_accounts: []
                     enterprise_accounts: []
                     passkeys: []
+                    passkey_count: 0
                     password_enabled: true
                     two_factor_enabled: false
                     totp_enabled: false
@@ -221,6 +222,7 @@ post:
                 external_accounts: []
                 enterprise_accounts: []
                 passkeys: []
+                passkey_count: 0
                 password_enabled: true
                 two_factor_enabled: false
                 totp_enabled: false

--- a/paths/fapi/me-passkeys.yaml
+++ b/paths/fapi/me-passkeys.yaml
@@ -1,0 +1,23 @@
+get:
+  operationId: listMyPasskeys
+  summary: List my passkeys
+  description: |
+    Every `Passkey` row registered against the current user. Powers
+    the security tab on `<UserProfile />`.
+
+    The full management surface — registration ceremony, rename,
+    deletion — is documented under this same path prefix and the
+    `{passkey_id}` sub-resources.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "200":
+      description: My passkeys.
+      content:
+        application/json:
+          schema:
+            type: array
+            items: { $ref: ../../components/schemas/Passkey.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }

--- a/paths/fapi/me.yaml
+++ b/paths/fapi/me.yaml
@@ -34,6 +34,7 @@ get:
                 external_accounts: []
                 enterprise_accounts: []
                 passkeys: []
+                passkey_count: 0
                 password_enabled: true
                 two_factor_enabled: false
                 totp_enabled: false


### PR DESCRIPTION
Closes #59

## Summary

- Add `components/schemas/Passkey.yaml` (`id`, `nickname`, `transports[]`, `aaguid`, `verified`, `last_used_at`, timestamps). Raw `credential_id`, `public_key`, `sign_count` never appear in payloads — server-side encrypted blobs only.
- `User.passkeys[]` now refs `Passkey` instead of a placeholder object. Add `User.passkey_count` so cold-path UI badges (`<UserButton />`, `<UserProfile />` security tab) don't need to load the full list.
- `Challenge.strategy` description gains a documented `passkey` entry (first-factor WebAuthn assertion). `SignIn` / `SignUp` `supported_strategies` docs surface `passkey` so SDKs know to advertise it.
- Stub `paths/fapi/me-passkeys.yaml` (GET list only) wires `Passkey.yaml` into the bundle — SDK codegen consumers see the type before the full management surface lands in OA-2.

## Bundle diff vs v0.4.0

- New schema: `Passkey`
- `User` required adds `passkey_count`; `User.passkeys[]` shape replaced (was free-form `object`, now `Passkey`).
- `Passkey` registered under both `bapi.yaml` and `fapi.yaml` schemas.
- Adds path `/v1/me/passkeys` (GET-only stub).