### PR TITLE
OA-2: FAPI /v1/me/passkeys CRUD + Challenge-based registration

### DIFF
--- a/components/schemas/Challenge.yaml
+++ b/components/schemas/Challenge.yaml
@@ -267,6 +267,17 @@ properties:
           code: { type: string }
           message: { type: string }
       - type: "null"
+  creation_options:
+    description: |
+      Server-built `PublicKeyCredentialCreationOptions` for the
+      passkey *registration* ceremony. Present on challenges
+      created by `POST /v1/me/passkeys/begin-registration`
+      (`strategy: "passkey"`, `mode: "registration"`); `null`
+      otherwise. Stable for the challenge's lifetime so multi-tab
+      clients can resume.
+    oneOf:
+      - $ref: ./PasskeyCreationOptions.yaml
+      - type: "null"
   created_at:
     $ref: ./Timestamp.yaml
   updated_at:

--- a/components/schemas/PasskeyAttestation.yaml
+++ b/components/schemas/PasskeyAttestation.yaml
@@ -1,0 +1,54 @@
+type: object
+description: |
+  WebAuthn `AuthenticatorAttestationResponse` envelope posted back
+  to the server after `navigator.credentials.create(...)` completes.
+  Binary fields are base64url-encoded.
+required:
+  - id
+  - raw_id
+  - response
+  - type
+additionalProperties: false
+properties:
+  id:
+    type: string
+    description: |
+      Credential id as base64url. Same value the authenticator will
+      send on future assertions; the server stores its raw bytes on
+      the `Passkey` row.
+  raw_id:
+    type: string
+    description: |
+      base64url-encoded credential id. Matches `id`; the WebAuthn
+      spec carries it twice (decoded vs raw) so we surface both for
+      strict relaying.
+  response:
+    type: object
+    required: [client_data_json, attestation_object]
+    additionalProperties: false
+    properties:
+      client_data_json:
+        type: string
+        description: |
+          base64url of the `clientDataJSON` blob the browser
+          produced. The server decodes it, checks `type ==
+          "webauthn.create"`, the embedded `challenge` matches the
+          ceremony, and the `origin` is on the allowlist.
+      attestation_object:
+        type: string
+        description: |
+          base64url of the CBOR-encoded `attestationObject`. The
+          server parses it to extract the authenticator data, the
+          new credential's public key, the AAGUID, and (when
+          `attestation != "none"`) the attestation statement.
+  type:
+    type: string
+    const: public-key
+  transports:
+    type: array
+    description: |
+      Transports the authenticator advertised. Carried into the new
+      `Passkey.transports[]`.
+    items:
+      type: string
+      enum: [usb, nfc, ble, internal, hybrid]

--- a/components/schemas/PasskeyBeginRegistrationRequest.yaml
+++ b/components/schemas/PasskeyBeginRegistrationRequest.yaml
@@ -1,0 +1,14 @@
+type: object
+description: |
+  Body for `POST /v1/me/passkeys/begin-registration`. Both fields
+  are optional — the server picks a default `nickname` if the
+  caller doesn't supply one.
+additionalProperties: false
+properties:
+  nickname:
+    type: string
+    maxLength: 100
+    description: |
+      User-supplied label baked onto the resulting `Passkey.nickname`
+      when the ceremony completes. Defaults to a server-generated
+      string when omitted.

--- a/components/schemas/PasskeyCompleteRegistrationRequest.yaml
+++ b/components/schemas/PasskeyCompleteRegistrationRequest.yaml
@@ -1,0 +1,19 @@
+type: object
+description: |
+  Body for `POST /v1/me/passkeys/complete-registration/{challenge_id}`.
+  Carries the authenticator's attestation response plus an optional
+  nickname override (in case the user named the passkey on the
+  client side, after the ceremony started).
+required: [attestation]
+additionalProperties: false
+properties:
+  attestation:
+    $ref: ./PasskeyAttestation.yaml
+  nickname:
+    type: string
+    maxLength: 100
+    description: |
+      Overrides the `nickname` supplied at begin-registration. The
+      stored `Passkey.nickname` defaults to this value when set,
+      else to the begin-registration value, else to a
+      server-generated string.

