### PR TITLE
OA-4: Appearance shape + BAPI /v1/instance/appearance + Environment.appearance

### DIFF
--- a/bapi.yaml
+++ b/bapi.yaml
@@ -178,6 +178,8 @@ paths:
     $ref: ./paths/bapi/instance-restrictions.yaml
   /v1/instance/organization-settings:
     $ref: ./paths/bapi/instance-organization-settings.yaml
+  /v1/instance/appearance:
+    $ref: ./paths/bapi/instance-appearance.yaml
   /v1/oauth-providers:
     $ref: ./paths/bapi/oauth-providers.yaml
   /v1/oauth-providers/{oauth_provider_id}:
@@ -245,6 +247,7 @@ components:
     BlocklistIdentifier:                       { $ref: ./components/schemas/BlocklistIdentifier.yaml }
     RedirectUrl:                               { $ref: ./components/schemas/RedirectUrl.yaml }
     InstanceSettings:                          { $ref: ./components/schemas/InstanceSettings.yaml }
+    Appearance:                                { $ref: ./components/schemas/Appearance.yaml }
     AttributeSetting:                          { $ref: ./components/schemas/AttributeSetting.yaml }
     InstanceUpdateRequest:                     { $ref: ./components/schemas/InstanceUpdateRequest.yaml }
     RestrictionsUpdateRequest:                 { $ref: ./components/schemas/RestrictionsUpdateRequest.yaml }

