### PR TITLE
OA-6: Document six new preset OAuth providers

### DIFF
--- a/components/schemas/Challenge.yaml
+++ b/components/schemas/Challenge.yaml
@@ -177,11 +177,13 @@ properties:
         sign-up first factor.
       - `oauth_<provider_key>` — first-factor social sign-in / sign-up.
         `<provider_key>` matches a row in the environment's
-        `OauthProvider` registry (`google`, `github`, `apple`,
-        `microsoft`, or any workspace-registered `custom_oidc` /
-        `custom_oauth2` slug). The challenge surfaces the IdP's
-        authorize URL on `external_verification_redirect_url`; the SDK
-        redirects the browser there and resumes via
+        `OauthProvider` registry (presets: `google`, `github`,
+        `apple`, `microsoft`, `discord`, `facebook`, `linkedin`,
+        `x`, `gitlab`, `slack`; or any workspace-registered
+        `custom_oidc` / `custom_oauth2` slug). The challenge
+        surfaces the IdP's authorize URL on
+        `external_verification_redirect_url`; the SDK redirects the
+        browser there and resumes via
         `/v1/oauth-callback/<provider_key>`.
       - `phone_code` — SMS code, served two ways:
           - **First factor on sign-up** (`step: "single"`) when the
@@ -221,6 +223,15 @@ properties:
       - totp
       - backup_code
       - oauth_google
+      - oauth_github
+      - oauth_apple
+      - oauth_microsoft
+      - oauth_discord
+      - oauth_facebook
+      - oauth_linkedin
+      - oauth_x
+      - oauth_gitlab
+      - oauth_slack
       - phone_code
       - passkey
   status:

--- a/components/schemas/OauthProvider.yaml
+++ b/components/schemas/OauthProvider.yaml
@@ -5,11 +5,44 @@ description: |
   `oauth_<provider_key>` first-factor `Challenge` strategy. Three kinds
   share a single shape:
 
-  - `preset` — bundled IdPs the platform ships with (`google`, `github`,
-    `apple`, `microsoft`). The OIDC discovery fields and default scope
-    set are filled in by the platform on create; the operator only
-    supplies `client_id`, `client_secret`, and any toggles
-    (`enabled`, `allow_sign_in`, …).
+  - `preset` — bundled IdPs the platform ships with. v0.4 ships
+    `google`, `github`, `apple`, `microsoft`; v0.5 adds `discord`,
+    `facebook`, `linkedin`, `x`, `gitlab`, `slack`. The OIDC
+    discovery fields and default scope set are filled in by the
+    platform on create; the operator only supplies `client_id`,
+    `client_secret`, and any toggles (`enabled`, `allow_sign_in`,
+    …).
+
+    Per-preset defaults:
+
+    - **Google** — OIDC discovery at
+      `https://accounts.google.com/.well-known/openid-configuration`.
+      Default scopes `[openid, email, profile]`.
+    - **GitHub** — Plain OAuth 2.0 (GitHub doesn't expose OIDC
+      discovery). Default scopes `[read:user, user:email]`.
+    - **Apple** — OIDC discovery at
+      `https://appleid.apple.com/.well-known/openid-configuration`.
+      Default scopes `[name, email]`.
+    - **Microsoft** — OIDC discovery at
+      `https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration`.
+      Default scopes `[openid, email, profile]`.
+    - **Discord** — Plain OAuth 2.0 (Discord doesn't expose OIDC
+      discovery). Default scopes `[identify, email]`.
+    - **Facebook** — Plain OAuth 2.0 with custom userinfo semantics
+      (the userinfo endpoint requires the `fields` query param to
+      surface email + name). Default scopes
+      `[public_profile, email]`.
+    - **LinkedIn** — OIDC discovery at
+      `https://www.linkedin.com/oauth/.well-known/openid-configuration`.
+      Default scopes `[openid, profile, email]`.
+    - **X** (formerly Twitter) — OAuth 2.0 with PKCE required.
+      Default scopes `[tweet.read, users.read]`.
+    - **GitLab** — OIDC discovery at
+      `https://gitlab.com/.well-known/openid-configuration`. Default
+      scopes `[openid, profile, email]`.
+    - **Slack** — "Sign in with Slack" OIDC discovery at
+      `https://slack.com/.well-known/openid-configuration`. Default
+      scopes `[openid, profile, email]`.
   - `custom_oidc` — workspace-registered OpenID Connect IdP. The
     operator supplies an `issuer` URL; the server fetches and caches
     `<issuer>/.well-known/openid-configuration` and populates the OIDC
@@ -87,13 +120,20 @@ properties:
       Stable slug used in the `oauth_<provider_key>` `Challenge.strategy`
       and in the computed `redirect_uri`. For `provider_kind: "preset"`
       this is one of the bundled values (`google`, `github`, `apple`,
-      `microsoft`). For `custom_oidc` / `custom_oauth2` it's a
+      `microsoft`, `discord`, `facebook`, `linkedin`, `x`, `gitlab`,
+      `slack`). For `custom_oidc` / `custom_oauth2` it's a
       workspace-chosen slug, unique per environment.
     examples:
       - google
       - github
       - apple
       - microsoft
+      - discord
+      - facebook
+      - linkedin
+      - x
+      - gitlab
+      - slack
       - acme_corp_sso
   name:
     type: string


### PR DESCRIPTION
Closes #64

## Summary

- Extend `OauthProvider.provider_key` documentation + examples with the six new preset slugs: `discord`, `facebook`, `linkedin`, `x`, `gitlab`, `slack`. The validator pattern is unchanged — preset rows just use one of the bundled slugs.
- Record per-preset OIDC discovery URLs and default scope sets in `OauthProvider`'s description so server implementers (AU-5) and operators have a single reference. Notes which presets use OAuth 2.0 only (GitHub, Discord, Facebook, X) vs OIDC discovery (Google, Apple, Microsoft, LinkedIn, GitLab, Slack), and flags X's PKCE requirement.
- `Challenge.strategy` description + example list updated to include the new `oauth_<provider_key>` entries so SDK type generators surface them.

## Bundle diff vs v0.4.0

- No schema additions; no new paths.
- `OauthProvider.provider_key` description text expanded; examples list extended from 5 entries to 11.
- `Challenge.strategy` description text expanded; examples list extended.