### PR TITLE
OA-3: enterprise_sso + saml first-factor strategies on Challenge

### DIFF
--- a/components/schemas/Challenge.yaml
+++ b/components/schemas/Challenge.yaml
@@ -108,6 +108,7 @@ required:
   - nonce
   - external_verification_redirect_url
   - error
+  - enterprise_connection_id
   - created_at
   - updated_at
 additionalProperties: false
@@ -212,6 +213,20 @@ properties:
         (allowed credentials, RP id, user-verification policy) on
         creation; the SDK runs `navigator.credentials.get(...)` and
         answers with the attestation response.
+      - `enterprise_sso` — generic enterprise-IdP first factor. The
+        server resolves the right `EnterpriseConnection` from the
+        identifier-domain → `EnterpriseConnection.domains[]` lookup,
+        then mints the IdP-side authorize URL (SAML `<AuthnRequest>`
+        on `saml_sso_url` or OIDC `/authorize` on the discovered
+        `authorization_endpoint`) and surfaces it on
+        `external_verification_redirect_url`. The SDK redirects the
+        browser there and resumes at `/v1/saml/{id}/acs` (SAML) or
+        `/v1/enterprise-sso-callback` (OIDC). v0.6+.
+      - `saml` — protocol-specific variant when the SDK already knows
+        the connection (org picker, wizard preview). Caller supplies
+        `enterprise_connection_id` on `ChallengeCreateRequest`; only
+        legal for connections with `protocol: "saml"`. Otherwise
+        identical to `enterprise_sso`. v0.6+.
     examples:
       - password
       - email_code
@@ -234,6 +249,8 @@ properties:
       - oauth_slack
       - phone_code
       - passkey
+      - enterprise_sso
+      - saml
   status:
     type: string
     enum: [pending, verified, transferable, failed, expired]
@@ -288,6 +305,16 @@ properties:
     oneOf:
       - $ref: ./PasskeyRequestOptions.yaml
       - type: "null"
+  enterprise_connection_id:
+    description: |
+      `EnterpriseConnection.id` the challenge resolved against.
+      Populated when `strategy` is `enterprise_sso` (domain-routed
+      resolution) or `saml` (caller-supplied
+      `enterprise_connection_id` on the request body). `null` for
+      every other strategy. v0.6+.
+    oneOf:
+      - $ref: ./Id.yaml
+      - type: "null"
   created_at:
     $ref: ./Timestamp.yaml
   updated_at:
@@ -307,6 +334,7 @@ examples:
     nonce: poll_01HKX9SY9V7H7TF8C8K7J9X4ZF
     external_verification_redirect_url: "https://acme.authn.sh/v1/client/handshake?__authn_ticket=tkt_01HKX9SY9V7H7TF8C8K7J9X4ZG&__authn_status=complete"
     error: null
+    enterprise_connection_id: null
     created_at: 1714723000000
     updated_at: 1714723000000
   - id: chal_01HKX9SY9V7H7TF8C8K7J9X4ZE
@@ -323,6 +351,7 @@ examples:
     nonce: null
     external_verification_redirect_url: null
     error: null
+    enterprise_connection_id: null
     created_at: 1714723000000
     updated_at: 1714723500000
   - id: chal_01HKX9SY9V7H7TF8C8K7J9X4ZN
@@ -339,6 +368,7 @@ examples:
     nonce: null
     external_verification_redirect_url: null
     error: null
+    enterprise_connection_id: null
     created_at: 1714723000000
     updated_at: 1714723000000
   - id: chal_01HKX9SY9V7H7TF8C8K7J9X4ZP
@@ -355,6 +385,7 @@ examples:
     nonce: "authn-domain-verification=01HKX9SY9V7H7TF8C8K7J9X4ZQ"
     external_verification_redirect_url: null
     error: null
+    enterprise_connection_id: null
     created_at: 1714896900000
     updated_at: 1714896900000
   - id: chal_01HKX9SY9V7H7TF8C8K7J9X4ZT
