### PR TITLE
OA-4: BAPI /v1/enterprise-connections (instance-wide CRUD + test dry-run)

### DIFF
--- a/bapi.yaml
+++ b/bapi.yaml
@@ -67,6 +67,8 @@ tags:
     description: Per-environment settings (`InstanceSetting`).
   - name: OAuth Providers
     description: Per-environment social-IdP configuration (`OauthProvider`).
+  - name: Enterprise Connections
+    description: Per-environment enterprise-IdP configuration (`EnterpriseConnection`).
   - name: SMS Templates
     description: Per-environment outbound SMS body customization (`SmsTemplate`).
   - name: Webhooks
@@ -188,6 +190,12 @@ paths:
     $ref: ./paths/bapi/oauth-provider.yaml
   /v1/oauth-providers/{oauth_provider_id}/test:
     $ref: ./paths/bapi/oauth-provider-test.yaml
+  /v1/enterprise-connections:
+    $ref: ./paths/bapi/enterprise-connections.yaml
+  /v1/enterprise-connections/{enterprise_connection_id}:
+    $ref: ./paths/bapi/enterprise-connection.yaml
+  /v1/enterprise-connections/{enterprise_connection_id}/test:
+    $ref: ./paths/bapi/enterprise-connection-test.yaml
   /v1/sms-templates:
     $ref: ./paths/bapi/sms-templates.yaml
   /v1/sms-templates/{sms_template_slug}:
@@ -285,6 +293,7 @@ components:
     OauthProviderTestResult:                   { $ref: ./components/schemas/OauthProviderTestResult.yaml }
     EnterpriseConnection:                      { $ref: ./components/schemas/EnterpriseConnection.yaml }
     EnterpriseConnectionRequest:               { $ref: ./components/schemas/EnterpriseConnectionRequest.yaml }
+    EnterpriseConnectionTestResult:            { $ref: ./components/schemas/EnterpriseConnectionTestResult.yaml }
     EnterpriseAccount:                         { $ref: ./components/schemas/EnterpriseAccount.yaml }
     SmsTemplate:                               { $ref: ./components/schemas/SmsTemplate.yaml }
     SmsTemplateRequest:                        { $ref: ./components/schemas/SmsTemplateRequest.yaml }

--- a/components/schemas/EnterpriseConnectionTestResult.yaml
+++ b/components/schemas/EnterpriseConnectionTestResult.yaml
@@ -1,0 +1,70 @@
+type: object
+description: |
+  Result of `POST /v1/enterprise-connections/{id}/test`. The dashboard
+  uses this shape to render a per-connection health indicator on the
+  Enterprise SSO configuration page. Always returned with HTTP `200`
+  even when probes fail — inspect `errors[]` to decide pass/fail.
+
+  For `protocol: "oidc"` connections, the server probes
+  `oidc_discovery_endpoint` (resolved from `oidc_issuer`) and surfaces
+  the HTTP status code on `discovery_status`. For `protocol: "saml"`
+  connections, the server fetches the IdP metadata XML from
+  `saml_idp_entity_id` (when the URL form is supplied), parses it, and
+  signature-verifies it; `discovery_status` carries the HTTP status of
+  the metadata fetch.
+required: [authorize_url, discovery_status, errors]
+additionalProperties: false
+properties:
+  authorize_url:
+    type: string
+    description: |
+      The fully-formed IdP authorize URL the SDK would redirect a user
+      to right now (with a synthetic `state` and the per-connection
+      ACS / redirect URI baked in). For SAML connections, the
+      `<AuthnRequest>` deflated + base64-encoded + appended to
+      `saml_sso_url` as `SAMLRequest=…`. For OIDC, the standard
+      `/authorize?response_type=code&…` URL.
+
+      Empty string when the server could not build the URL (e.g. OIDC
+      discovery refresh failed and no cached endpoint exists, or SAML
+      metadata parsing failed).
+    examples:
+      - "https://idp.acme.example/saml/sso?SAMLRequest=fVJBb%2FIwDP0r..."
+      - "https://login.microsoftonline.com/acme-tenant/v2.0/authorize?response_type=code&client_id=11111111-2222-3333-4444-555555555555&redirect_uri=https%3A%2F%2Facme.authn.sh%2Fv1%2Fenterprise-sso-callback&scope=openid+profile+email&state=test_01HKX9SY9V7H7TF8C8K7J9X4ZA"
+  discovery_status:
+    type: [integer, "null"]
+    minimum: 100
+    maximum: 599
+    description: |
+      HTTP status code returned by the discovery probe. For OIDC, the
+      `GET <oidc_discovery_endpoint>` response code (`200` = healthy).
+      For SAML, the `GET <saml_idp_entity_id>` metadata fetch (when
+      the URL form is supplied). `null` when no discovery URL is
+      configured for the connection.
+  errors:
+    type: array
+    description: |
+      Collected probe errors. Empty when every check passed. Each
+      entry uses the standard `Error` shape (`code` is a stable
+      machine-readable token; SDKs match on it).
+    items:
+      $ref: ./Error.yaml
+examples:
+  - authorize_url: "https://idp.acme.example/saml/sso?SAMLRequest=fVJBb%2FIwDP0r..."
+    discovery_status: 200
+    errors: []
+  - authorize_url: "https://login.microsoftonline.com/acme-tenant/v2.0/authorize?response_type=code&client_id=11111111-2222-3333-4444-555555555555&redirect_uri=https%3A%2F%2Facme.authn.sh%2Fv1%2Fenterprise-sso-callback&scope=openid+profile+email&state=test_01HKX9SY9V7H7TF8C8K7J9X4ZA"
+    discovery_status: 200
+    errors: []
+  - authorize_url: ""
+    discovery_status: 502
+    errors:
+      - code: enterprise_connection_discovery_unreachable
+        message: "Could not reach the OIDC discovery endpoint"
+        long_message: "The IdP's /.well-known/openid-configuration endpoint returned 502. Verify the issuer URL and that authn.sh can reach the IdP."
+  - authorize_url: ""
+    discovery_status: null
+    errors:
+      - code: enterprise_connection_saml_metadata_invalid
+        message: "SAML metadata did not parse"
+        long_message: "Fetched the IdP metadata XML but signature verification failed. Verify saml_idp_certificate matches the IdP's signing key."

