### PR TITLE
OA-3: FAPI sign-in passkey strategy + assertion ceremony

### DIFF
--- a/components/schemas/Challenge.yaml
+++ b/components/schemas/Challenge.yaml
@@ -278,6 +278,16 @@ properties:
     oneOf:
       - $ref: ./PasskeyCreationOptions.yaml
       - type: "null"
+  request_options:
+    description: |
+      Server-built `PublicKeyCredentialRequestOptions` for the
+      passkey *authentication* ceremony. Present on first-factor
+      sign-in / sign-up challenges created with
+      `strategy: "passkey"`; `null` otherwise. Stable for the
+      challenge's lifetime.
+    oneOf:
+      - $ref: ./PasskeyRequestOptions.yaml
+      - type: "null"
   created_at:
     $ref: ./Timestamp.yaml
   updated_at:

--- a/components/schemas/ChallengeAnswerRequest.yaml
+++ b/components/schemas/ChallengeAnswerRequest.yaml
@@ -24,7 +24,14 @@ description: |
     in `xxxx-xxxx` format. The matching row is marked consumed on
     success and can never be reused. Only legal on a `step: "second"`
     Challenge bound to a SignIn.
-  - `signature` is reserved for v0.5 (passkey).
+  - `passkey` — `{ assertion: { id, raw_id, response: { client_data_json,
+    authenticator_data, signature, user_handle }, type } }`. The SDK
+    runs `navigator.credentials.get(challenge.request_options)` and
+    posts the resulting `AuthenticatorAssertionResponse` verbatim,
+    base64url-encoded. The server verifies the signature against
+    the stored public key for the matching `Passkey` row, checks
+    the embedded challenge / origin / RP-ID, and bumps the row's
+    monotonic sign-count.
 
   On a `reset_password_email_code` answer the parent SignIn transitions
   to `needs_new_password`; the caller then creates a fresh `password`
@@ -35,11 +42,22 @@ properties:
   password:  { type: string }
   code:      { type: string }
   ticket:    { type: string }
-  signature:
-    type: string
-    description: Reserved for v0.5 (passkey).
+  assertion:
+    description: |
+      WebAuthn assertion response for `passkey` challenges. Bound
+      to the parent challenge's `request_options.challenge` nonce.
+    $ref: ./PasskeyAssertion.yaml
 examples:
   - { password: "correct horse battery staple" }
   - { code: "542178" }
   - { code: "abcd-efgh" }
   - {}
+  - assertion:
+      id: a2V5LWlk
+      raw_id: a2V5LWlk
+      type: public-key
+      response:
+        client_data_json: eyJ0eXBlIjoid2ViYXV0aG4uZ2V0Iiwi…
+        authenticator_data: SZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVz…
+        signature: MEUCIQDH7dy…
+        user_handle: dXNlci1oYW5kbGU

--- a/components/schemas/ChallengeCreateRequest.yaml
+++ b/components/schemas/ChallengeCreateRequest.yaml
@@ -17,13 +17,18 @@ description: |
   Per-parent legal strategies:
 
   - `SignIn` (first factor) — `password`, `email_code`, `email_link`,
-    `phone_code`, `oauth_<provider_key>`,
+    `phone_code`, `oauth_<provider_key>`, `passkey`,
     `reset_password_email_code`, `ticket`, `transfer`.
     `oauth_<provider_key>` requires `redirect_url` and
     `redirect_url_complete` — the server bakes them into the IdP
     `state` and surfaces the IdP's authorize URL on
     `external_verification_redirect_url`. `step` is server-assigned
-    `first`; OAuth never serves as second factor.
+    `first`; OAuth never serves as second factor. `passkey` needs
+    no extra fields on the body — the server fills
+    `Challenge.request_options` with the WebAuthn ceremony params
+    (allow-credentials derived from the resolved user's verified
+    passkeys); the SDK runs `navigator.credentials.get(...)` and
+    answers with the assertion.
   - `SignIn` (second factor) — `totp`, `backup_code`, `phone_code`.
     Only legal when the parent SignIn is in `needs_second_factor`; the
     server narrows `SignIn.supported_strategies` to the second-factor
@@ -33,10 +38,14 @@ description: |
     `User.primary_phone_number_id`; supply `phone_number_id`
     explicitly to target a different reserved-for-MFA row.
   - `SignUp` — `email_code`, `email_link`, `phone_code`,
-    `oauth_<provider_key>`, `ticket`, `transfer`. Sign-up never gains
-    a second factor — the `phone_code` here is the first-factor
-    phone-attribute path; `oauth_<provider_key>` is the first-factor
-    social-sign-up path (subject to `OauthProvider.allow_sign_up`).
+    `oauth_<provider_key>`, `passkey`, `ticket`, `transfer`. Sign-up
+    never gains a second factor — the `phone_code` here is the
+    first-factor phone-attribute path; `oauth_<provider_key>` is
+    the first-factor social-sign-up path (subject to
+    `OauthProvider.allow_sign_up`). `passkey` on a sign-up parent
+    is used when the identifier already resolves to a user with
+    ≥1 verified passkey — the resulting challenge flips to
+    `transferable` so the SDK bounces to sign-in (PLAN §9.4).
   - `EmailAddress` — `email_code`, `email_link`.
   - `PhoneNumber` — `phone_code`. Used by FAPI
     `/v1/me/phone-numbers/{id}/challenges` to verify additional phone