--- a/components/schemas/Appearance.yaml
+++ b/components/schemas/Appearance.yaml
@@ -1,0 +1,215 @@
+type: object
+description: |
+  Operator-configured visual customisation for the bundled
+  components (`<SignIn />`, `<SignUp />`, `<UserProfile />`, …).
+  Configured once per environment via BAPI; the SDK reads the live
+  copy from `GET /v1/environment` and merges with consumer-supplied
+  props at render time.
+
+  ### Three-axis customisation
+
+  - `variables` — CSS design tokens (colours, fonts, sizing). Loose
+    string typing — the server doesn't validate hex vs. `rgb()` vs.
+    named colours, just round-trips whatever the operator wrote.
+    Tokens are applied as CSS custom properties on the component
+    root.
+  - `elements` — className override map keyed by stable element
+    names. Values are space-separated className strings the SDK
+    appends to the default class list, so consumers can layer their
+    Tailwind / utility classes on top without owning the markup.
+  - `layout` — structural toggles (logo URL, social-buttons
+    placement, optional-field visibility, animation opt-out).
+
+  Every block is optional and partially-specified; SDKs treat
+  missing keys as "use the default".
+
+  ### ETag
+
+  The `/v1/environment` response wraps this shape with an `etag` so
+  the SDK can short-circuit re-renders when the config hasn't
+  changed. `etag = sha256(canonical-JSON(appearance))`.
+additionalProperties: false
+properties:
+  variables:
+    type: object
+    description: |
+      CSS design-token map applied as custom properties on the
+      component root. Every value is a free-form CSS string —
+      `"#0a84ff"`, `"rgb(10 132 255)"`, `"royalblue"`, `"1rem"`,
+      `"system-ui, sans-serif"` are all valid.
+    additionalProperties: false
+    properties:
+      colorPrimary:
+        type: string
+        description: Primary brand accent (buttons, focus rings, links).
+      colorBackground:
+        type: string
+        description: Card / surface background.
+      colorText:
+        type: string
+        description: Default body text colour.
+      colorTextOnPrimary:
+        type: string
+        description: Text colour rendered on top of `colorPrimary` (e.g. primary button labels).
+      colorInputBackground:
+        type: string
+        description: Form input background.
+      colorInputText:
+        type: string
+        description: Form input text colour.
+      colorDanger:
+        type: string
+        description: Destructive / error accent (delete buttons, validation errors).
+      colorSuccess:
+        type: string
+        description: Success accent (verified states, success banners).
+      colorWarning:
+        type: string
+        description: Warning accent (pending verification, caution banners).
+      colorNeutral:
+        type: string
+        description: Neutral accent (secondary buttons, muted text).
+      fontFamily:
+        type: string
+        description: Default font family for body copy.
+      fontFamilyButtons:
+        type: string
+        description: Override for button typography. Falls back to `fontFamily`.
+      fontSize:
+        type: string
+        description: Base font size (e.g. `"14px"`, `"1rem"`).
+      borderRadius:
+        type: string
+        description: Component corner radius.
+      spacingUnit:
+        type: string
+        description: Spacing scale unit; multiplied for padding/gap.
+  elements:
+    type: object
+    description: |
+      Per-element className override map. Keys are stable element
+      names exposed by the SDK; values are space-separated className
+      strings appended to the default class list. Unknown keys are
+      ignored.
+    additionalProperties:
+      type: string
+    properties:
+      formButtonPrimary:           { type: string }
+      formButtonReset:             { type: string }
+      formFieldInput:              { type: string }
+      formFieldLabel:              { type: string }
+      formFieldErrorText:          { type: string }
+      card:                        { type: string }
+      headerTitle:                 { type: string }
+      headerSubtitle:              { type: string }
+      dividerLine:                 { type: string }
+      dividerText:                 { type: string }
+      socialButtonsBlockButton:    { type: string }
+      socialButtonsProviderIcon:   { type: string }
+      footerActionLink:            { type: string }
+      userPreviewMainIdentifier:   { type: string }
+      userPreviewSecondaryIdentifier: { type: string }
+      userButtonAvatarBox:         { type: string }
+      userButtonPopoverActionButton: { type: string }
+  layout:
+    type: object
+    description: Structural toggles applied to the component shell.
+    additionalProperties: false
+    properties:
+      logoImageUrl:
+        type: [string, "null"]
+        format: uri
+        description: |
+          Image rendered above the card title. `null` to hide the
+          logo entirely (the operator's brand probably lives outside
+          the component).
+      logoLinkUrl:
+        type: [string, "null"]
+        format: uri
+        description: |
+          Where the logo links to when clicked. Defaults to the
+          environment `home_url`.
+      socialButtonsPlacement:
+        type: string
+        enum: [top, bottom]
+        default: top
+        description: |
+          Render the OAuth provider buttons above (`top`) or below
+          (`bottom`) the identifier form.
+      socialButtonsVariant:
+        type: string
+        enum: [blockButton, iconButton]
+        default: blockButton
+        description: |
+          `blockButton` — labelled "Continue with Google" buttons
+          stacked vertically. `iconButton` — icon-only buttons laid
+          out horizontally.
+      showOptionalFields:
+        type: boolean
+        default: true
+        description: |
+          When `false`, fields the environment marks as `optional`
+          (e.g. `first_name`, `last_name`) are hidden on the sign-up
+          form.
+      privacyPageUrl:
+        type: [string, "null"]
+        format: uri
+        description: Linked from the footer / sign-up legal copy.
+      termsPageUrl:
+        type: [string, "null"]
+        format: uri
+        description: Linked from the footer / sign-up legal copy.
+      helpPageUrl:
+        type: [string, "null"]
+        format: uri
+        description: Linked from the help affordance in `<UserProfile />`.
+      animations:
+        type: boolean
+        default: true
+        description: |
+          When `false`, the SDK uses `prefers-reduced-motion`-style
+          static styling regardless of the user agent's setting.
+          Useful for embedded contexts where animation chrome is
+          distracting.
+examples:
+  - {}
+  - variables:
+      colorPrimary: "#0a84ff"
+      colorTextOnPrimary: "#ffffff"
+      borderRadius: "0.5rem"
+    layout:
+      socialButtonsPlacement: top
+      animations: true
+  - variables:
+      colorPrimary: "rgb(10 132 255)"
+      colorBackground: "#0b1220"
+      colorText: "#e6edf3"
+      colorTextOnPrimary: "#ffffff"
+      colorInputBackground: "#111827"
+      colorInputText: "#e6edf3"
+      colorDanger: "#f87171"
+      colorSuccess: "#34d399"
+      colorWarning: "#fbbf24"
+      colorNeutral: "#9ca3af"
+      fontFamily: "Inter, system-ui, sans-serif"
+      fontFamilyButtons: "Inter, system-ui, sans-serif"
+      fontSize: "14px"
+      borderRadius: "0.5rem"
+      spacingUnit: "0.25rem"
+    elements:
+      card: "shadow-2xl border border-slate-700"
+      formButtonPrimary: "tracking-wide uppercase"
+      formFieldInput: "ring-1 ring-slate-700"
+      headerTitle: "text-2xl"
+      socialButtonsBlockButton: "border border-slate-700"
+      footerActionLink: "text-sky-400"
+    layout:
+      logoImageUrl: "https://cdn.acme.com/logo-dark.svg"
+      logoLinkUrl: "https://acme.com"
+      socialButtonsPlacement: bottom
+      socialButtonsVariant: blockButton
+      showOptionalFields: false
+      privacyPageUrl: "https://acme.com/privacy"
+      termsPageUrl: "https://acme.com/terms"
+      helpPageUrl: "https://acme.com/help"
+      animations: true