@@ -371,6 +402,7 @@ examples:
     nonce: null
     external_verification_redirect_url: null
     error: null
+    enterprise_connection_id: null
     created_at: 1714723000000
     updated_at: 1714723000000
   - id: chal_01HKX9SY9V7H7TF8C8K7J9X4ZU
@@ -387,5 +419,40 @@ examples:
     nonce: null
     external_verification_redirect_url: null
     error: null
+    enterprise_connection_id: null
     created_at: 1714723000000
     updated_at: 1714723500000
+  - id: chal_01HKX9SY9V7H7TF8C8K7J9X4ZV
+    object: challenge
+    sign_in_id: sia_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    sign_up_id: null
+    email_address_id: null
+    organization_domain_id: null
+    step: first
+    strategy: enterprise_sso
+    status: pending
+    attempts: 0
+    expire_at: 1714724000000
+    nonce: null
+    external_verification_redirect_url: "https://idp.acme.example/saml/sso?SAMLRequest=..."
+    error: null
+    enterprise_connection_id: entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    created_at: 1714723000000
+    updated_at: 1714723000000
+  - id: chal_01HKX9SY9V7H7TF8C8K7J9X4ZW
+    object: challenge
+    sign_in_id: sia_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    sign_up_id: null
+    email_address_id: null
+    organization_domain_id: null
+    step: first
+    strategy: saml
+    status: pending
+    attempts: 0
+    expire_at: 1714724000000
+    nonce: null
+    external_verification_redirect_url: "https://idp.acme.example/saml/sso?SAMLRequest=..."
+    error: null
+    enterprise_connection_id: entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    created_at: 1714723000000
+    updated_at: 1714723000000

--- a/components/schemas/ChallengeCreateRequest.yaml
+++ b/components/schemas/ChallengeCreateRequest.yaml
@@ -17,8 +17,8 @@ description: |
   Per-parent legal strategies:
 
   - `SignIn` (first factor) — `password`, `email_code`, `email_link`,
-    `phone_code`, `oauth_<provider_key>`, `passkey`,
-    `reset_password_email_code`, `ticket`, `transfer`.
+    `phone_code`, `oauth_<provider_key>`, `passkey`, `enterprise_sso`,
+    `saml`, `reset_password_email_code`, `ticket`, `transfer`.
     `oauth_<provider_key>` requires `redirect_url` and
     `redirect_url_complete` — the server bakes them into the IdP
     `state` and surfaces the IdP's authorize URL on
@@ -38,14 +38,17 @@ description: |
     `User.primary_phone_number_id`; supply `phone_number_id`
     explicitly to target a different reserved-for-MFA row.
   - `SignUp` — `email_code`, `email_link`, `phone_code`,
-    `oauth_<provider_key>`, `passkey`, `ticket`, `transfer`. Sign-up
-    never gains a second factor — the `phone_code` here is the
-    first-factor phone-attribute path; `oauth_<provider_key>` is
-    the first-factor social-sign-up path (subject to
-    `OauthProvider.allow_sign_up`). `passkey` on a sign-up parent
-    is used when the identifier already resolves to a user with
-    ≥1 verified passkey — the resulting challenge flips to
-    `transferable` so the SDK bounces to sign-in (PLAN §9.4).
+    `oauth_<provider_key>`, `passkey`, `enterprise_sso`, `saml`,
+    `ticket`, `transfer`. Sign-up never gains a second factor — the
+    `phone_code` here is the first-factor phone-attribute path;
+    `oauth_<provider_key>` is the first-factor social-sign-up path
+    (subject to `OauthProvider.allow_sign_up`). `passkey` on a
+    sign-up parent is used when the identifier already resolves to
+    a user with ≥1 verified passkey — the resulting challenge flips
+    to `transferable` so the SDK bounces to sign-in. `enterprise_sso`
+    / `saml` mint a `User` + `EnterpriseAccount` on a fresh identity
+    or flip to `transferable` when the IdP-asserted identity already
+    has a `User`.
   - `EmailAddress` — `email_code`, `email_link`.
   - `PhoneNumber` — `phone_code`. Used by FAPI
     `/v1/me/phone-numbers/{id}/challenges` to verify additional phone