--- a/paths/bapi/enterprise-connection-test.yaml
+++ b/paths/bapi/enterprise-connection-test.yaml
@@ -1,0 +1,73 @@
+parameters:
+  - name: enterprise_connection_id
+    in: path
+    required: true
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+post:
+  operationId: testEnterpriseConnection
+  summary: Dry-run an enterprise connection
+  description: |
+    Probe the connection's configuration without redirecting any user.
+    The dashboard runs this on save to surface broken IdPs up front,
+    instead of letting an operator find out at sign-in time.
+
+    The server:
+
+    - Builds the IdP authorize URL the SDK would redirect to (using a
+      synthetic `state` and the per-connection ACS / redirect URI) and
+      returns it on `authorize_url`.
+    - For OIDC connections, `GET`s the `oidc_discovery_endpoint`
+      (resolved from `oidc_issuer`) and records the HTTP status on
+      `discovery_status`. `200` is healthy; other codes surface a
+      problem on the IdP side.
+    - For SAML connections, fetches the IdP metadata XML from
+      `saml_idp_entity_id` (when the URL form is supplied), parses it,
+      and verifies the signature against `saml_idp_certificate`. The
+      HTTP status of the metadata fetch is reflected on
+      `discovery_status`.
+    - Collects any errors (validation, OIDC discovery refresh, SAML
+      metadata signature failures, network timeouts) into `errors[]`.
+
+    Always returns `200` — even when probes fail. The caller inspects
+    `errors[]` to decide whether to surface a red dot in the UI.
+  tags: [Enterprise Connections]
+  responses:
+    "200":
+      description: Probe result. Inspect `errors[]` to decide pass/fail.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/EnterpriseConnectionTestResult.yaml }
+          examples:
+            healthy_saml:
+              summary: SAML — all probes passed
+              value:
+                authorize_url: "https://idp.acme.example/saml/sso?SAMLRequest=fVJBb%2FIwDP0r..."
+                discovery_status: 200
+                errors: []
+            healthy_oidc:
+              summary: OIDC — all probes passed
+              value:
+                authorize_url: "https://login.microsoftonline.com/acme-tenant/v2.0/authorize?response_type=code&client_id=11111111-2222-3333-4444-555555555555&redirect_uri=https%3A%2F%2Facme.authn.sh%2Fv1%2Fenterprise-sso-callback&scope=openid+profile+email&state=test_01HKX9SY9V7H7TF8C8K7J9X4ZA"
+                discovery_status: 200
+                errors: []
+            misconfigured_discovery:
+              summary: OIDC — discovery endpoint returns 5xx
+              value:
+                authorize_url: ""
+                discovery_status: 502
+                errors:
+                  - code: enterprise_connection_discovery_unreachable
+                    message: "Could not reach the OIDC discovery endpoint"
+                    long_message: "The IdP's /.well-known/openid-configuration endpoint returned 502. Verify the issuer URL and that authn.sh can reach the IdP."
+            saml_metadata_invalid:
+              summary: SAML — metadata signature verification failed
+              value:
+                authorize_url: ""
+                discovery_status: null
+                errors:
+                  - code: enterprise_connection_saml_metadata_invalid
+                    message: "SAML metadata did not parse"
+                    long_message: "Fetched the IdP metadata XML but signature verification failed. Verify saml_idp_certificate matches the IdP's signing key."
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }

--- a/paths/bapi/enterprise-connection.yaml
+++ b/paths/bapi/enterprise-connection.yaml
@@ -1,0 +1,87 @@
+parameters:
+  - name: enterprise_connection_id
+    in: path
+    required: true
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+get:
+  operationId: getEnterpriseConnection
+  summary: Get an enterprise connection
+  description: |
+    Fetch a single `EnterpriseConnection` row. Write-only secrets
+    (`oidc_client_secret`, `saml_signing_key`) are never included.
+  tags: [Enterprise Connections]
+  responses:
+    "200":
+      description: The enterprise connection.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/EnterpriseConnection.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+
+patch:
+  operationId: updateEnterpriseConnection
+  summary: Update an enterprise connection
+  description: |
+    Partial update. `protocol` and `organization_id` are immutable —
+    sending a different value returns `422`. Every other field is
+    optional; omitted keys are left untouched.
+
+    Sending `oidc_client_secret: null` clears the stored secret (e.g.
+    when migrating to PKCE). Sending `saml_signing_key: null` clears
+    the stored SP signing key (the platform will regenerate on the
+    next request signing).
+
+    Patching `enabled` to `false` keeps existing `EnterpriseAccount`
+    rows but prevents new sign-ins via this connection.
+  tags: [Enterprise Connections]
+  parameters:
+    - $ref: ../../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../../components/schemas/EnterpriseConnectionRequest.yaml }
+        examples:
+          disable:
+            summary: Pause without deleting
+            value: { enabled: false }
+          rotate_oidc_secret:
+            summary: Rotate the OIDC client secret
+            value: { oidc_client_secret: new-shhhh }
+          rotate_saml_cert:
+            summary: Rotate the IdP signing certificate
+            value:
+              saml_idp_certificate: "-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
+          extend_domains:
+            summary: Add a verified domain to the routing list
+            value:
+              domains: ["acme.example", "acme-corp.example"]
+  responses:
+    "200":
+      description: The updated enterprise connection.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/EnterpriseConnection.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }
+
+delete:
+  operationId: deleteEnterpriseConnection
+  summary: Delete an enterprise connection
+  description: |
+    Soft delete. Refuses (`409 enterprise_connection_in_use`) when any
+    `EnterpriseAccount` rows still link to this connection — operators
+    must migrate or unlink those users first to keep the audit trail
+    of past sign-ins intact. Once deleted, the `enterprise_sso` and
+    `saml` strategies pinned to this connection are rejected for this
+    environment.
+  tags: [Enterprise Connections]
+  responses:
+    "204":
+      description: Deleted.
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "409": { $ref: ../../components/responses/Conflict.yaml }