--- a/components/schemas/Environment.yaml
+++ b/components/schemas/Environment.yaml
@@ -15,6 +15,7 @@ required:
   - localization
   - oauth_providers
   - sms
+  - appearance
   - paths
   - sessions
   - created_at
@@ -210,6 +211,29 @@ properties:
     items:
       type: object
       additionalProperties: true
+  appearance:
+    type: object
+    description: |
+      Operator-configured visual customisation merged with
+      consumer-supplied `appearance` props at render time. Same
+      `Appearance` shape served by BAPI's
+      `GET /v1/instance/appearance`, plus an `etag` so the SDK can
+      cache and short-circuit re-renders.
+    required: [etag]
+    additionalProperties: false
+    properties:
+      etag:
+        type: string
+        description: |
+          `sha256(canonical-JSON(<appearance-without-etag>))`. Stable
+          across reads while the operator's config is unchanged.
+        examples: ["sha256:9c1185a5c5e9fc54612808977ee8f548b2258d31"]
+      variables:
+        $ref: ./Appearance.yaml#/properties/variables
+      elements:
+        $ref: ./Appearance.yaml#/properties/elements
+      layout:
+        $ref: ./Appearance.yaml#/properties/layout
   sms:
     type: object
     description: |

--- a/fapi.yaml
+++ b/fapi.yaml
@@ -226,6 +226,7 @@ components:
     Client:                                    { $ref: ./components/schemas/Client.yaml }
     ClientResponseEnvelope:                    { $ref: ./components/schemas/ClientResponseEnvelope.yaml }
     Environment:                               { $ref: ./components/schemas/Environment.yaml }
+    Appearance:                                { $ref: ./components/schemas/Appearance.yaml }
     Session:                                   { $ref: ./components/schemas/Session.yaml }
     SessionActivity:                           { $ref: ./components/schemas/SessionActivity.yaml }
     SignIn:                                    { $ref: ./components/schemas/SignIn.yaml }