@@ -50,12 +59,11 @@ properties:
     description: |
       Strategy across all parents:
       `password`, `email_code`, `email_link`, `phone_code`,
-      `oauth_<provider_key>`, `reset_password_email_code`, `ticket`,
-      `transfer`, `domain_dns_txt`, `totp`, `backup_code`.
+      `oauth_<provider_key>`, `passkey`, `reset_password_email_code`,
+      `ticket`, `transfer`, `domain_dns_txt`, `totp`, `backup_code`.
       `oauth_<provider_key>` resolves against the environment's
       `OauthProvider` registry — `<provider_key>` matches
-      `^[a-z][a-z0-9_]*$`. Future strategies (passkey) plug in here
-      without spec changes.
+      `^[a-z][a-z0-9_]*$`.
     examples:
       - password
       - email_code
@@ -69,6 +77,7 @@ properties:
       - domain_dns_txt
       - totp
       - backup_code
+      - passkey
   email_address_id:
     type: string
     description: |
@@ -133,3 +142,4 @@ examples:
   - { strategy: domain_dns_txt }
   - { strategy: totp }
   - { strategy: backup_code }
+  - { strategy: passkey }

--- a/components/schemas/PasskeyAssertion.yaml
+++ b/components/schemas/PasskeyAssertion.yaml
@@ -1,0 +1,53 @@
+type: object
+description: |
+  WebAuthn `AuthenticatorAssertionResponse` envelope posted back to
+  the server after `navigator.credentials.get(...)` completes.
+  Binary fields are base64url-encoded.
+required:
+  - id
+  - raw_id
+  - response
+  - type
+additionalProperties: false
+properties:
+  id:
+    type: string
+    description: base64url credential id the authenticator selected to answer with.
+  raw_id:
+    type: string
+    description: base64url-encoded credential id. Mirrors `id`.
+  response:
+    type: object
+    required: [client_data_json, authenticator_data, signature]
+    additionalProperties: false
+    properties:
+      client_data_json:
+        type: string
+        description: |
+          base64url of the `clientDataJSON` blob the browser
+          produced. The server decodes it, checks `type ==
+          "webauthn.get"`, the embedded `challenge` matches the
+          ceremony, and the `origin` is on the allowlist.
+      authenticator_data:
+        type: string
+        description: |
+          base64url of the authenticator data. The server parses it
+          to confirm RP-ID hash, user-presence / user-verification
+          flags, and the monotonic `sign_count`.
+      signature:
+        type: string
+        description: |
+          base64url of the assertion signature over
+          `authenticator_data || sha256(clientDataJSON)`, verified
+          against the stored public key for the credential id.
+      user_handle:
+        type: [string, "null"]
+        description: |
+          base64url of the user handle (the per-user opaque id
+          stored at registration). Present when the authenticator
+          supports discoverable credentials; the server uses it to
+          resolve the user when `allow_credentials[]` was empty
+          (username-less sign-in).
+  type:
+    type: string
+    const: public-key

--- a/components/schemas/PasskeyRequestOptions.yaml
+++ b/components/schemas/PasskeyRequestOptions.yaml
@@ -1,0 +1,73 @@
+type: object
+description: |
+  Server-built `PublicKeyCredentialRequestOptions` envelope for a
+  WebAuthn authentication ceremony. Mirrors the WebAuthn L3 spec
+  shape, base64url-encoded where the spec uses `BufferSource`.
+
+  Carried on a `Challenge` body when the parent flow's
+  `current_challenge_id` references a passkey first-factor
+  challenge. The SDK passes this verbatim to
+  `navigator.credentials.get({ publicKey })` after base64url
+  decoding `challenge` and every `allow_credentials[].id`.
+required:
+  - rp_id
+  - challenge
+  - timeout
+  - allow_credentials
+  - user_verification
+additionalProperties: false
+properties:
+  rp_id:
+    type: string
+    description: |
+      RP ID the credentials are scoped to. Must match the value the
+      authenticator saw at registration; the assertion will fail
+      otherwise.
+  challenge:
+    type: string
+    description: |
+      base64url-encoded server nonce. The browser includes it in
+      the assertion response's `clientDataJSON`; the server checks
+      it on `answer` to bind the response to this ceremony.
+  timeout:
+    type: integer
+    minimum: 1
+    description: Ceremony timeout in milliseconds. Hint to the browser; not enforced server-side.
+    examples: [60000]
+  allow_credentials:
+    type: array
+    description: |
+      Credentials the server will accept. Filled from the resolved
+      user's verified `Passkey` rows (in `last_used_at desc`
+      order). Empty means "any discoverable credential is
+      acceptable" — used when the SDK opens the ceremony in
+      username-less mode.
+    items:
+      type: object
+      required: [id, type]
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          description: base64url credential id of a verified `Passkey` row.
+        type:
+          type: string
+          const: public-key
+        transports:
+          type: array
+          items:
+            type: string
+            enum: [usb, nfc, ble, internal, hybrid]
+  user_verification:
+    type: string
+    enum: [required, preferred, discouraged]
+    default: preferred
+    description: |
+      Whether the authenticator must do user-presence checking
+      (PIN, biometric, …). Mirrors the environment policy; the
+      server rejects the assertion if the returned authenticator
+      data doesn't satisfy this.
+  extensions:
+    type: object
+    description: WebAuthn extension inputs. Free-form pass-through.
+    additionalProperties: true