--- a/components/schemas/PasskeyCreationOptions.yaml
+++ b/components/schemas/PasskeyCreationOptions.yaml
@@ -1,0 +1,154 @@
+type: object
+description: |
+  Server-built `PublicKeyCredentialCreationOptions` envelope for a
+  WebAuthn registration ceremony. Mirrors the WebAuthn L3 spec
+  shape, base64url-encoded where the spec uses `BufferSource`. The
+  SDK passes this verbatim to
+  `navigator.credentials.create({ publicKey })` after URL-safe
+  base64 decoding `challenge`, `user.id`, and every
+  `exclude_credentials[].id`.
+
+  Carried on a `Challenge` body (the registration challenge created
+  by `POST /v1/me/passkeys/begin-registration`) so multi-tab clients
+  can resume the ceremony by re-reading the parent challenge.
+required:
+  - rp
+  - user
+  - challenge
+  - pub_key_cred_params
+  - timeout
+  - attestation
+  - authenticator_selection
+  - exclude_credentials
+additionalProperties: false
+properties:
+  rp:
+    type: object
+    required: [id, name]
+    additionalProperties: false
+    properties:
+      id:
+        type: string
+        description: |
+          RP ID — the effective domain the credential is scoped to
+          (e.g. `acme.com`). Matches `Environment.host` minus the
+          `<env_slug>.` subdomain unless the operator overrode it.
+      name:
+        type: string
+        description: Human-readable RP name displayed by the authenticator UI.
+  user:
+    type: object
+    required: [id, name, display_name]
+    additionalProperties: false
+    properties:
+      id:
+        type: string
+        description: |
+          Opaque, per-environment, per-user handle. base64url-encoded
+          bytes — not the `User.id` ULID directly; surfacing the
+          ULID would leak it to the authenticator.
+      name:
+        type: string
+        description: |
+          Username the authenticator may display alongside the RP
+          name (typically the user's primary email).
+      display_name:
+        type: string
+        description: |
+          Human-readable name the authenticator may show
+          (typically `first_name + last_name`).
+  challenge:
+    type: string
+    description: |
+      base64url-encoded server nonce. The browser includes it in
+      the attestation response; the server checks it on
+      `complete-registration` to bind the response to this exact
+      ceremony.
+  pub_key_cred_params:
+    type: array
+    description: |
+      Algorithms the server will accept, in operator-preference
+      order. Mirrors WebAuthn `PublicKeyCredentialParameters`.
+    items:
+      type: object
+      required: [type, alg]
+      additionalProperties: false
+      properties:
+        type:
+          type: string
+          const: public-key
+        alg:
+          type: integer
+          description: |
+            COSE algorithm identifier. Common values: `-7` (ES256),
+            `-257` (RS256), `-8` (EdDSA).
+          examples: [-7, -257]
+  timeout:
+    type: integer
+    minimum: 1
+    description: Ceremony timeout in milliseconds. Hint to the browser; not enforced server-side.
+    examples: [60000]
+  attestation:
+    type: string
+    enum: [none, indirect, direct, enterprise]
+    default: none
+    description: |
+      Attestation conveyance preference. Defaults to `none` because
+      the server doesn't validate authenticator provenance in v0.5.
+  authenticator_selection:
+    type: object
+    additionalProperties: false
+    required: [resident_key, user_verification]
+    properties:
+      authenticator_attachment:
+        type: [string, "null"]
+        enum: [platform, cross-platform, null]
+        description: |
+          When set, restricts registration to platform (Touch ID,
+          Windows Hello) or cross-platform (roaming security key)
+          authenticators. `null` allows both.
+      resident_key:
+        type: string
+        enum: [discouraged, preferred, required]
+        default: preferred
+        description: |
+          How strongly the server wants a client-side discoverable
+          credential. `preferred` is the v0.5 default — enables
+          username-less sign-in when the authenticator supports it
+          while falling back gracefully when it doesn't.
+      user_verification:
+        type: string
+        enum: [discouraged, preferred, required]
+        default: preferred
+        description: |
+          Whether the authenticator must do user-presence checking
+          (PIN, biometric, …). `preferred` accepts UV when available;
+          `required` refuses authenticators that can't UV.
+  exclude_credentials:
+    type: array
+    description: |
+      Credentials already registered against this user. The
+      authenticator refuses to enroll if any match, so the user
+      doesn't accidentally register the same authenticator twice.
+    items:
+      type: object
+      required: [id, type]
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          description: base64url credential id of an existing `Passkey` row.
+        type:
+          type: string
+          const: public-key
+        transports:
+          type: array
+          items:
+            type: string
+            enum: [usb, nfc, ble, internal, hybrid]
+  extensions:
+    type: object
+    description: |
+      WebAuthn extension inputs (e.g. `credProps`). Free-form — the
+      server passes the operator-configured set through verbatim.
+    additionalProperties: true

--- a/components/schemas/PasskeyUpdateRequest.yaml
+++ b/components/schemas/PasskeyUpdateRequest.yaml
@@ -1,0 +1,11 @@
+type: object
+description: |
+  Body for `PATCH /v1/me/passkeys/{id}`. Only `nickname` is mutable
+  from the user-facing surface — every other field is set by the
+  ceremony or by assertion bookkeeping.
+required: [nickname]
+additionalProperties: false
+properties:
+  nickname:
+    type: string
+    maxLength: 100

--- a/fapi.yaml
+++ b/fapi.yaml
@@ -140,6 +140,12 @@ paths:
     $ref: ./paths/fapi/me-external-account.yaml
   /v1/me/passkeys:
     $ref: ./paths/fapi/me-passkeys.yaml
+  /v1/me/passkeys/begin-registration:
+    $ref: ./paths/fapi/me-passkey-begin-registration.yaml
+  /v1/me/passkeys/complete-registration/{challenge_id}:
+    $ref: ./paths/fapi/me-passkey-complete-registration.yaml
+  /v1/me/passkeys/{passkey_id}:
+    $ref: ./paths/fapi/me-passkey.yaml
   /v1/me/sessions:
     $ref: ./paths/fapi/me-sessions.yaml
   /v1/me/change-password:
@@ -221,6 +227,11 @@ components:
     EmailAddress:                              { $ref: ./components/schemas/EmailAddress.yaml }
     ExternalAccount:                           { $ref: ./components/schemas/ExternalAccount.yaml }
     Passkey:                                   { $ref: ./components/schemas/Passkey.yaml }
+    PasskeyCreationOptions:                    { $ref: ./components/schemas/PasskeyCreationOptions.yaml }
+    PasskeyAttestation:                        { $ref: ./components/schemas/PasskeyAttestation.yaml }
+    PasskeyBeginRegistrationRequest:           { $ref: ./components/schemas/PasskeyBeginRegistrationRequest.yaml }
+    PasskeyCompleteRegistrationRequest:        { $ref: ./components/schemas/PasskeyCompleteRegistrationRequest.yaml }
+    PasskeyUpdateRequest:                      { $ref: ./components/schemas/PasskeyUpdateRequest.yaml }
     PhoneNumber:                               { $ref: ./components/schemas/PhoneNumber.yaml }
     PhoneNumberCreateRequest:                  { $ref: ./components/schemas/PhoneNumberCreateRequest.yaml }
     PhoneNumberUpdateRequest:                  { $ref: ./components/schemas/PhoneNumberUpdateRequest.yaml }

--- a/paths/fapi/me-passkey-begin-registration.yaml
+++ b/paths/fapi/me-passkey-begin-registration.yaml
@@ -1,0 +1,56 @@
+post:
+  operationId: beginMyPasskeyRegistration
+  summary: Begin a passkey registration ceremony
+  description: |
+    Mints a `Passkey` row in the unverified state and a parent
+    `Challenge` with `strategy: "passkey"`, `step: "first"`,
+    `mode: "registration"`. The response carries the
+    server-built `PublicKeyCredentialCreationOptions` on
+    `challenge.creation_options`; the SDK hands that to
+    `navigator.credentials.create({ publicKey })`, then posts the
+    attestation response to
+    `POST /v1/me/passkeys/complete-registration/{challenge_id}`.
+
+    Multi-tab clients can resume the ceremony by re-fetching the
+    parent challenge — the `creation_options` block is stable for
+    the challenge's lifetime.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: false
+    content:
+      application/json:
+        schema: { $ref: ../../components/schemas/PasskeyBeginRegistrationRequest.yaml }
+        examples:
+          named:
+            value: { nickname: YubiKey 5C }
+          unnamed:
+            value: {}
+  responses:
+    "201":
+      description: |
+        Registration challenge. `Challenge.nonce` is the base64url
+        WebAuthn challenge nonce; the matching ceremony parameters
+        live in `creation_options`.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: ../../components/schemas/Challenge.yaml
+              - type: object
+                required: [creation_options]
+                properties:
+                  creation_options:
+                    $ref: ../../components/schemas/PasskeyCreationOptions.yaml
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "422":
+      description: |
+        Validation failure. Possible `code` values:
+
+        - `passkey_not_supported` — the environment has WebAuthn
+          disabled, so registration is refused outright.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ErrorResponse.yaml }

