### PR TITLE
OA-5: Localization shape + BAPI overrides + public catalog endpoint

### DIFF
--- a/bapi.yaml
+++ b/bapi.yaml
@@ -180,6 +180,8 @@ paths:
     $ref: ./paths/bapi/instance-organization-settings.yaml
   /v1/instance/appearance:
     $ref: ./paths/bapi/instance-appearance.yaml
+  /v1/instance/localization:
+    $ref: ./paths/bapi/instance-localization.yaml
   /v1/oauth-providers:
     $ref: ./paths/bapi/oauth-providers.yaml
   /v1/oauth-providers/{oauth_provider_id}:
@@ -248,6 +250,8 @@ components:
     RedirectUrl:                               { $ref: ./components/schemas/RedirectUrl.yaml }
     InstanceSettings:                          { $ref: ./components/schemas/InstanceSettings.yaml }
     Appearance:                                { $ref: ./components/schemas/Appearance.yaml }
+    Localization:                              { $ref: ./components/schemas/Localization.yaml }
+    LocalizationUpdateRequest:                 { $ref: ./components/schemas/LocalizationUpdateRequest.yaml }
     AttributeSetting:                          { $ref: ./components/schemas/AttributeSetting.yaml }
     InstanceUpdateRequest:                     { $ref: ./components/schemas/InstanceUpdateRequest.yaml }
     RestrictionsUpdateRequest:                 { $ref: ./components/schemas/RestrictionsUpdateRequest.yaml }

--- a/components/schemas/Environment.yaml
+++ b/components/schemas/Environment.yaml
@@ -193,16 +193,37 @@ properties:
         type: [string, "null"]
   localization:
     type: object
+    description: |
+      Locale set the SDK is allowed to surface. The actual catalog
+      lives behind `GET /v1/localization/{locale}` (public, cacheable)
+      — this block only surfaces what's needed to pick a locale and
+      key the cache.
+    required: [default_locale, fallback_locale, supported_locales, override_etag]
     additionalProperties: false
     properties:
       default_locale:
         type: string
+        description: BCP-47 tag the SDK falls back to before reading a user preference.
+        examples: ["en-US"]
+      fallback_locale:
+        type: string
+        description: |
+          BCP-47 tag the SDK falls back to per-key when the active
+          locale has no translation for a given key. Typically `en-US`.
         examples: ["en-US"]
       supported_locales:
         type: array
         items:
           type: string
-        examples: [["en-US", "pt-BR", "fr-FR"]]
+        examples: [["en-US", "pt-BR", "es-ES", "fr-FR", "de-DE"]]
+      override_etag:
+        type: string
+        description: |
+          `sha256(canonical-JSON(overrides))`. Mirrors the `ETag`
+          header on `GET /v1/localization/{locale}` so the SDK can
+          treat the env bootstrap as the cache key for every locale
+          fetch.
+        examples: ["sha256:9c1185a5c5e9fc54612808977ee8f548b2258d31"]
   oauth_providers:
     type: array
     description: |