@@ -59,11 +62,15 @@ properties:
     description: |
       Strategy across all parents:
       `password`, `email_code`, `email_link`, `phone_code`,
-      `oauth_<provider_key>`, `passkey`, `reset_password_email_code`,
-      `ticket`, `transfer`, `domain_dns_txt`, `totp`, `backup_code`.
+      `oauth_<provider_key>`, `passkey`, `enterprise_sso`, `saml`,
+      `reset_password_email_code`, `ticket`, `transfer`,
+      `domain_dns_txt`, `totp`, `backup_code`.
       `oauth_<provider_key>` resolves against the environment's
       `OauthProvider` registry — `<provider_key>` matches
-      `^[a-z][a-z0-9_]*$`.
+      `^[a-z][a-z0-9_]*$`. `enterprise_sso` is identifier-less
+      domain-routed; `saml` requires `enterprise_connection_id` on
+      the body and is only legal for connections with
+      `protocol: "saml"`.
     examples:
       - password
       - email_code
@@ -78,6 +85,8 @@ properties:
       - totp
       - backup_code
       - passkey
+      - enterprise_sso
+      - saml
   email_address_id:
     type: string
     description: |
@@ -116,11 +125,22 @@ properties:
     type: string
     format: uri
     description: |
-      For `oauth_<provider_key>`, the URL the SDK should land the
-      user on after the parent flow finishes successfully (or flips
-      to `transferable`). Must be on the redirect-URL allowlist.
-      Required when `strategy` starts with `oauth_`; ignored
+      For `oauth_<provider_key>` / `enterprise_sso` / `saml`, the
+      URL the SDK should land the user on after the parent flow
+      finishes successfully (or flips to `transferable`). Must be
+      on the redirect-URL allowlist. Required when `strategy` is
+      `oauth_<provider_key>`, `enterprise_sso`, or `saml`; ignored
       otherwise.
+  enterprise_connection_id:
+    type: string
+    description: |
+      Required when `strategy` is `saml` — the
+      `EnterpriseConnection.id` (`entcon_…`) to drive the SAML flow
+      against. Only legal for connections with `protocol: "saml"`.
+      Optional for `enterprise_sso` (omit to let domain routing
+      pick); when supplied for `enterprise_sso` it pins the
+      Challenge to that connection without domain routing.
+      Ignored for every other strategy.
 examples:
   - { strategy: password }
   - { strategy: email_code, email_address_id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE }
@@ -143,3 +163,10 @@ examples:
   - { strategy: totp }
   - { strategy: backup_code }
   - { strategy: passkey }
+  - strategy: enterprise_sso
+    redirect_url: https://app.acme.com/sign-in
+    redirect_url_complete: https://app.acme.com/dashboard
+  - strategy: saml
+    enterprise_connection_id: entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    redirect_url: https://app.acme.com/sign-in
+    redirect_url_complete: https://app.acme.com/dashboard

--- a/components/schemas/SignIn.yaml
+++ b/components/schemas/SignIn.yaml
@@ -15,7 +15,50 @@ description: |
   top via the `needs_second_factor` step. v0.4 adds
   `oauth_<provider_key>` for first-factor social sign-in (see below).
   v0.5 adds `passkey` (WebAuthn) as an identifier-less first-factor