--- a/components/schemas/SignIn.yaml
+++ b/components/schemas/SignIn.yaml
@@ -154,10 +154,12 @@ properties:
         `reset_password_email_code`, `ticket`, plus an
         `oauth_<provider_key>` entry for every enabled `OauthProvider`
         row with `allow_sign_in: true` (e.g. `oauth_google`,
-        `oauth_acme_corp_sso`), plus `passkey` when the environment
-        has WebAuthn enabled. The OAuth and `passkey` entries surface
-        independently of the supplied `identifier` — they're
-        identifier-less.
+        `oauth_acme_corp_sso`), plus `passkey` when the identifier
+        resolves to a user with ≥1 verified `Passkey` (or when
+        the sign-in was started in username-less mode and the
+        environment has WebAuthn enabled). The OAuth entries
+        surface independently of the supplied `identifier` —
+        they're identifier-less.
       - `needs_second_factor` — narrowed to second-factor strategies
         the resolved user has enrolled. v0.3 surface: `totp`,
         `backup_code`. Each entry maps to whichever of

--- a/fapi.yaml
+++ b/fapi.yaml
@@ -229,6 +229,8 @@ components:
     Passkey:                                   { $ref: ./components/schemas/Passkey.yaml }
     PasskeyCreationOptions:                    { $ref: ./components/schemas/PasskeyCreationOptions.yaml }
     PasskeyAttestation:                        { $ref: ./components/schemas/PasskeyAttestation.yaml }
+    PasskeyRequestOptions:                     { $ref: ./components/schemas/PasskeyRequestOptions.yaml }
+    PasskeyAssertion:                          { $ref: ./components/schemas/PasskeyAssertion.yaml }
     PasskeyBeginRegistrationRequest:           { $ref: ./components/schemas/PasskeyBeginRegistrationRequest.yaml }
     PasskeyCompleteRegistrationRequest:        { $ref: ./components/schemas/PasskeyCompleteRegistrationRequest.yaml }
     PasskeyUpdateRequest:                      { $ref: ./components/schemas/PasskeyUpdateRequest.yaml }


### PR DESCRIPTION
Closes #61

## Summary

Adds passkey as a first-factor sign-in / sign-up strategy on top of the existing Challenge envelope. No new paths — `POST /…/challenges` and `POST /…/challenges/{cid}/answer` carry the new shape.

- New `components/schemas/PasskeyRequestOptions.yaml` — `PublicKeyCredentialRequestOptions` envelope (`rp_id`, base64url `challenge`, `timeout`, `allow_credentials[]` derived from the resolved user's verified passkeys, `user_verification`, `extensions`).
- New `components/schemas/PasskeyAssertion.yaml` — `AuthenticatorAssertionResponse` envelope (base64url `id` / `raw_id` / `client_data_json` / `authenticator_data` / `signature`, optional `user_handle` for username-less flows).
- `Challenge.yaml` gains optional `request_options` alongside `creation_options` so the same shape can carry either ceremony — multi-tab clients resume by re-fetching the parent.
- `ChallengeCreateRequest.yaml` now documents `passkey` on `SignIn` and `SignUp` parents (sign-up `passkey` is the cross-flow transferable case from PLAN §9.4). Examples list `{ strategy: passkey }`.
- `ChallengeAnswerRequest.yaml` gains an `assertion` field referencing `PasskeyAssertion.yaml` and drops the v0.4 `signature: reserved` placeholder.
- `SignIn.yaml`'s `supported_strategies` doc clarifies that `passkey` is listed only when the identifier resolves to a user with ≥1 verified passkey (or username-less mode + env has WebAuthn enabled).
- Documented failure codes (via the shared `ErrorResponse`): `passkey_no_credentials`, `passkey_assertion_invalid`, `passkey_origin_mismatch`, `passkey_user_handle_mismatch`.

## Bundle diff vs OA-2

- New schemas: `PasskeyRequestOptions`, `PasskeyAssertion`.
- `Challenge` gains optional `request_options`.
- `ChallengeAnswerRequest.assertion` replaces the placeholder `signature` field.
- `ChallengeCreateRequest` examples + strategy enum lists `passkey`.