--- a/components/schemas/Localization.yaml
+++ b/components/schemas/Localization.yaml
@@ -1,0 +1,86 @@
+type: object
+description: |
+  Per-environment localization configuration. Stores **overrides
+  only** — the canonical default catalog ships with `@authn-sh/sdk-react`
+  and is merged in at render time. The render-time merge resolves
+  each key as:
+
+  ```
+  default_catalog[locale]
+    ⊕ overrides[locale]                  # operator's per-locale tweak
+    ⊕ default_catalog[fallback_locale]   # used for keys the active locale didn't translate
+    ⊕ overrides[fallback_locale]
+    ⊕ (per-key hard fallback, baked into the SDK)
+  ```
+
+  v0.5 ships canonical catalogs for `en-US`, `pt-BR`, `es-ES`,
+  `fr-FR`, `de-DE`. Operators add new locales by listing them in
+  `supported_locales[]` and providing the catalog under
+  `overrides[locale]` — the SDK refuses to surface a locale that
+  isn't in `supported_locales[]`, even if a partial override exists.
+required:
+  - default_locale
+  - fallback_locale
+  - supported_locales
+  - overrides
+additionalProperties: false
+properties:
+  default_locale:
+    type: string
+    description: |
+      BCP-47 tag. Used when the SDK can't read a user preference (e.g.
+      first paint, unauthenticated pages).
+    examples: ["en-US", "pt-BR"]
+  fallback_locale:
+    type: string
+    description: |
+      BCP-47 tag the SDK falls back to per-key when the active locale
+      doesn't have a translation for a given key. Typically `en-US`.
+    examples: ["en-US"]
+  supported_locales:
+    type: array
+    items:
+      type: string
+    description: |
+      Locales the SDK is allowed to surface in the language picker
+      and to auto-detect from `Accept-Language`. Must include
+      `default_locale` and `fallback_locale`. Locales not present in
+      the bundled default catalog must have a full override blob —
+      the BAPI `PATCH` validator returns `unsupported_locale` if a
+      caller adds an entry here without a matching default or
+      override.
+    examples: [["en-US", "pt-BR", "es-ES"]]
+  overrides:
+    type: object
+    description: |
+      Per-locale operator overrides. Outer key is a BCP-47 locale
+      tag; inner map is dot-keyed canonical keys to translated
+      strings. Unknown keys are rejected by the BAPI validator with
+      `unknown_localization_key`. Setting a key to `null` via
+      `PATCH /v1/instance/localization` removes that single override
+      without affecting the rest of the locale.
+    additionalProperties:
+      type: object
+      additionalProperties:
+        type: string
+      description: Dot-keyed catalog. Keys mirror `sdk-react`'s canonical schema.
+examples:
+  - default_locale: en-US
+    fallback_locale: en-US
+    supported_locales: [en-US, pt-BR, es-ES, fr-FR, de-DE]
+    overrides: {}
+  - default_locale: en-US
+    fallback_locale: en-US
+    supported_locales: [en-US, pt-BR]
+    overrides:
+      en-US:
+        signIn.start.title: "Welcome to Acme"
+        signIn.start.subtitle: "Sign in to continue to your dashboard."
+  - default_locale: pt-BR
+    fallback_locale: en-US
+    supported_locales: [en-US, pt-BR]
+    overrides:
+      pt-BR:
+        signIn.start.title: "Bem-vindo de volta"
+        signIn.start.actionText: "Não tem uma conta?"
+        signIn.start.actionLink: "Criar conta"

--- a/components/schemas/LocalizationUpdateRequest.yaml
+++ b/components/schemas/LocalizationUpdateRequest.yaml
@@ -1,0 +1,27 @@
+type: object
+description: |
+  Body for `PATCH /v1/instance/localization`. Every field is optional.
+
+  - `default_locale` / `fallback_locale` — scalar replace when supplied.
+  - `supported_locales[]` — full-array replace when supplied.
+  - `overrides[locale]` — per-key merge. The inner map merges
+    key-by-key into the existing locale's overrides; sending a
+    string overwrites that key, sending `null` removes it (the SDK
+    falls back to the canonical default). Unknown dot-keyed paths
+    are rejected with `unknown_localization_key`.
+additionalProperties: false
+properties:
+  default_locale:
+    type: string
+  fallback_locale:
+    type: string
+  supported_locales:
+    type: array
+    items:
+      type: string
+  overrides:
+    type: object
+    additionalProperties:
+      type: object
+      additionalProperties:
+        type: [string, "null"]

--- a/fapi.yaml
+++ b/fapi.yaml
@@ -76,6 +76,8 @@ security:
 paths:
   /v1/environment:
     $ref: ./paths/fapi/environment.yaml
+  /v1/localization/{locale}:
+    $ref: ./paths/fapi/localization.yaml
   /v1/client:
     $ref: ./paths/fapi/client.yaml
   /v1/client/handshake:
@@ -227,6 +229,7 @@ components:
     ClientResponseEnvelope:                    { $ref: ./components/schemas/ClientResponseEnvelope.yaml }
     Environment:                               { $ref: ./components/schemas/Environment.yaml }
     Appearance:                                { $ref: ./components/schemas/Appearance.yaml }
+    Localization:                              { $ref: ./components/schemas/Localization.yaml }
     Session:                                   { $ref: ./components/schemas/Session.yaml }
     SessionActivity:                           { $ref: ./components/schemas/SessionActivity.yaml }
     SignIn:                                    { $ref: ./components/schemas/SignIn.yaml }