-  strategy alongside OAuth. SAML lands in a later milestone.
+  strategy alongside OAuth. v0.6 adds enterprise SSO via
+  `enterprise_sso` (generic, domain-routed) and `saml` (caller picks
+  the connection — see below).
+
+  ### Enterprise-SSO first-factor flow (v0.6)
+
+  Two first-factor strategies surface enterprise IdPs:
+
+  - `enterprise_sso` — generic; the server resolves the right
+    `EnterpriseConnection` from the identifier-domain →
+    `EnterpriseConnection.domains[]` lookup. When the identifier
+    domain matches exactly one enterprise connection,
+    `SignIn.supported_strategies` narrows to `["enterprise_sso"]` and
+    `SignIn.enterprise_connection_id` is populated; the SDK issues a
+    Challenge with `strategy: "enterprise_sso"` and follows the IdP
+    redirect.
+  - `saml` — caller picks the connection explicitly via
+    `ChallengeCreateRequest.enterprise_connection_id`. Used by the
+    multi-connection org picker on `<SignIn />` and by the
+    `EnterpriseConnection.test` dry-run preview.
+
+  Both strategies surface the IdP's authorize URL on the Challenge's
+  `external_verification_redirect_url`. The SDK redirects the browser
+  there; the server resumes at `/v1/saml/{id}/acs` (SAML) or
+  `/v1/enterprise-sso-callback` (OIDC), creates / matches the
+  `EnterpriseAccount`, flips the Challenge to `verified`, and advances
+  the SignIn to `complete` (or `transferable` if the resolved identity
+  has no matching `User`).
+
+  ### Enterprise-SSO error codes
+
+  - `enterprise_sso_no_connection` — `enterprise_sso` was requested
+    but the identifier domain matches no `EnterpriseConnection`.
+  - `enterprise_sso_multiple_connections` — `enterprise_sso` was
+    requested and the identifier domain matches more than one
+    `EnterpriseConnection`. The SDK should fall back to listing the
+    matching connections (server returns them in `meta.connections[]`)
+    and re-issuing the Challenge with `strategy: "saml"` plus an
+    explicit `enterprise_connection_id`.
+  - `enterprise_sso_assertion_invalid` — surfaced on the resumption
+    endpoint when the SAML assertion fails signature verification,
+    audience check, or NotBefore/NotOnOrAfter window, or when the
+    OIDC id_token fails JWKS verification or `nonce` mismatch. The
+    Challenge lands `failed`; the SDK creates a fresh one to retry.
 
   ### OAuth first-factor flow (v0.4, PLAN §9.3 + §9.4)
 
@@ -159,7 +202,13 @@ properties:
         the sign-in was started in username-less mode and the
         environment has WebAuthn enabled). The OAuth entries
         surface independently of the supplied `identifier` —
-        they're identifier-less.
+        they're identifier-less. v0.6 adds `enterprise_sso` (when the
+        identifier domain resolves to ≥1 `EnterpriseConnection`) and
+        `saml` (when at least one `protocol: "saml"` connection is
+        reachable from the identifier or via the org picker). When
+        domain routing resolves exactly one enterprise connection,
+        the server narrows the list to `["enterprise_sso"]` and
+        populates `SignIn.enterprise_connection_id`.
       - `needs_second_factor` — narrowed to second-factor strategies
         the resolved user has enrolled. v0.3 surface: `totp`,
         `backup_code`. Each entry maps to whichever of
@@ -175,9 +224,22 @@ properties:
     examples:
       - [password, email_code, email_link, reset_password_email_code]
       - [password, email_code, oauth_google, oauth_github, passkey]
+      - [enterprise_sso]
+      - [enterprise_sso, saml]
       - [totp, backup_code]
       - [totp]
       - [backup_code]
+  enterprise_connection_id:
+    description: |
+      Populated when verified-domain routing resolved exactly one
+      `EnterpriseConnection` for the identifier. `null` when no
+      domain match was found, when the identifier hasn't been
+      resolved yet (`needs_identifier`), or when multiple
+      connections match (the SDK picks one and supplies it on the
+      `saml` `Challenge` body). v0.6+.
+    oneOf:
+      - $ref: ./Id.yaml
+      - type: "null"
   current_challenge_id:
     description: |
       Pointer to the live `Challenge` if one's in flight. `null` when