--- a/paths/fapi/me-passkey-complete-registration.yaml
+++ b/paths/fapi/me-passkey-complete-registration.yaml
@@ -1,0 +1,50 @@
+parameters:
+  - name: challenge_id
+    in: path
+    required: true
+    description: |
+      The `Challenge.id` returned by `begin-registration`. Must be
+      in `status: pending` and bound to the calling user.
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+post:
+  operationId: completeMyPasskeyRegistration
+  summary: Complete a passkey registration ceremony
+  description: |
+    Verifies the WebAuthn attestation response, flips the parent
+    `Challenge` to `verified`, and finalises the `Passkey` row
+    (`verified: true`, transports captured from the attestation).
+
+    Common failure codes (HTTP 422):
+
+    - `passkey_origin_mismatch` — the `clientDataJSON.origin` is not
+      on the environment's allowlist.
+    - `passkey_attestation_invalid` — the attestation statement
+      failed signature verification or used an unsupported
+      attestation format.
+    - `passkey_replayed` — the credential id is already enrolled on
+      another row (should be impossible because
+      `exclude_credentials[]` was sent on begin-registration, but
+      the server defends against tampered ceremonies).
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../../components/schemas/PasskeyCompleteRegistrationRequest.yaml }
+  responses:
+    "201":
+      description: The newly-verified passkey, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "422":
+      description: Attestation rejected.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ErrorResponse.yaml }