--- a/paths/bapi/instance-localization.yaml
+++ b/paths/bapi/instance-localization.yaml
@@ -1,0 +1,127 @@
+get:
+  operationId: getInstanceLocalization
+  summary: Get the localization configuration
+  description: |
+    Returns the per-environment localization config — the locale
+    set the SDK is allowed to surface, plus the operator's
+    overrides. The canonical default catalogs are not returned
+    here; they ship with `@authn-sh/sdk-react`.
+  tags: [Instance]
+  responses:
+    "200":
+      description: Localization configuration.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/Localization.yaml }
+          examples:
+            defaults_only:
+              summary: Defaults — no operator overrides
+              value:
+                default_locale: en-US
+                fallback_locale: en-US
+                supported_locales: [en-US, pt-BR, es-ES, fr-FR, de-DE]
+                overrides: {}
+            en_US_override:
+              summary: Single en-US override
+              value:
+                default_locale: en-US
+                fallback_locale: en-US
+                supported_locales: [en-US, pt-BR, es-ES, fr-FR, de-DE]
+                overrides:
+                  en-US:
+                    signIn.start.title: "Welcome to Acme"
+                    signIn.start.subtitle: "Sign in to continue to your dashboard."
+            sparse_pt_BR:
+              summary: Sparse pt-BR override (other keys fall back to canonical)
+              value:
+                default_locale: pt-BR
+                fallback_locale: en-US
+                supported_locales: [en-US, pt-BR]
+                overrides:
+                  pt-BR:
+                    signIn.start.title: "Bem-vindo de volta"
+                    signIn.start.actionText: "Não tem uma conta?"
+                    signIn.start.actionLink: "Criar conta"
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+
+put:
+  operationId: replaceInstanceLocalization
+  summary: Replace the localization configuration
+  description: |
+    Full replacement. Any locale / key not present in the body is
+    cleared. Emits `localization.updated`.
+
+    The validator may reject the request with:
+
+    - `422 invalid_locale_code` — `default_locale`, `fallback_locale`,
+      or an entry of `supported_locales[]` is not a valid BCP-47 tag.
+    - `422 unsupported_locale` — `supported_locales[]` entry has no
+      bundled default catalog and no matching `overrides` entry.
+    - `422 unknown_localization_key` — an override references a
+      dot-keyed path the canonical schema doesn't know about.
+  tags: [Instance]
+  parameters:
+    - $ref: ../../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../../components/schemas/Localization.yaml }
+  responses:
+    "200":
+      description: The replaced localization configuration.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/Localization.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }
+
+patch:
+  operationId: updateInstanceLocalization
+  summary: Patch the localization configuration
+  description: |
+    Sparse partial update. Merge semantics:
+
+    - `default_locale` / `fallback_locale` — scalar replace.
+    - `supported_locales[]` — full-array replace when supplied.
+    - `overrides[locale]` — per-key merge. Sending
+      `{"overrides":{"pt-BR":{"signIn.start.title":"X"}}}` updates
+      only that one key on `pt-BR` and leaves every other `pt-BR`
+      key in place. Send a key with an explicit `null` to remove
+      that single override (the SDK falls back to the canonical
+      default).
+
+    Same validators as `PUT`. Emits `localization.updated`.
+  tags: [Instance]
+  parameters:
+    - $ref: ../../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../../components/schemas/LocalizationUpdateRequest.yaml }
+        examples:
+          add_override:
+            summary: Add a single pt-BR override
+            value:
+              overrides:
+                pt-BR:
+                  signIn.start.title: "Bem-vindo de volta"
+          remove_override:
+            summary: Clear an existing override key (falls back to canonical)
+            value:
+              overrides:
+                pt-BR:
+                  signIn.start.title: null
+          rename_default:
+            summary: Promote pt-BR to the default locale
+            value:
+              default_locale: pt-BR
+  responses:
+    "200":
+      description: The updated localization configuration.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/Localization.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }

--- a/paths/fapi/localization.yaml
+++ b/paths/fapi/localization.yaml
@@ -1,0 +1,100 @@
+parameters:
+  - name: locale
+    in: path
+    required: true
+    description: BCP-47 locale tag (e.g. `en-US`, `pt-BR`).
+    schema:
+      type: string
+      examples: ["en-US", "pt-BR"]
+
+get:
+  operationId: getLocalizationCatalog
+  summary: Get a merged localization catalog
+  description: |
+    Public, unauthenticated, CORS-enabled. Returns the merged
+    catalog (canonical default ⊕ operator overrides) for the
+    requested locale. Used by the SDK at boot to hydrate the
+    bundled components without bundling the full canonical catalog
+    on the consumer side.
+
+    The response is heavily cacheable —
+    `Cache-Control: public, max-age=300, stale-while-revalidate=3600`
+    — and the matching `ETag` mirrors `Environment.localization.override_etag`,
+    so a client that's already holding the env bootstrap can skip
+    re-fetching the catalog until the etag changes.
+  tags: [Environment]
+  security: []
+  responses:
+    "200":
+      description: Merged localization catalog.
+      headers:
+        Cache-Control:
+          schema:
+            type: string
+            examples: ["public, max-age=300, stale-while-revalidate=3600"]
+          description: Always `public, max-age=300, stale-while-revalidate=3600`.
+        ETag:
+          schema:
+            type: string
+            examples: ["\"sha256:9c1185a5c5e9fc54612808977ee8f548b2258d31\""]
+          description: |
+            Strong validator. Mirrors
+            `Environment.localization.override_etag`. Pair with
+            `If-None-Match` on subsequent fetches.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [locale, catalog]
+            additionalProperties: false
+            properties:
+              locale:
+                type: string
+                description: BCP-47 tag the catalog was rendered for. Echoes the path parameter.
+              catalog:
+                type: object
+                description: |
+                  Dot-keyed map of canonical keys to translated
+                  strings. Keys mirror `sdk-react`'s canonical
+                  schema; missing keys mean "let the SDK fall back
+                  per-key".
+                additionalProperties:
+                  type: string
+          examples:
+            pt_BR:
+              summary: A ~30-key sample of the pt-BR catalog
+              value:
+                locale: pt-BR
+                catalog:
+                  signIn.start.title: "Bem-vindo de volta"
+                  signIn.start.subtitle: "Entre para continuar"
+                  signIn.start.actionText: "Não tem uma conta?"
+                  signIn.start.actionLink: "Criar conta"
+                  signIn.password.label: "Senha"
+                  signIn.password.actionLink: "Esqueci minha senha"
+                  signIn.password.placeholder: "••••••••"
+                  signIn.emailCode.title: "Verifique seu email"
+                  signIn.emailCode.subtitle: "Enviamos um código para {identifier}"
+                  signIn.emailCode.resendButton: "Reenviar código"
+                  signIn.phoneCode.title: "Verifique seu telefone"
+                  signIn.phoneCode.subtitle: "Enviamos um código por SMS"
+                  signIn.totpMfa.title: "Insira o código do autenticador"
+                  signIn.backupCodeMfa.title: "Use um código de recuperação"
+                  signIn.alternativeMethods.title: "Use outro método"
+                  signUp.start.title: "Criar conta"
+                  signUp.start.actionText: "Já tem uma conta?"
+                  signUp.start.actionLink: "Entrar"
+                  signUp.emailLink.title: "Verifique seu email"
+                  signUp.emailLink.subtitle: "Clique no link que enviamos"
+                  userButton.action__manageAccount: "Gerenciar conta"
+                  userButton.action__signOut: "Sair"
+                  userProfile.start.headerTitle__account: "Conta"
+                  userProfile.start.headerTitle__security: "Segurança"
+                  userProfile.emailAddressSection.primaryButton: "Adicionar email"
+                  userProfile.passwordSection.primaryButton__updatePassword: "Atualizar senha"
+                  userProfile.totpSection.primaryButton__enableMfa: "Configurar autenticador"
+                  userProfile.passkeySection.primaryButton: "Adicionar passkey"
+                  formButtonPrimary: "Continuar"
+                  formFieldAction__forgotPassword: "Esqueci minha senha"
+    "404":
+      $ref: ../../components/responses/NotFound.yaml


### PR DESCRIPTION
Closes #63

## Summary

- New `components/schemas/Localization.yaml` — `default_locale`, `fallback_locale`, `supported_locales[]`, `overrides[locale][key] = string`. The SDK ships canonical default catalogs; the server stores overrides only and the render-time merge resolves `default ⊕ overrides[active] ⊕ default[fallback] ⊕ overrides[fallback]`.
- New `components/schemas/LocalizationUpdateRequest.yaml` — sparse PATCH body. `default_locale` / `fallback_locale` are scalar-replace; `supported_locales[]` is full-array replace; `overrides[locale]` is per-key merge, with `null` removing a single key without dropping the rest of the locale.
- New BAPI surface `paths/bapi/instance-localization.yaml` — GET / PUT (full replace) / PATCH (sparse merge). Documents `invalid_locale_code`, `unsupported_locale`, `unknown_localization_key` error codes on `422`. Writes emit `localization.updated` once OA-7 lands.
- New public, CORS-enabled FAPI endpoint `paths/fapi/localization.yaml` (`GET /v1/localization/{locale}`) returns the merged catalog with `Cache-Control: public, max-age=300, stale-while-revalidate=3600` and an `ETag` mirroring `Environment.localization.override_etag`. Example response shows a ~30-key pt-BR catalog.
- `Environment.localization` gains `fallback_locale` and `override_etag` alongside the existing default / supported fields.
- Registered `Localization` + `LocalizationUpdateRequest` under both `bapi.yaml` and `fapi.yaml` schemas.

## Bundle diff vs v0.4.0

- New schemas: `Localization`, `LocalizationUpdateRequest`.
- New paths: BAPI `/v1/instance/localization` + FAPI `/v1/localization/{locale}`.
- `Environment.localization` required-list gains `fallback_locale`, `override_etag`.