--- a/paths/bapi/instance-appearance.yaml
+++ b/paths/bapi/instance-appearance.yaml
@@ -1,0 +1,110 @@
+get:
+  operationId: getInstanceAppearance
+  summary: Get the appearance configuration
+  description: |
+    Returns the operator-configured `Appearance` for this environment.
+    Missing keys mean "use the SDK default" — an empty `{}` is a
+    completely default-themed install.
+  tags: [Instance]
+  responses:
+    "200":
+      description: Appearance configuration.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/Appearance.yaml }
+          examples:
+            default:
+              summary: Defaults — operator has not set anything yet
+              value: {}
+            brand_color_only:
+              summary: Brand-colour override
+              value:
+                variables:
+                  colorPrimary: "#0a84ff"
+                  colorTextOnPrimary: "#ffffff"
+                layout:
+                  socialButtonsPlacement: top
+            full:
+              summary: Full element-class + variables + layout override
+              value:
+                variables:
+                  colorPrimary: "rgb(10 132 255)"
+                  colorBackground: "#0b1220"
+                  colorText: "#e6edf3"
+                  colorTextOnPrimary: "#ffffff"
+                  fontFamily: "Inter, system-ui, sans-serif"
+                  borderRadius: "0.5rem"
+                elements:
+                  card: "shadow-2xl border border-slate-700"
+                  formButtonPrimary: "tracking-wide uppercase"
+                  formFieldInput: "ring-1 ring-slate-700"
+                  headerTitle: "text-2xl"
+                  socialButtonsBlockButton: "border border-slate-700"
+                  footerActionLink: "text-sky-400"
+                layout:
+                  logoImageUrl: "https://cdn.acme.com/logo-dark.svg"
+                  logoLinkUrl: "https://acme.com"
+                  socialButtonsPlacement: bottom
+                  socialButtonsVariant: blockButton
+                  showOptionalFields: false
+                  privacyPageUrl: "https://acme.com/privacy"
+                  termsPageUrl: "https://acme.com/terms"
+                  helpPageUrl: "https://acme.com/help"
+                  animations: true
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+
+put:
+  operationId: replaceInstanceAppearance
+  summary: Replace the appearance configuration
+  description: |
+    Full replacement — any key not present in the request body is
+    cleared back to its default. Emits
+    `instance.config.appearance_updated`.
+  tags: [Instance]
+  parameters:
+    - $ref: ../../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../../components/schemas/Appearance.yaml }
+  responses:
+    "200":
+      description: The replaced appearance configuration.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/Appearance.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }
+
+patch:
+  operationId: updateInstanceAppearance
+  summary: Patch the appearance configuration
+  description: |
+    Deep-merge update — supplied keys overwrite their counterparts in
+    `variables` / `elements` / `layout`; unsupplied keys are left
+    alone. Send a key with an explicit `null` to clear it back to the
+    default. Emits `instance.config.appearance_updated`.
+  tags: [Instance]
+  parameters:
+    - $ref: ../../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../../components/schemas/Appearance.yaml }
+        examples:
+          recolor:
+            summary: Update only the primary brand colour
+            value:
+              variables:
+                colorPrimary: "#16a34a"
+                colorTextOnPrimary: "#ffffff"
+  responses:
+    "200":
+      description: The updated appearance configuration.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/Appearance.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }


### PR DESCRIPTION
Closes #62

## Summary

- New `components/schemas/Appearance.yaml`: three-axis customisation — `variables` (CSS design tokens; loose string typing for `#hex` / `rgb()` / named colours / lengths), `elements` (className override map keyed by stable element names like `formButtonPrimary`, `card`, `socialButtonsBlockButton`), `layout` (logo URL, social-buttons placement, optional-field visibility, animations toggle).
- New BAPI surface `paths/bapi/instance-appearance.yaml`:
  - `GET /v1/instance/appearance` → `Appearance`
  - `PUT /v1/instance/appearance` body `Appearance` → `Appearance` (full replace)
  - `PATCH /v1/instance/appearance` body `Partial<Appearance>` → `Appearance` (deep merge on `variables` / `elements` / `layout`)
  - Both writes emit `instance.config.appearance_updated` once OA-7 lands.
- `Environment.appearance` gains an `etag` field (`sha256(canonical-JSON(blob))`) so the SDK can short-circuit re-renders.
- Registered `Appearance` under both `bapi.yaml` and `fapi.yaml` schemas.
- Three documented examples on `GET /v1/instance/appearance`: empty default, brand-colour override, full element-class override.

## Bundle diff vs v0.4.0

- New schema: `Appearance`.
- New path: `/v1/instance/appearance` on BAPI.
- `Environment` required-list gains `appearance`; new `etag`-bearing inline shape there.