### PR TITLE
OA-6: Verified-domain enrollment modes + enterprise-SSO routing

### DIFF
--- a/components/schemas/OrganizationDomain.yaml
+++ b/components/schemas/OrganizationDomain.yaml
@@ -1,9 +1,25 @@
 type: object
 description: |
   A domain attached to an `Organization`. Once verified, drives
-  domain-based enrollment — depending on `enrollment_mode`, sign-ups
-  with a matching email get an automatic invitation, an automatic
-  membership-request suggestion, or nothing at all.
+  domain-based enrollment and (v0.6+) enterprise-SSO routing.
+
+  ### Enrollment vs SSO routing
+
+  The two behaviours are independent and can stack:
+
+  - **Enrollment** (`enrollment_mode`) controls what happens to a
+    user whose sign-up email matches the domain. Three modes: no-op,
+    auto-invitation, auto-suggestion.
+  - **SSO routing** (v0.6) — separately, when the org has at least
+    one verified `EnterpriseConnection` whose `domains[]` includes
+    this row's `name`, a sign-in whose identifier domain matches is
+    routed to that connection. The server narrows the resolved
+    `SignIn.supported_strategies` to `["enterprise_sso"]` and
+    populates `SignIn.enterprise_connection_id`. Ambiguous matches
+    (multiple connections claim the same domain) surface all
+    options on the SignIn so the SDK can prompt; see OA-3 errors
+    `enterprise_sso_no_connection` /
+    `enterprise_sso_multiple_connections`.
 
   Verification runs through a `Challenge` against
   `/v1/organizations/{org}/domains/{id}/challenges`. The proof channel
@@ -58,13 +74,28 @@ properties:
       - automatic_invitation
       - automatic_suggestion
     description: |
-      - `manual_invitation` — domain match has no effect on sign-up;
-        members must be invited explicitly.
-      - `automatic_invitation` — sign-ups with a matching email
-        skip the invitation step and join as `default_role`.
+      Gates the post-sign-up enrollment side-effect for matches on
+      this domain. Independent of enterprise-SSO routing — that's
+      driven by `EnterpriseConnection.domains[]` and applies at
+      sign-in time, not sign-up.
+
+      - `manual_invitation` — domain match grants no membership on
+        sign-up. Members must be invited explicitly via
+        `OrganizationInvitation`. For sign-ins routed through an
+        enterprise connection (v0.6), the resulting `User` still
+        lands without an `OrganizationMembership` in this mode —
+        the connection's `default_role` is ignored.
+      - `automatic_invitation` — first sign-up under this domain
+        auto-creates an `OrganizationInvitation` that immediately
+        resolves to an `OrganizationMembership` at the org's
+        default role. For enterprise-SSO sign-ins, the JIT-
+        provisioned membership uses the connection's `default_role`.
       - `automatic_suggestion` — sign-ups with a matching email get
         an `OrganizationMembershipRequest` row that an admin must
-        approve.
+        approve via `POST .../membership-requests/{id}/accept`.
+        For enterprise-SSO sign-ins, the membership request is
+        still minted (admin approval is required even though the
+        IdP asserted the identity).
   affiliation_email_address:
     type: [string, "null"]
     format: email

--- a/paths/fapi/sign-ins.yaml
+++ b/paths/fapi/sign-ins.yaml
@@ -7,6 +7,34 @@ post:
     can pick one and create a `Challenge`), or supply an identifier +
     strategy (and password when applicable) to fold the first challenge
     into the create call.
+
+    ### Domain routing to enterprise connections (v0.6)
+
+    When the identifier resolves to an email and the email's domain
+    matches at least one verified `OrganizationDomain` whose org has a
+    reachable `EnterpriseConnection` (the connection's `domains[]`
+    includes the same name), the server applies enterprise-SSO
+    routing:
+
+    - **Exactly one matching connection** —
+      `SignIn.supported_strategies` narrows to `["enterprise_sso"]`
+      and `SignIn.enterprise_connection_id` is populated. The SDK
+      issues a `Challenge` with `strategy: "enterprise_sso"` and
+      follows `external_verification_redirect_url`.
+    - **Multiple matching connections** — all reachable connections
+      surface; `supported_strategies` includes `enterprise_sso` plus
+      one `saml` entry per `protocol: "saml"` connection so the SDK
+      can pick. `SignIn.enterprise_connection_id` stays `null` until
+      the SDK picks one (issuing a `Challenge` with
+      `strategy: "saml"` and an explicit
+      `enterprise_connection_id` body field).
+    - **No matching connection** — domain routing is a no-op;
+      `supported_strategies` reflects the environment's
+      `auth_config` as usual.
+
+    Domain routing is independent of `OrganizationDomain.enrollment_mode`
+    — that field gates the post-sign-up membership side-effect, not
+    sign-in steering.
   tags: [Sign-Ins]
   security:
     - client_cookie: []


### PR DESCRIPTION
Closes #79

## Summary

Documents v0.6 semantics for how verified `OrganizationDomain` rows interact with `EnterpriseConnection`s. Two independent behaviours that stack:

1. **Enrollment** (`enrollment_mode`) — post-sign-up membership side-effect.
2. **SSO routing** — sign-in steering, driven by `EnterpriseConnection.domains[]`.

## Schema doc updates

- `OrganizationDomain.yaml` — top-level description splits the two behaviours apart; each `enrollment_mode` enum value now spells out what happens to a sign-in routed through an enterprise connection (whether JIT membership is minted, whether admin approval is required, etc.).
- `paths/fapi/sign-ins.yaml` — `POST /v1/client/sign-ins` description now documents the server-side domain-routing logic: exactly-one-match → `supported_strategies: [enterprise_sso]`; multi-match → both `enterprise_sso` and per-SAML `saml` entries; no-match → fall back to `auth_config`.

The `SignIn.enterprise_connection_id` field that gets populated by this routing was added in OA-3.

## Validation

`npm run lint` pass; `npm run bundle` clean.