### PR TITLE
OA-1: EnterpriseConnection resource shape (SAML + OIDC, instance + org-scoped)

### DIFF
--- a/bapi.yaml
+++ b/bapi.yaml
@@ -283,6 +283,8 @@ components:
     OauthProvider:                             { $ref: ./components/schemas/OauthProvider.yaml }
     OauthProviderRequest:                      { $ref: ./components/schemas/OauthProviderRequest.yaml }
     OauthProviderTestResult:                   { $ref: ./components/schemas/OauthProviderTestResult.yaml }
+    EnterpriseConnection:                      { $ref: ./components/schemas/EnterpriseConnection.yaml }
+    EnterpriseConnectionRequest:               { $ref: ./components/schemas/EnterpriseConnectionRequest.yaml }
     SmsTemplate:                               { $ref: ./components/schemas/SmsTemplate.yaml }
     SmsTemplateRequest:                        { $ref: ./components/schemas/SmsTemplateRequest.yaml }
 

--- a/components/schemas/EnterpriseConnection.yaml
+++ b/components/schemas/EnterpriseConnection.yaml
@@ -1,0 +1,329 @@
+type: object
+description: |
+  Per-environment Enterprise SSO IdP. One row carries either a SAML 2.0
+  or an OIDC connection — consumers branch on `protocol`. Connections are
+  either **instance-wide** (`organization_id: null`) — usable by any user
+  in the environment whose email matches one of the connection's verified
+  `domains` — or **org-scoped** (`organization_id` set) — usable only by
+  members of that organization.
+
+  ### Discovery and routing
+
+  A `SignIn` enters the enterprise-SSO path when the resolved identifier's
+  domain matches a verified `OrganizationDomain` whose connection mode
+  selects SSO (see OA-6), or when the SDK explicitly requests the
+  `enterprise_sso` / `saml` strategy with a `connection_id`. The server
+  resolves the right `EnterpriseConnection` and surfaces the IdP redirect
+  on the resulting `Challenge` (`external_verification_redirect_url`).
+
+  ### Computed read-only fields
+
+  Two URLs are computed server-side from the connection `id` and the
+  environment slug; operators register them with the IdP:
+
+  - `saml_acs_url` — SAML AssertionConsumerService URL. Format:
+    `https://<env_slug>.authn.sh/v1/saml/<id>/acs`. Per-connection so the
+    server can dispatch the inbound assertion to the right row.
+  - `saml_sp_entity_id` — SP entity identifier the IdP sees. Stable per
+    connection. Format: `https://<env_slug>.authn.sh/v1/saml/<id>/metadata`.
+  - `oidc_redirect_uri` — OIDC redirect URI. Format:
+    `https://<env_slug>.authn.sh/v1/enterprise-sso-callback`.
+    Shared across OIDC connections — the server identifies the connection
+    via the OAuth `state` parameter.
+
+  ### Secret handling
+
+  `oidc_client_secret` and `saml_signing_key` are **write-only**. Accepted
+  on `POST` / `PATCH` (see `EnterpriseConnectionRequest`), encrypted at
+  rest, and never returned by any GET. The public shape carries only the
+  IdP-supplied public material (`oidc_client_id`, `saml_idp_certificate`).
+
+  ### Attribute mapping
+
+  Map of authn.sh field names (keys) to IdP claim / SAML attribute paths
+  (values). Standard keys: `email_address`, `first_name`, `last_name`,
+  `provider_user_id`, plus `organization_role` (maps to the
+  `OrganizationMembership.role` to assign on JIT provisioning when the
+  connection is org-scoped). Sensible defaults are filled in by the
+  server when the operator omits the field on create.
+
+  ### Identifier
+
+  ID prefix `entcon_` (e.g. `entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA`).
+required:
+  - id
+  - object
+  - protocol
+  - name
+  - enabled
+  - organization_id
+  - domains
+  - default_role
+  - attribute_mapping
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: enterprise_connection
+  protocol:
+    type: string
+    enum: [saml, oidc]
+    description: |
+      Which IdP protocol this connection speaks. Immutable after create
+      — switching protocols means deleting the row and creating a new
+      one so the IdP-side registration starts clean.
+  name:
+    type: string
+    minLength: 1
+    maxLength: 100
+    description: |
+      Human-readable label rendered in the Account Portal and on
+      `<SignIn />` when more than one enterprise connection is offered.
+  enabled:
+    type: boolean
+    description: |
+      When `false`, the connection is hidden from sign-in routing and
+      the `enterprise_sso` / `saml` strategy is rejected for it.
+      Existing `EnterpriseAccount` links survive the toggle.
+  organization_id:
+    type: [string, "null"]
+    description: |
+      `null` for instance-wide connections (any user in the env whose
+      email matches a verified `domain` can use it). Set to an
+      `Organization.id` to scope the connection to that organization's
+      members. Immutable after create.
+  domains:
+    type: array
+    items:
+      type: string
+      format: hostname
+    description: |
+      Verified email domains routed to this connection. Each entry must
+      match a verified `OrganizationDomain` (org-scoped connections) or
+      a workspace-verified domain (instance-wide connections). Empty
+      array is legal — the connection is then reachable only via
+      explicit `connection_id` on the SignIn.
+    examples:
+      - ["acme.example", "acme-corp.example"]
+  default_role:
+    type: string
+    description: |
+      `Role.key` (e.g. `org:member`) assigned to the
+      `OrganizationMembership` minted on JIT provisioning when this
+      connection is org-scoped. Ignored for instance-wide connections.
+      Defaults to `org:member` on create.
+    examples:
+      - org:member
+      - org:admin
+  attribute_mapping:
+    type: object
+    description: |
+      Map of authn.sh field names (keys) to IdP claim / SAML attribute
+      paths (values). Keys: `email_address`, `first_name`, `last_name`,
+      `provider_user_id`, `organization_role`. Defaults are filled in
+      by the server (`email_address` → `email` for OIDC,
+      `email_address` → `urn:oid:0.9.2342.19200300.100.1.3` for SAML;
+      etc.).
+    additionalProperties:
+      type: string
+    examples:
+      - email_address: email
+        first_name: given_name
+        last_name: family_name
+        provider_user_id: sub
+      - email_address: "urn:oid:0.9.2342.19200300.100.1.3"
+        first_name: "urn:oid:2.5.4.42"
+        last_name: "urn:oid:2.5.4.4"
+        provider_user_id: nameid
+  saml_idp_entity_id:
+    type: [string, "null"]
+    description: |
+      SAML EntityID the IdP publishes for itself. Required when
+      `protocol: "saml"`; `null` for OIDC.
+    examples:
+      - https://idp.acme.example/saml/metadata
+  saml_sso_url:
+    type: [string, "null"]
+    format: uri
+    description: |
+      SAML SingleSignOnService URL the SDK redirects the browser to.
+      Required when `protocol: "saml"`; `null` for OIDC.
+    examples:
+      - https://idp.acme.example/saml/sso
+  saml_idp_certificate:
+    type: [string, "null"]
+    description: |
+      PEM-encoded X.509 certificate the IdP uses to sign SAML assertions.
+      The server verifies inbound assertions against this. Required when
+      `protocol: "saml"`; `null` for OIDC.
+    examples:
+      - "-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
+  saml_signing_algorithm:
+    type: [string, "null"]
+    enum: [RSA_SHA256, RSA_SHA384, RSA_SHA512, null]
+    description: |
+      Signature algorithm for assertions. Defaults to `RSA_SHA256` on
+      create when `protocol: "saml"`. `null` for OIDC.
+  saml_audience_uri:
+    type: [string, "null"]
+    description: |
+      `Audience` URI the IdP must include in the SAML assertion.
+      Defaults to `saml_sp_entity_id` on create when `protocol: "saml"`;
+      operators can override for IdPs that pin audience to a custom URI.
+      `null` for OIDC.
+  saml_acs_url:
+    type: [string, "null"]
+    format: uri
+    readOnly: true
+    description: |
+      Server-computed AssertionConsumerService URL. Format:
+      `https://<env_slug>.authn.sh/v1/saml/<id>/acs`. Operators register
+      this exact value with the IdP. `null` for OIDC.
+    examples:
+      - https://acme.authn.sh/v1/saml/entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA/acs
+  saml_sp_entity_id:
+    type: [string, "null"]
+    format: uri
+    readOnly: true
+    description: |
+      Server-computed SP EntityID. Format:
+      `https://<env_slug>.authn.sh/v1/saml/<id>/metadata`. This URL also
+      serves SP metadata XML. `null` for OIDC.
+    examples:
+      - https://acme.authn.sh/v1/saml/entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA/metadata
+  oidc_issuer:
+    type: [string, "null"]
+    format: uri
+    description: |
+      OIDC issuer URL the server runs discovery from. Required when
+      `protocol: "oidc"`; `null` for SAML.
+    examples:
+      - https://idp.acme.example
+  oidc_discovery_endpoint:
+    type: [string, "null"]
+    format: uri
+    description: |
+      Resolved discovery document URL. Populated by the server from
+      `oidc_issuer` (`<issuer>/.well-known/openid-configuration`);
+      admin-overridable for non-standard discovery paths. `null` for
+      SAML.
+  oidc_client_id:
+    type: [string, "null"]
+    description: |
+      OIDC client identifier issued by the IdP. Required when
+      `protocol: "oidc"`; `null` for SAML.
+    examples:
+      - authn-acme-prod
+  oidc_scopes:
+    type: array
+    items:
+      type: string
+    description: |
+      Scope set requested on the `/authorize` redirect. Defaults to
+      `["openid", "profile", "email"]` on create when `protocol: "oidc"`.
+      Empty for SAML connections.
+    examples:
+      - ["openid", "profile", "email"]
+      - ["openid", "profile", "email", "groups"]
+  oidc_redirect_uri:
+    type: [string, "null"]
+    format: uri
+    readOnly: true
+    description: |
+      Server-computed OIDC redirect URI. Format:
+      `https://<env_slug>.authn.sh/v1/enterprise-sso-callback`. Shared
+      across the env's OIDC enterprise connections — the server
+      identifies the connection via the OAuth `state` parameter.
+      Operators register this exact value with the IdP. `null` for SAML.
+    examples:
+      - https://acme.authn.sh/v1/enterprise-sso-callback
+  created_at:
+    $ref: ./Timestamp.yaml
+  updated_at:
+    $ref: ./Timestamp.yaml
+examples:
+  - id: entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    object: enterprise_connection
+    protocol: saml
+    name: Acme Okta
+    enabled: true
+    organization_id: org_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    domains: ["acme.example"]
+    default_role: org:member
+    attribute_mapping:
+      email_address: "urn:oid:0.9.2342.19200300.100.1.3"
+      first_name: "urn:oid:2.5.4.42"
+      last_name: "urn:oid:2.5.4.4"
+      provider_user_id: nameid
+    saml_idp_entity_id: https://idp.acme.example/saml/metadata
+    saml_sso_url: https://idp.acme.example/saml/sso
+    saml_idp_certificate: "-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
+    saml_signing_algorithm: RSA_SHA256
+    saml_audience_uri: https://acme.authn.sh/v1/saml/entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA/metadata
+    saml_acs_url: https://acme.authn.sh/v1/saml/entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA/acs
+    saml_sp_entity_id: https://acme.authn.sh/v1/saml/entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA/metadata
+    oidc_issuer: null
+    oidc_discovery_endpoint: null
+    oidc_client_id: null
+    oidc_scopes: []
+    oidc_redirect_uri: null
+    created_at: 1714723000000
+    updated_at: 1714723000000
+  - id: entcon_01HKX9SY9V7H7TF8C8K7J9X4ZC
+    object: enterprise_connection
+    protocol: oidc
+    name: Acme Azure AD
+    enabled: true
+    organization_id: org_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    domains: ["acme.example", "acme-corp.example"]
+    default_role: org:member
+    attribute_mapping:
+      email_address: email
+      first_name: given_name
+      last_name: family_name
+      provider_user_id: sub
+    saml_idp_entity_id: null
+    saml_sso_url: null
+    saml_idp_certificate: null
+    saml_signing_algorithm: null
+    saml_audience_uri: null
+    saml_acs_url: null
+    saml_sp_entity_id: null
+    oidc_issuer: https://login.microsoftonline.com/acme-tenant/v2.0
+    oidc_discovery_endpoint: https://login.microsoftonline.com/acme-tenant/v2.0/.well-known/openid-configuration
+    oidc_client_id: 11111111-2222-3333-4444-555555555555
+    oidc_scopes: ["openid", "profile", "email"]
+    oidc_redirect_uri: https://acme.authn.sh/v1/enterprise-sso-callback
+    created_at: 1714723000000
+    updated_at: 1714723000000
+  - id: entcon_01HKX9SY9V7H7TF8C8K7J9X4ZD
+    object: enterprise_connection
+    protocol: oidc
+    name: Workspace-wide Okta
+    enabled: true
+    organization_id: null
+    domains: ["staff.example"]
+    default_role: org:member
+    attribute_mapping:
+      email_address: email
+      first_name: given_name
+      last_name: family_name
+      provider_user_id: sub
+    saml_idp_entity_id: null
+    saml_sso_url: null
+    saml_idp_certificate: null
+    saml_signing_algorithm: null
+    saml_audience_uri: null
+    saml_acs_url: null
+    saml_sp_entity_id: null
+    oidc_issuer: https://staff-corp.okta.com
+    oidc_discovery_endpoint: https://staff-corp.okta.com/.well-known/openid-configuration
+    oidc_client_id: 0oa1abcdEFGHIJKLM2x7
+    oidc_scopes: ["openid", "profile", "email", "groups"]
+    oidc_redirect_uri: https://staff.authn.sh/v1/enterprise-sso-callback
+    created_at: 1714723000000
+    updated_at: 1714723000000

