### PR TITLE
OA-5: FAPI /v1/organizations/{org_id}/enterprise-connections (per-org CRUD, role-gated)

### DIFF
--- a/fapi.yaml
+++ b/fapi.yaml
@@ -64,6 +64,8 @@ tags:
     description: Pending invitations to join an organization.
   - name: Org Domains
     description: Verified domains attached to an organization.
+  - name: Org Enterprise Connections
+    description: Per-organization enterprise-IdP configuration (`EnterpriseConnection`).
   - name: Org Membership Requests
     description: Pending join requests created by domain auto-suggestion.
   - name: JWKS / OIDC
@@ -186,6 +188,12 @@ paths:
     $ref: ./paths/fapi/organization-membership-request-accept.yaml
   /v1/organizations/{organization_id}/membership-requests/{request_id}/reject:
     $ref: ./paths/fapi/organization-membership-request-reject.yaml
+  /v1/organizations/{organization_id}/enterprise-connections:
+    $ref: ./paths/fapi/organization-enterprise-connections.yaml
+  /v1/organizations/{organization_id}/enterprise-connections/{enterprise_connection_id}:
+    $ref: ./paths/fapi/organization-enterprise-connection.yaml
+  /v1/organizations/{organization_id}/enterprise-connections/{enterprise_connection_id}/test:
+    $ref: ./paths/fapi/organization-enterprise-connection-test.yaml
   /v1/me/organization-memberships:
     $ref: ./paths/fapi/me-organization-memberships.yaml
   /v1/me/organization-invitations:
@@ -227,6 +235,9 @@ components:
     EmailAddress:                              { $ref: ./components/schemas/EmailAddress.yaml }
     ExternalAccount:                           { $ref: ./components/schemas/ExternalAccount.yaml }
     EnterpriseAccount:                         { $ref: ./components/schemas/EnterpriseAccount.yaml }
+    EnterpriseConnection:                      { $ref: ./components/schemas/EnterpriseConnection.yaml }
+    EnterpriseConnectionRequest:               { $ref: ./components/schemas/EnterpriseConnectionRequest.yaml }
+    EnterpriseConnectionTestResult:            { $ref: ./components/schemas/EnterpriseConnectionTestResult.yaml }
     Passkey:                                   { $ref: ./components/schemas/Passkey.yaml }
     PasskeyCreationOptions:                    { $ref: ./components/schemas/PasskeyCreationOptions.yaml }
     PasskeyAttestation:                        { $ref: ./components/schemas/PasskeyAttestation.yaml }

--- a/paths/fapi/organization-enterprise-connection-test.yaml
+++ b/paths/fapi/organization-enterprise-connection-test.yaml
@@ -1,0 +1,58 @@
+parameters:
+  - name: organization_id
+    in: path
+    required: true
+    description: ID of the organization.
+    schema: { $ref: ../../components/schemas/Id.yaml }
+  - name: enterprise_connection_id
+    in: path
+    required: true
+    description: ID of the enterprise connection.
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+post:
+  operationId: testOrganizationEnterpriseConnection
+  summary: Dry-run an enterprise connection
+  description: |
+    Probe the connection without redirecting any user — same dry-run
+    semantics as the BAPI surface
+    `POST /v1/enterprise-connections/{id}/test`. The
+    `<OrganizationProfile />` SSO setup wizard calls this on save to
+    surface broken IdPs up front.
+
+    Always returns `200` even when probes fail; inspect `errors[]` to
+    decide pass/fail.
+
+    **Access**: requires `org:sys_sso:manage`.
+  tags: [Org Enterprise Connections]
+  responses:
+    "200":
+      description: Probe result. Inspect `errors[]` to decide pass/fail.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/EnterpriseConnectionTestResult.yaml }
+          examples:
+            healthy_saml:
+              summary: SAML — all probes passed
+              value:
+                authorize_url: "https://idp.acme.example/saml/sso?SAMLRequest=fVJBb%2FIwDP0r..."
+                discovery_status: 200
+                errors: []
+            healthy_oidc:
+              summary: OIDC — all probes passed
+              value:
+                authorize_url: "https://login.microsoftonline.com/acme-tenant/v2.0/authorize?response_type=code&client_id=11111111-2222-3333-4444-555555555555&redirect_uri=https%3A%2F%2Facme.authn.sh%2Fv1%2Fenterprise-sso-callback&scope=openid+profile+email&state=test_01HKX9SY9V7H7TF8C8K7J9X4ZA"
+                discovery_status: 200
+                errors: []
+            misconfigured:
+              summary: OIDC — discovery endpoint returns 5xx
+              value:
+                authorize_url: ""
+                discovery_status: 502
+                errors:
+                  - code: enterprise_connection_discovery_unreachable
+                    message: "Could not reach the OIDC discovery endpoint"
+                    long_message: "The IdP's /.well-known/openid-configuration endpoint returned 502. Verify the issuer URL and that authn.sh can reach the IdP."
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "403": { $ref: ../../components/responses/Forbidden.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }

--- a/paths/fapi/organization-enterprise-connection.yaml
+++ b/paths/fapi/organization-enterprise-connection.yaml
@@ -1,0 +1,80 @@
+parameters:
+  - name: organization_id
+    in: path
+    required: true
+    description: ID of the organization.
+    schema: { $ref: ../../components/schemas/Id.yaml }
+  - name: enterprise_connection_id
+    in: path
+    required: true
+    description: ID of the enterprise connection.
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+get:
+  operationId: getOrganizationEnterpriseConnection
+  summary: Get an enterprise connection
+  description: |
+    Fetch a single `EnterpriseConnection` row scoped to this org.
+    Returns `404` when the row exists but is scoped to a different
+    org or is instance-wide. Write-only secrets are never included.
+
+    **Access**: requires `org:sys_sso:read`.
+  tags: [Org Enterprise Connections]
+  responses:
+    "200":
+      description: The enterprise connection.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/EnterpriseConnection.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "403": { $ref: ../../components/responses/Forbidden.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+
+patch:
+  operationId: updateOrganizationEnterpriseConnection
+  summary: Update an enterprise connection
+  description: |
+    Partial update — same shape as the BAPI surface. `protocol` and
+    `organization_id` are immutable; every other field is optional.
+
+    **Access**: requires `org:sys_sso:manage`.
+  tags: [Org Enterprise Connections]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../../components/schemas/EnterpriseConnectionRequest.yaml }
+        examples:
+          disable:
+            summary: Pause without deleting
+            value: { enabled: false }
+          rotate_oidc_secret:
+            summary: Rotate the OIDC client secret
+            value: { oidc_client_secret: new-shhhh }
+  responses:
+    "200":
+      description: The updated enterprise connection.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/EnterpriseConnection.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "403": { $ref: ../../components/responses/Forbidden.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }
+
+delete:
+  operationId: deleteOrganizationEnterpriseConnection
+  summary: Delete an enterprise connection
+  description: |
+    Soft delete. Refuses (`409 enterprise_connection_in_use`) when any
+    `EnterpriseAccount` rows still link.
+
+    **Access**: requires `org:sys_sso:manage`.
+  tags: [Org Enterprise Connections]
+  responses:
+    "204":
+      description: Deleted.
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "403": { $ref: ../../components/responses/Forbidden.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "409": { $ref: ../../components/responses/Conflict.yaml }

--- a/paths/fapi/organization-enterprise-connections.yaml
+++ b/paths/fapi/organization-enterprise-connections.yaml
@@ -1,0 +1,94 @@
+parameters:
+  - name: organization_id
+    in: path
+    required: true
+    description: ID of the organization.
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+get:
+  operationId: listOrganizationEnterpriseConnections
+  summary: List enterprise connections for an organization
+  description: |
+    Paginated list of `EnterpriseConnection` rows scoped to this
+    organization (`organization_id` on each row equals the path id).
+    Instance-wide rows are not surfaced here — for those, list via
+    the BAPI `/v1/enterprise-connections`.
+
+    **Access**: requires `org:sys_sso:read` on the calling user's
+    membership.
+  tags: [Org Enterprise Connections]
+  parameters:
+    - $ref: ../../components/parameters/LimitParam.yaml
+    - $ref: ../../components/parameters/OffsetParam.yaml
+  responses:
+    "200":
+      description: A page of enterprise connections.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: ../../components/schemas/PaginatedList.yaml
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: ../../components/schemas/EnterpriseConnection.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "403": { $ref: ../../components/responses/Forbidden.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+
+post:
+  operationId: createOrganizationEnterpriseConnection
+  summary: Create an enterprise connection for an organization
+  description: |
+    Register an `EnterpriseConnection` scoped to this organization.
+    `organization_id` on the body is ignored — the server takes it
+    from the path parameter, so the SDK can omit it.
+
+    Drives the Enterprise SSO setup wizard on `<OrganizationProfile />`:
+    customers' own org admins configure their IdP without involving
+    the SaaS operator.
+
+    **Access**: requires `org:sys_sso:manage` on the calling user's
+    membership. Lacking the permission returns
+    `403 forbidden` with `meta.permission: "org:sys_sso:manage"` on
+    the error body.
+  tags: [Org Enterprise Connections]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../../components/schemas/EnterpriseConnectionRequest.yaml }
+        examples:
+          saml_org:
+            summary: SAML connection for this org
+            value:
+              protocol: saml
+              name: Acme Okta
+              domains: ["acme.example"]
+              saml_idp_entity_id: https://idp.acme.example/saml/metadata
+              saml_sso_url: https://idp.acme.example/saml/sso
+              saml_idp_certificate: "-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
+              default_role: org:member
+          oidc_org:
+            summary: OIDC connection for this org
+            value:
+              protocol: oidc
+              name: Acme Azure AD
+              domains: ["acme.example", "acme-corp.example"]
+              oidc_issuer: https://login.microsoftonline.com/acme-tenant/v2.0
+              oidc_client_id: 11111111-2222-3333-4444-555555555555
+              oidc_client_secret: shhhh
+              oidc_scopes: [openid, profile, email]
+              default_role: org:member
+  responses:
+    "201":
+      description: The created enterprise connection.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/EnterpriseConnection.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "403": { $ref: ../../components/responses/Forbidden.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "409": { $ref: ../../components/responses/Conflict.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }


### PR DESCRIPTION
Closes #78

## Summary

Per-org FAPI surface for `EnterpriseConnection` — drives the SSO section on `<OrganizationProfile />`. Customers' org admins configure their IdPs without involving the SaaS operator.

## Operations

- `GET /v1/organizations/{org_id}/enterprise-connections` — list rows scoped to this org (instance-wide rows live on the BAPI). Requires `org:sys_sso:read`.
- `POST .../enterprise-connections` — create. `organization_id` taken from path. Requires `org:sys_sso:manage`. SAML + OIDC examples.
- `GET|PATCH|DELETE .../enterprise-connections/{id}` — read / update / soft-delete. Read `org:sys_sso:read`; mutations `org:sys_sso:manage`. Returns 404 when the row is scoped to a different org or is instance-wide.
- `POST .../enterprise-connections/{id}/test` — dry-run; same shape as OA-4 BAPI test. Requires `org:sys_sso:manage`.

## New tag

FAPI tag `Org Enterprise Connections`.

## Schemas registered on fapi.yaml

`EnterpriseConnection`, `EnterpriseConnectionRequest`, `EnterpriseConnectionTestResult` (were BAPI-only before).

## Validation

- `npm run lint` pass; `npm run bundle` clean.