--- a/components/schemas/SignUp.yaml
+++ b/components/schemas/SignUp.yaml
@@ -16,8 +16,12 @@ description: |
   identifier-less social sign-up that mints a `User` +
   `ExternalAccount` together. v0.5 adds `passkey` as a documented
   strategy on completed sign-ups so SDKs can prompt the new user to
-  enroll a passkey immediately. SAML sign-ups land in a later
-  milestone.
+  enroll a passkey immediately. v0.6 adds `enterprise_sso` and `saml`
+  — identifier-less enterprise sign-up that mints a `User` +
+  `EnterpriseAccount` together. When the IdP returns an identity that
+  already has a `User`, the Challenge flips to `transferable` and the
+  SDK bounces to sign-in via
+  `POST /v1/client/sign-ins { transfer: true }`.
 
   ### OAuth sign-up flow (v0.4, PLAN §9.3 + §9.4)
 
@@ -120,10 +124,14 @@ properties:
       social sign-up; one entry per enabled `OauthProvider` row with
       `allow_sign_up: true`. `passkey` — surfaced post-completion so
       SDKs can chain a passkey enrollment ceremony on the freshly
-      minted `User`. Empty when the flow is `abandoned`.
+      minted `User`. `enterprise_sso` / `saml` (v0.6) —
+      identifier-less enterprise sign-up; surfaces when the
+      environment has ≥1 `EnterpriseConnection` reachable. Empty
+      when the flow is `abandoned`.
     examples:
       - [email_code, email_link]
       - [email_code, oauth_google, oauth_github]
+      - [email_code, enterprise_sso]
   current_challenge_id:
     description: |
       Pointer to the live `Challenge` if one's in flight. `null` when


### PR DESCRIPTION
Closes #76

## Summary

Adds two v0.6 first-factor strategies on `Challenge` that drive Enterprise SSO sign-in / sign-up:

- `enterprise_sso` — identifier-less, domain-routed. Server resolves the right `EnterpriseConnection` from `EnterpriseConnection.domains[]` based on the identifier domain. When exactly one matches, the parent SignIn narrows `supported_strategies` to `[enterprise_sso]` and populates `SignIn.enterprise_connection_id`.
- `saml` — caller-picks the connection via `enterprise_connection_id` on the request body. Only legal for connections with `protocol: "saml"`. Used by the multi-connection org picker on `<SignIn />` and by the EnterpriseConnection test dry-run.

Both surface the IdP's authorize URL on `external_verification_redirect_url`; the server resumes at `/v1/saml/{id}/acs` (SAML) or `/v1/enterprise-sso-callback` (OIDC) and creates / matches the `EnterpriseAccount` row.

## Schema changes

- `Challenge.yaml`
  - `strategy` enum + description extended with `enterprise_sso` + `saml`
  - New field `enterprise_connection_id` (nullable) — surfaces which connection resolved
  - Two new example payloads (enterprise_sso, saml)
- `ChallengeCreateRequest.yaml`
  - `strategy` enum + description extended
  - New optional `enterprise_connection_id` field (required for `saml`, optional pin for `enterprise_sso`)
  - `redirect_url_complete` doc extended to cover the new strategies
  - Two new example bodies
- `SignIn.yaml`
  - New `enterprise_connection_id` field
  - Description + `supported_strategies` doc extended
  - New error-code section: `enterprise_sso_no_connection`, `enterprise_sso_multiple_connections`, `enterprise_sso_assertion_invalid`
- `SignUp.yaml`
  - Description + `supported_strategies` doc extended for identifier-less enterprise sign-up + `transferable` bounce to sign-in

## Validation

- `npm run lint` — pass.
- `npm run bundle` — bapi + fapi bundle cleanly.

Out of scope: server-side strategy implementation (lives in authn AU-7); domain-routing nuance lives in OA-6.