--- a/components/schemas/EnterpriseConnectionRequest.yaml
+++ b/components/schemas/EnterpriseConnectionRequest.yaml
@@ -1,0 +1,164 @@
+type: object
+description: |
+  Request body for `POST /v1/enterprise-connections` and
+  `PATCH /v1/enterprise-connections/{id}`. Mirrors `EnterpriseConnection`
+  minus the server-computed fields (`id`, `object`, `saml_acs_url`,
+  `saml_sp_entity_id`, `oidc_redirect_uri`, `created_at`, `updated_at`)
+  and adds the write-only secrets (`oidc_client_secret`,
+  `saml_signing_key`).
+
+  ### POST vs PATCH
+
+  - On `POST`, `protocol`, `name` are always required.
+    `organization_id` is required (use `null` for instance-wide).
+    For `protocol: "saml"` the operator must supply `saml_idp_entity_id`,
+    `saml_sso_url`, and `saml_idp_certificate`.
+    For `protocol: "oidc"` the operator must supply `oidc_issuer` and
+    `oidc_client_id`. `oidc_client_secret` is required on `POST` unless
+    the IdP supports PKCE-only public clients.
+  - On `PATCH`, every field is optional. `protocol` and
+    `organization_id` are immutable — sending a different value returns
+    `422`.
+
+  ### Write-only secrets
+
+  - `oidc_client_secret` — OIDC client secret. Omit on PATCH to leave
+    the stored value unchanged. Send `null` on PATCH to clear it (when
+    migrating to PKCE).
+  - `saml_signing_key` — PEM-encoded private key the SP uses to sign
+    SAML AuthnRequests / LogoutRequests. Optional on POST (the platform
+    can generate one on demand). Omit on PATCH to keep the stored key;
+    send `null` to clear and regenerate.
+
+  Both fields are encrypted at rest and never returned by any response.
+additionalProperties: false
+properties:
+  protocol:
+    type: string
+    enum: [saml, oidc]
+    description: |
+      Required on `POST`; immutable on `PATCH`.
+  name:
+    type: string
+    minLength: 1
+    maxLength: 100
+  enabled:
+    type: boolean
+    default: true
+  organization_id:
+    type: [string, "null"]
+    description: |
+      Required on `POST` (use `null` for instance-wide). Immutable on
+      `PATCH`.
+  domains:
+    type: array
+    items:
+      type: string
+      format: hostname
+    description: |
+      Verified domains routed to this connection. Each entry must
+      already exist as a verified `OrganizationDomain` (org-scoped
+      connections) or workspace-verified domain (instance-wide). Sending
+      an unverified domain returns `422 enterprise_connection_domain_unverified`.
+  default_role:
+    type: string
+    description: |
+      `Role.key` assigned to JIT-provisioned `OrganizationMembership`
+      rows. Defaults to `org:member`. Ignored for instance-wide
+      connections.
+  attribute_mapping:
+    type: object
+    additionalProperties:
+      type: string
+    description: |
+      Override the server-supplied defaults. Keys: `email_address`,
+      `first_name`, `last_name`, `provider_user_id`, `organization_role`.
+  saml_idp_entity_id:
+    type: [string, "null"]
+    description: |
+      Required on `POST` for `protocol: "saml"`. `null` for OIDC.
+  saml_sso_url:
+    type: [string, "null"]
+    format: uri
+    description: |
+      Required on `POST` for `protocol: "saml"`. `null` for OIDC.
+  saml_idp_certificate:
+    type: [string, "null"]
+    description: |
+      PEM-encoded X.509 certificate. Required on `POST` for
+      `protocol: "saml"`. `null` for OIDC.
+  saml_signing_algorithm:
+    type: [string, "null"]
+    enum: [RSA_SHA256, RSA_SHA384, RSA_SHA512, null]
+    description: |
+      Defaults to `RSA_SHA256` for SAML connections.
+  saml_audience_uri:
+    type: [string, "null"]
+    description: |
+      Defaults to the computed `saml_sp_entity_id`. Override for IdPs
+      that pin audience to a custom URI.
+  saml_signing_key:
+    type: [string, "null"]
+    writeOnly: true
+    description: |
+      Write-only. PEM-encoded private key for signing AuthnRequests /
+      LogoutRequests. Optional on POST (platform generates one when
+      omitted). Send `null` on PATCH to clear and regenerate.
+  oidc_issuer:
+    type: [string, "null"]
+    format: uri
+    description: |
+      Required on `POST` for `protocol: "oidc"`. `null` for SAML.
+  oidc_discovery_endpoint:
+    type: [string, "null"]
+    format: uri
+    description: |
+      Optional override for `<oidc_issuer>/.well-known/openid-configuration`.
+  oidc_client_id:
+    type: [string, "null"]
+    description: |
+      Required on `POST` for `protocol: "oidc"`. `null` for SAML.
+  oidc_client_secret:
+    type: [string, "null"]
+    writeOnly: true
+    maxLength: 1024
+    description: |
+      Write-only OIDC client secret. Required on `POST` for
+      `protocol: "oidc"` unless the IdP supports PKCE-only public
+      clients. Omit on PATCH to keep the stored value; send `null` to
+      clear it. Encrypted at rest; never returned.
+  oidc_scopes:
+    type: array
+    items:
+      type: string
+    description: |
+      Overrides the default `["openid", "profile", "email"]` for OIDC
+      connections.
+examples:
+  - protocol: saml
+    name: Acme Okta
+    organization_id: org_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    domains: ["acme.example"]
+    saml_idp_entity_id: https://idp.acme.example/saml/metadata
+    saml_sso_url: https://idp.acme.example/saml/sso
+    saml_idp_certificate: "-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
+    attribute_mapping:
+      email_address: "urn:oid:0.9.2342.19200300.100.1.3"
+      provider_user_id: nameid
+  - protocol: oidc
+    name: Acme Azure AD
+    organization_id: org_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    domains: ["acme.example", "acme-corp.example"]
+    oidc_issuer: https://login.microsoftonline.com/acme-tenant/v2.0
+    oidc_client_id: 11111111-2222-3333-4444-555555555555
+    oidc_client_secret: shhhh
+    oidc_scopes: ["openid", "profile", "email"]
+  - protocol: oidc
+    name: Workspace-wide Okta
+    organization_id: null
+    domains: ["staff.example"]
+    oidc_issuer: https://staff-corp.okta.com
+    oidc_client_id: 0oa1abcdEFGHIJKLM2x7
+    oidc_client_secret: shhhh
+    oidc_scopes: ["openid", "profile", "email", "groups"]
+    default_role: org:member