--- a/paths/fapi/me-passkey.yaml
+++ b/paths/fapi/me-passkey.yaml
@@ -1,0 +1,54 @@
+parameters:
+  - name: passkey_id
+    in: path
+    required: true
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+patch:
+  operationId: updateMyPasskey
+  summary: Rename one of my passkeys
+  description: |
+    Only `nickname` is mutable. Everything else (transports,
+    aaguid, verified state, sign-count) is set by the ceremony or
+    by assertion bookkeeping and can't be changed from the FAPI.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../../components/schemas/PasskeyUpdateRequest.yaml }
+        examples:
+          rename:
+            value: { nickname: Work YubiKey }
+  responses:
+    "200":
+      description: The renamed passkey, wrapped.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ClientResponseEnvelope.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }
+
+delete:
+  operationId: deleteMyPasskey
+  summary: Remove one of my passkeys
+  description: |
+    Soft-removes the passkey — sets `removed_at`, so the row stays
+    in place for audit-log correlation, but the credential can no
+    longer be used to authenticate. The user must keep at least one
+    way to sign in (password, OAuth, or another passkey);
+    removing the last sign-in method returns `422`.
+  tags: [Me]
+  security:
+    - client_cookie: []
+    - dev_browser_jwt: []
+  responses:
+    "204":
+      description: Removed.
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }

--- a/paths/fapi/me-passkeys.yaml
+++ b/paths/fapi/me-passkeys.yaml
@@ -4,10 +4,6 @@ get:
   description: |
     Every `Passkey` row registered against the current user. Powers
     the security tab on `<UserProfile />`.
-
-    The full management surface — registration ceremony, rename,
-    deletion — is documented under this same path prefix and the
-    `{passkey_id}` sub-resources.
   tags: [Me]
   security:
     - client_cookie: []
@@ -18,6 +14,14 @@ get:
       content:
         application/json:
           schema:
-            type: array
-            items: { $ref: ../../components/schemas/Passkey.yaml }
+            type: object
+            required: [data, total_count]
+            additionalProperties: false
+            properties:
+              data:
+                type: array
+                items: { $ref: ../../components/schemas/Passkey.yaml }
+              total_count:
+                type: integer
+                minimum: 0
     "401": { $ref: ../../components/responses/Unauthorized.yaml }


### PR DESCRIPTION
Closes #60

## Summary

Replaces the OA-1 stub with the full user-facing passkey surface, plus the Challenge-based registration ceremony.

- `GET /v1/me/passkeys` → `{ data: Passkey[], total_count }`.
- `POST /v1/me/passkeys/begin-registration` → `Challenge` with `strategy: passkey`, plus a `creation_options` block carrying the server-built `PublicKeyCredentialCreationOptions`.
- `POST /v1/me/passkeys/complete-registration/{challenge_id}` → `ClientResponseEnvelope(Passkey)` after verifying the attestation, flipping the parent challenge to `verified`.
- `PATCH /v1/me/passkeys/{id}` → rename (only `nickname` is mutable).
- `DELETE /v1/me/passkeys/{id}` → soft-remove (keeps the row for audit-log correlation; 422 when removing the last sign-in method).

New schemas:
- `PasskeyCreationOptions` — `PublicKeyCredentialCreationOptions` envelope (rp, user, base64url challenge, pub_key_cred_params[], timeout, attestation, authenticator_selection, exclude_credentials[], extensions).
- `PasskeyAttestation` — `AuthenticatorAttestationResponse` envelope (base64url raw_id / clientDataJSON / attestationObject, transports[]).
- `PasskeyBeginRegistrationRequest`, `PasskeyCompleteRegistrationRequest`, `PasskeyUpdateRequest`.

`Challenge.yaml` gains optional `creation_options` so multi-tab clients can resume the ceremony by re-fetching the parent challenge.

Documented failure codes via the shared `ErrorResponse`: `passkey_not_supported`, `passkey_origin_mismatch`, `passkey_attestation_invalid`, `passkey_replayed`.

## Bundle diff vs the OA-1 stub

- New schemas: `PasskeyCreationOptions`, `PasskeyAttestation`, `PasskeyBeginRegistrationRequest`, `PasskeyCompleteRegistrationRequest`, `PasskeyUpdateRequest`.
- New paths: `/v1/me/passkeys/begin-registration`, `/v1/me/passkeys/complete-registration/{challenge_id}`, `/v1/me/passkeys/{passkey_id}`.
- `GET /v1/me/passkeys` response shape changed from bare array to `{ data, total_count }`.
- `Challenge` gains optional `creation_options`.