--- a/paths/bapi/enterprise-connections.yaml
+++ b/paths/bapi/enterprise-connections.yaml
@@ -1,0 +1,102 @@
+get:
+  operationId: listEnterpriseConnections
+  summary: List enterprise connections
+  description: |
+    Paginated list of every `EnterpriseConnection` row configured on
+    the environment, regardless of `enabled` state. Includes both
+    instance-wide (`organization_id: null`) and org-scoped rows by
+    default; filter with `organization_id` to narrow down.
+  tags: [Enterprise Connections]
+  parameters:
+    - $ref: ../../components/parameters/LimitParam.yaml
+    - $ref: ../../components/parameters/OffsetParam.yaml
+    - name: organization_id
+      in: query
+      required: false
+      description: |
+        Filter by scope. Supply an `Organization.id` to return only
+        rows scoped to that org. Supply the literal string `null` to
+        return only instance-wide rows. Omit to return both.
+      schema:
+        type: string
+  responses:
+    "200":
+      description: A page of enterprise connections.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: ../../components/schemas/PaginatedList.yaml
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: ../../components/schemas/EnterpriseConnection.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+
+post:
+  operationId: createEnterpriseConnection
+  summary: Create an instance-wide enterprise connection
+  description: |
+    Register an instance-wide `EnterpriseConnection`. Two protocols:
+
+    - `saml` — operator supplies `saml_idp_entity_id`, `saml_sso_url`,
+      and `saml_idp_certificate`. `saml_signing_algorithm` defaults to
+      `RSA_SHA256`. The server computes `saml_acs_url` and
+      `saml_sp_entity_id` from the new row's id and returns them on
+      the response — register both with the IdP.
+    - `oidc` — operator supplies `oidc_issuer` and `oidc_client_id`.
+      The server fetches `<oidc_issuer>/.well-known/openid-configuration`
+      and populates `oidc_discovery_endpoint`. The computed
+      `oidc_redirect_uri` is returned — register it with the IdP.
+      `oidc_client_secret` is required unless the IdP supports
+      PKCE-only public clients.
+
+    This path is **instance-wide only** — `organization_id` is rejected
+    on POST through the BAPI. Per-org connections are created through
+    the FAPI at
+    `POST /v1/organizations/{org_id}/enterprise-connections`, gated
+    by the `org:sys_sso:manage` permission on the calling user's
+    membership.
+
+    All write-only secrets (`oidc_client_secret`, `saml_signing_key`)
+    are encrypted at rest and never returned by any GET.
+  tags: [Enterprise Connections]
+  parameters:
+    - $ref: ../../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../../components/schemas/EnterpriseConnectionRequest.yaml }
+        examples:
+          saml_workspace_wide:
+            summary: Instance-wide SAML
+            value:
+              protocol: saml
+              name: Workspace-wide Okta
+              organization_id: null
+              domains: ["staff.example"]
+              saml_idp_entity_id: https://staff-corp.okta.com/saml2/metadata
+              saml_sso_url: https://staff-corp.okta.com/sso/saml
+              saml_idp_certificate: "-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
+          oidc_workspace_wide:
+            summary: Instance-wide OIDC
+            value:
+              protocol: oidc
+              name: Workspace-wide Okta
+              organization_id: null
+              domains: ["staff.example"]
+              oidc_issuer: https://staff-corp.okta.com
+              oidc_client_id: 0oa1abcdEFGHIJKLM2x7
+              oidc_client_secret: shhhh
+              oidc_scopes: [openid, profile, email, groups]
+  responses:
+    "201":
+      description: The created enterprise connection.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/EnterpriseConnection.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "409": { $ref: ../../components/responses/Conflict.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }


### PR DESCRIPTION
Closes #77

## Summary

BAPI surface for instance-wide `EnterpriseConnection` rows — what operators drive from the dashboard. Per-org creation lives in the FAPI per OA-5 (gated by `org:sys_sso:manage`).

## Operations

- `GET /v1/enterprise-connections` — list. Optional `organization_id` filter (use literal `null` for instance-wide only).
- `POST /v1/enterprise-connections` — create. **Instance-wide only**; `organization_id` rejected on this path. Two protocol examples (SAML + OIDC).
- `GET|PATCH|DELETE /v1/enterprise-connections/{id}` — `protocol` and `organization_id` immutable on PATCH. DELETE soft-removes; refuses (`409 enterprise_connection_in_use`) when `EnterpriseAccount` rows still link. PATCH examples: disable, rotate OIDC secret, rotate SAML cert, extend domains.
- `POST /v1/enterprise-connections/{id}/test` — dry-run. OIDC: probe `oidc_discovery_endpoint`. SAML: fetch + signature-verify metadata XML. Four response examples covering healthy/unhealthy SAML + OIDC.

## New schema

`components/schemas/EnterpriseConnectionTestResult.yaml` — `authorize_url`, `discovery_status`, `errors[]`. Modelled on `OauthProviderTestResult` but with the discovery-status field that fits both protocols.

## Tag

New BAPI tag `Enterprise Connections`.

## Validation

- `npm run lint` pass; `npm run bundle` clean.