### PR DESCRIPTION
Closes #74

## Summary

Adds the v0.6 Enterprise SSO foundation as two new schemas — `EnterpriseConnection` and `EnterpriseConnectionRequest`. Single shape carries both SAML 2.0 and OIDC under a `protocol` discriminator; consumers branch on the field rather than maintaining parallel resources.

Instance-wide (`organization_id: null`) and org-scoped variants share one shape. Both write-only secrets (`oidc_client_secret`, `saml_signing_key`) are encrypted at rest and never returned.

Endpoints come in OA-4 (BAPI) / OA-5 (FAPI per-org). Webhook events in OA-8.

## Schemas

- `components/schemas/EnterpriseConnection.yaml`
  - `id` (`entcon_…`), `object: "enterprise_connection"`, `protocol` (`saml` | `oidc`)
  - `organization_id` (nullable — `null` for instance-wide; immutable)
  - `domains[]`, `default_role`, `attribute_mapping`
  - SAML block: `saml_idp_entity_id`, `saml_sso_url`, `saml_idp_certificate`, `saml_signing_algorithm`, `saml_audience_uri`
  - Computed read-only: `saml_acs_url`, `saml_sp_entity_id`, `oidc_redirect_uri`
  - OIDC block: `oidc_issuer`, `oidc_discovery_endpoint`, `oidc_client_id`, `oidc_scopes[]`
- `components/schemas/EnterpriseConnectionRequest.yaml`
  - Same fields minus computed; adds write-only `oidc_client_secret`, `saml_signing_key`
  - `protocol` + `organization_id` immutable on PATCH

Both schemas registered on `bapi.yaml` `components.schemas`.

## Examples

Three example payloads on `EnterpriseConnection` (SAML org-scoped, OIDC org-scoped, OIDC instance-wide) and three on `EnterpriseConnectionRequest` (one per shape).

## Validation

- `npm run lint` — pass (only the pre-existing `no-invalid-media-type-examples` warning on `paths/bapi/instance.yaml`).
- `npm run bundle` — bapi + fapi bundle cleanly. `EnterpriseConnection` references appear in `dist/bapi.bundled.yaml`.

## Bundle diff

`bapi.yaml` gains two `components.schemas` entries:

```yaml
EnterpriseConnection:        { $ref: ./components/schemas/EnterpriseConnection.yaml }
EnterpriseConnectionRequest: { $ref: ./components/schemas/EnterpriseConnectionRequest.yaml }
```

No FAPI changes in this PR (OA-5 adds the per-org FAPI surface).