### PR TITLE
OA-7: SCIM 2.0 surface + per-org token / mapping / endpoint CRUD

### DIFF
--- a/components/schemas/ScimAttributeMapping.yaml
+++ b/components/schemas/ScimAttributeMapping.yaml
@@ -1,0 +1,45 @@
+type: object
+description: |
+  Override map from SCIM attribute paths to authn.sh `User` /
+  `OrganizationMembership` fields, scoped per organization. The server
+  ships with a sensible default mapping (`userName` →
+  `email_address`, `name.givenName` → `first_name`, …); this resource
+  lets org admins override it for IdPs that ship non-standard
+  attribute names.
+
+  One row per org — replace it via `PUT
+  /v1/organizations/{org_id}/scim/attribute-mappings`.
+required: [organization_id, mapping]
+additionalProperties: false
+properties:
+  organization_id:
+    $ref: ./Id.yaml
+  mapping:
+    type: object
+    description: |
+      Map from SCIM attribute path (key) to authn.sh field name
+      (value). Standard keys:
+
+      - `userName` — usually `email_address`
+      - `name.givenName` — usually `first_name`
+      - `name.familyName` — usually `last_name`
+      - `emails[primary eq true].value` — usually `email_address`
+      - `externalId` — usually `external_id`
+      - `urn:…:enterprise:2.0:User.department` — free-form into
+        `public_metadata.department` (or wherever the operator
+        wants).
+    additionalProperties:
+      type: string
+    examples:
+      - userName: email_address
+        name.givenName: first_name
+        name.familyName: last_name
+        externalId: external_id
+examples:
+  - organization_id: org_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    mapping:
+      userName: email_address
+      name.givenName: first_name
+      name.familyName: last_name
+      externalId: external_id
+      "emails[primary eq true].value": email_address

--- a/components/schemas/ScimError.yaml
+++ b/components/schemas/ScimError.yaml
@@ -1,0 +1,51 @@
+type: object
+description: |
+  SCIM 2.0 error envelope (RFC 7644 §3.12). Returned by every
+  `/scim/v2/*` endpoint on a 4xx/5xx response instead of the standard
+  authn.sh `ErrorResponse` shape.
+required: [schemas, status]
+additionalProperties: false
+properties:
+  schemas:
+    type: array
+    items: { type: string }
+    description: |
+      Always `["urn:ietf:params:scim:api:messages:2.0:Error"]`.
+    examples:
+      - ["urn:ietf:params:scim:api:messages:2.0:Error"]
+  status:
+    type: string
+    description: |
+      HTTP status code as a string per the SCIM RFC (`"400"`,
+      `"401"`, …).
+    examples:
+      - "400"
+      - "404"
+      - "409"
+  scimType:
+    type: string
+    enum:
+      - invalidFilter
+      - tooMany
+      - uniqueness
+      - mutability
+      - invalidSyntax
+      - invalidPath
+      - noTarget
+      - invalidValue
+      - invalidVers
+      - sensitive
+    description: |
+      Standard SCIM error subtype (RFC 7644 §3.12 table). Present for
+      4xx responses; absent for 5xx.
+  detail:
+    type: string
+    description: Human-readable error message.
+examples:
+  - schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"]
+    status: "409"
+    scimType: uniqueness
+    detail: "A user with that userName already exists."
+  - schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"]
+    status: "404"
+    detail: "Resource not found."

--- a/components/schemas/ScimGroup.yaml
+++ b/components/schemas/ScimGroup.yaml
@@ -1,0 +1,57 @@
+type: object
+description: |
+  SCIM 2.0 `Group` resource (RFC 7643). Used to model
+  `OrganizationMembership` cohorts the IdP wants to sync. The server
+  maps each SCIM `Group` to an authn.sh `Role` (or the
+  `OrganizationMembership.role` field) per the connection's mapping.
+required: [schemas, displayName]
+additionalProperties: true
+properties:
+  schemas:
+    type: array
+    items: { type: string }
+    examples:
+      - ["urn:ietf:params:scim:schemas:core:2.0:Group"]
+  id:
+    type: string
+    examples:
+      - scimgrp_01HKX9SY9V7H7TF8C8K7J9X4ZB
+  externalId:
+    type: [string, "null"]
+  displayName:
+    type: string
+    description: Human-readable label (e.g. "Engineering").
+  members:
+    type: array
+    description: |
+      `ScimUser` ids that belong to the group. PATCH operations on
+      this list translate to `OrganizationMembership` add / remove
+      side-effects.
+    items:
+      type: object
+      properties:
+        value:   { type: string }
+        display: { type: string }
+        $ref:    { type: string, format: uri }
+        type:    { type: string }
+  meta:
+    type: object
+    properties:
+      resourceType: { type: string }
+      created:      { type: string, format: date-time }
+      lastModified: { type: string, format: date-time }
+      location:     { type: string, format: uri }
+examples:
+  - schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"]
+    id: scimgrp_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    externalId: "okta-group-eng"
+    displayName: Engineering
+    members:
+      - value: user_01HKX9SY9V7H7TF8C8K7J9X4ZA
+        display: alice@acme.example
+        type: User
+    meta:
+      resourceType: Group
+      created: "2026-05-11T19:00:00Z"
+      lastModified: "2026-05-11T19:00:00Z"
+      location: https://acme.authn.sh/scim/v2/Groups/scimgrp_01HKX9SY9V7H7TF8C8K7J9X4ZB

--- a/components/schemas/ScimListResponse.yaml
+++ b/components/schemas/ScimListResponse.yaml
@@ -1,0 +1,40 @@
+type: object
+description: |
+  SCIM 2.0 `ListResponse` envelope (RFC 7644 §3.4.2). Returned by
+  `GET /scim/v2/Users` and `GET /scim/v2/Groups`.
+
+  Distinct from the authn.sh `PaginatedList` envelope — IdPs expect
+  the standard SCIM keys (`totalResults`, `startIndex`,
+  `itemsPerPage`, `Resources`) verbatim.
+required: [schemas, totalResults, Resources]
+additionalProperties: false
+properties:
+  schemas:
+    type: array
+    items: { type: string }
+    description: |
+      Always `["urn:ietf:params:scim:api:messages:2.0:ListResponse"]`.
+    examples:
+      - ["urn:ietf:params:scim:api:messages:2.0:ListResponse"]
+  totalResults:
+    type: integer
+    minimum: 0
+    description: Total number of matching resources across all pages.
+  startIndex:
+    type: integer
+    minimum: 1
+    description: |
+      1-based index of the first row on this page (SCIM uses 1-based
+      pagination, unlike authn.sh's 0-based offsets).
+  itemsPerPage:
+    type: integer
+    minimum: 0
+    description: Count of `Resources` on this page.
+  Resources:
+    type: array
+    description: |
+      The page of resources. Type depends on the listed endpoint
+      (`ScimUser` for `/Users`, `ScimGroup` for `/Groups`).
+    items:
+      type: object
+      additionalProperties: true

--- a/components/schemas/ScimPatchOp.yaml
+++ b/components/schemas/ScimPatchOp.yaml
@@ -1,0 +1,59 @@
+type: object
+description: |
+  SCIM 2.0 `PatchOp` envelope (RFC 7644 §3.5.2). Body of `PATCH
+  /scim/v2/Users/{id}` and `PATCH /scim/v2/Groups/{id}`.
+
+  Carries an ordered list of operations (`add` / `remove` / `replace`)
+  against a resource. The server applies them atomically — partial
+  application failures surface as `400 invalidPath` /
+  `400 invalidValue` per RFC 7644 §3.12.
+required: [schemas, Operations]
+additionalProperties: false
+properties:
+  schemas:
+    type: array
+    items: { type: string }
+    description: |
+      Always `["urn:ietf:params:scim:api:messages:2.0:PatchOp"]`.
+    examples:
+      - ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]
+  Operations:
+    type: array
+    items:
+      type: object
+      required: [op]
+      additionalProperties: false
+      properties:
+        op:
+          type: string
+          enum: [add, remove, replace, Add, Remove, Replace]
+          description: |
+            Operation kind. SCIM is case-insensitive on the verb;
+            both lowercase and PascalCase are accepted.
+        path:
+          type: string
+          description: |
+            SCIM attribute path (e.g. `active`, `emails[type eq
+            "work"].value`, `members`). Required for `remove`,
+            optional for `add` / `replace` (when omitted, `value`
+            must be a complete resource patch).
+        value:
+          description: |
+            Replacement / additional value. Type depends on `path` —
+            scalar for primitive attributes, object / array for
+            structured ones.
+examples:
+  - schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]
+    Operations:
+      - op: replace
+        path: active
+        value: false
+  - schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]
+    Operations:
+      - op: add
+        path: members
+        value:
+          - value: user_01HKX9SY9V7H7TF8C8K7J9X4ZA
+            display: alice@acme.example
+      - op: remove
+        path: 'members[value eq "user_01HKX9SY9V7H7TF8C8K7J9X4ZC"]'

--- a/components/schemas/ScimToken.yaml
+++ b/components/schemas/ScimToken.yaml
@@ -1,0 +1,94 @@
+type: object
+description: |
+  Bearer token issued to an IdP's SCIM agent. The IdP pastes the
+  plaintext into its provisioning configuration; subsequent IdP-side
+  requests authenticate against `/scim/v2/*` with
+  `Authorization: Bearer <token>`.
+
+  ### Single-shot plaintext
+
+  The full plaintext token is **only** returned by `POST
+  /v1/organizations/{org_id}/scim/tokens` (the issue endpoint), and
+  only on the response body. Every subsequent read exposes the
+  `prefix` only — there is no way to recover the plaintext after the
+  initial response is consumed. Operators must store the value at
+  issue time or rotate.
+
+  ### Identifier prefixes
+
+  - Row id prefix: `scimt_` (e.g.
+    `scimt_01HKX9SY9V7H7TF8C8K7J9X4ZA`).
+  - Plaintext token prefix: `scim_` followed by base32-encoded random
+    bytes (e.g. `scim_ULID0123456789…`).
+required:
+  - id
+  - object
+  - organization_id
+  - name
+  - prefix
+  - created_at
+  - revoked_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: scim_token
+  organization_id:
+    description: |
+      `Organization.id` this token is scoped to. SCIM requests
+      authenticated with this token can only touch users + groups
+      within this org's `EnterpriseConnection`-provisioned
+      population.
+    $ref: ./Id.yaml
+  name:
+    type: string
+    minLength: 1
+    maxLength: 100
+    description: |
+      Operator-chosen label rendered in the dashboard. Useful to
+      tell multiple IdPs apart on the same org.
+  prefix:
+    type: string
+    description: |
+      First 12 characters of the plaintext (`scim_xxxxxxxx`) for
+      operator-visible identification. The remaining bytes are
+      stored as a hash.
+    examples:
+      - "scim_01HKX9SY"
+  token:
+    type: [string, "null"]
+    writeOnly: true
+    description: |
+      Full plaintext token. Populated only on the response to `POST
+      /v1/organizations/{org_id}/scim/tokens`; **never returned by
+      any GET**. `null` on every list / read response.
+    examples:
+      - "scim_01HKX9SYABCDEFGHJKMNPQRSTVWXYZ234567"
+  created_at:
+    $ref: ./Timestamp.yaml
+  revoked_at:
+    description: |
+      Set when `POST /scim/tokens/{id}/revoke` succeeds. Once set,
+      the token is rejected on every `/scim/v2/*` request with
+      `401 invalidVers`. `null` while the token is active.
+    oneOf:
+      - $ref: ./Timestamp.yaml
+      - type: "null"
+examples:
+  - id: scimt_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    object: scim_token
+    organization_id: org_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    name: Okta — Production
+    prefix: "scim_01HKX9SY"
+    created_at: 1714723000000
+    revoked_at: null
+  - id: scimt_01HKX9SY9V7H7TF8C8K7J9X4ZC
+    object: scim_token
+    organization_id: org_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    name: Okta — Production (rotated)
+    prefix: "scim_01HKX9TT"
+    token: "scim_01HKX9TTABCDEFGHJKMNPQRSTVWXYZ234567"
+    created_at: 1714724000000
+    revoked_at: null

--- a/components/schemas/ScimUser.yaml
+++ b/components/schemas/ScimUser.yaml
@@ -1,0 +1,109 @@
+type: object
+description: |
+  SCIM 2.0 `User` resource (RFC 7643). Sent to `/scim/v2/Users` by an
+  IdP for directory sync. The server maps incoming SCIM attributes to
+  authn.sh `User` columns per the connection's `ScimAttributeMapping`,
+  then mints / updates / disables the underlying `User` row.
+
+  Only the fields authn.sh consumes or emits are documented here.
+  `additionalProperties: true` because IdPs ship vendor-specific
+  extensions (`urn:ietf:params:scim:schemas:extension:enterprise:2.0:User`,
+  Okta-specific keys, …) and SCIM consumers must tolerate them.
+required: [schemas, userName]
+additionalProperties: true
+properties:
+  schemas:
+    type: array
+    items:
+      type: string
+    description: |
+      Schema URIs the resource conforms to. Always includes
+      `urn:ietf:params:scim:schemas:core:2.0:User`; IdPs add
+      extension URIs after that.
+    examples:
+      - ["urn:ietf:params:scim:schemas:core:2.0:User"]
+      - ["urn:ietf:params:scim:schemas:core:2.0:User", "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"]
+  id:
+    type: string
+    description: |
+      Server-assigned identifier — the underlying `User.id` exposed
+      under its `user_` prefix. Mutable only by the server.
+    examples:
+      - user_01HKX9SY9V7H7TF8C8K7J9X4ZA
+  externalId:
+    type: [string, "null"]
+    description: |
+      IdP-side identifier. Mapped to `User.external_id` so the IdP can
+      look its row up after provisioning.
+  userName:
+    type: string
+    description: |
+      Primary unique handle for the user. Mapped to the resolved
+      primary `email_address` (or `User.username` for IdPs that ship
+      one).
+  name:
+    type: object
+    properties:
+      familyName: { type: string }
+      givenName:  { type: string }
+      formatted:  { type: string }
+  displayName:
+    type: string
+  emails:
+    type: array
+    items:
+      type: object
+      properties:
+        value:   { type: string, format: email }
+        type:    { type: string }
+        primary: { type: boolean }
+  active:
+    type: boolean
+    description: |
+      `true` for active users. Patching to `false` disables the
+      underlying `User` (mirrors `POST /v1/users/{id}/lock` with an
+      indefinite lockout). DELETE on `/scim/v2/Users/{id}` is a hard
+      delete; flipping `active` to `false` is the SCIM-idiomatic
+      deprovision.
+  groups:
+    type: array
+    description: |
+      Group memberships the IdP asserts for this user. Mapped to
+      `OrganizationMembership` rows on the connection's org.
+      Read-only — managed via `/scim/v2/Groups` PATCH operations.
+    items:
+      type: object
+      properties:
+        value:   { type: string }
+        display: { type: string }
+        $ref:    { type: string, format: uri }
+  meta:
+    type: object
+    properties:
+      resourceType: { type: string }
+      created:      { type: string, format: date-time }
+      lastModified: { type: string, format: date-time }
+      location:     { type: string, format: uri }
+examples:
+  - schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"]
+    id: user_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    externalId: "00uabcdEFGHIJKLM2x7"
+    userName: alice@acme.example
+    name:
+      givenName: Alice
+      familyName: Anderson
+      formatted: "Alice Anderson"
+    displayName: "Alice Anderson"
+    emails:
+      - value: alice@acme.example
+        type: work
+        primary: true
+    active: true
+    groups:
+      - value: scimgrp_01HKX9SY9V7H7TF8C8K7J9X4ZB
+        display: Engineering
+    meta:
+      resourceType: User
+      created: "2026-05-11T19:00:00Z"
+      lastModified: "2026-05-11T19:00:00Z"
+      location: https://acme.authn.sh/scim/v2/Users/user_01HKX9SY9V7H7TF8C8K7J9X4ZA

--- a/fapi.yaml
+++ b/fapi.yaml
@@ -70,6 +70,10 @@ tags:
     description: Pending join requests created by domain auto-suggestion.
   - name: JWKS / OIDC
     description: Public keys and OIDC discovery served per-environment.
+  - name: SCIM
+    description: SCIM 2.0 directory-sync endpoints (RFC 7644). Authenticated via `bearer_scim_token`.
+  - name: Org SCIM
+    description: Per-organization SCIM token + mapping CRUD (admin-facing).
 
 security:
   - client_cookie: []
@@ -194,6 +198,22 @@ paths:
     $ref: ./paths/fapi/organization-enterprise-connection.yaml
   /v1/organizations/{organization_id}/enterprise-connections/{enterprise_connection_id}/test:
     $ref: ./paths/fapi/organization-enterprise-connection-test.yaml
+  /v1/organizations/{organization_id}/scim/tokens:
+    $ref: ./paths/fapi/organization-scim-tokens.yaml
+  /v1/organizations/{organization_id}/scim/tokens/{scim_token_id}/revoke:
+    $ref: ./paths/fapi/organization-scim-token-revoke.yaml
+  /v1/organizations/{organization_id}/scim/attribute-mappings:
+    $ref: ./paths/fapi/organization-scim-attribute-mappings.yaml
+  /v1/organizations/{organization_id}/scim/endpoint:
+    $ref: ./paths/fapi/organization-scim-endpoint.yaml
+  /scim/v2/Users:
+    $ref: ./paths/fapi/scim-users.yaml
+  /scim/v2/Users/{scim_user_id}:
+    $ref: ./paths/fapi/scim-user.yaml
+  /scim/v2/Groups:
+    $ref: ./paths/fapi/scim-groups.yaml
+  /scim/v2/Groups/{scim_group_id}:
+    $ref: ./paths/fapi/scim-group.yaml
   /v1/me/organization-memberships:
     $ref: ./paths/fapi/me-organization-memberships.yaml
   /v1/me/organization-invitations:
@@ -225,6 +245,16 @@ components:
         FAPI host that can't set a SameSite=Lax cookie cross-site (no HTTPS),
         it sends this query-string JWT instead. Production never uses this.
 
+    bearer_scim_token:
+      type: http
+      scheme: bearer
+      bearerFormat: scim_token
+      description: |
+        Per-organization SCIM 2.0 bearer token (`scim_<base32-ULID-bytes>`).
+        Issued by `POST /v1/organizations/{org_id}/scim/tokens`; scope is the
+        organization the token was minted for. Only valid on `/scim/v2/*`
+        endpoints — every other FAPI path rejects this scheme.
+
   schemas:
     Id:                                        { $ref: ./components/schemas/Id.yaml }
     Timestamp:                                 { $ref: ./components/schemas/Timestamp.yaml }
@@ -238,6 +268,13 @@ components:
     EnterpriseConnection:                      { $ref: ./components/schemas/EnterpriseConnection.yaml }
     EnterpriseConnectionRequest:               { $ref: ./components/schemas/EnterpriseConnectionRequest.yaml }
     EnterpriseConnectionTestResult:            { $ref: ./components/schemas/EnterpriseConnectionTestResult.yaml }
+    ScimUser:                                  { $ref: ./components/schemas/ScimUser.yaml }
+    ScimGroup:                                 { $ref: ./components/schemas/ScimGroup.yaml }
+    ScimListResponse:                          { $ref: ./components/schemas/ScimListResponse.yaml }
+    ScimPatchOp:                               { $ref: ./components/schemas/ScimPatchOp.yaml }
+    ScimError:                                 { $ref: ./components/schemas/ScimError.yaml }
+    ScimToken:                                 { $ref: ./components/schemas/ScimToken.yaml }
+    ScimAttributeMapping:                      { $ref: ./components/schemas/ScimAttributeMapping.yaml }
     Passkey:                                   { $ref: ./components/schemas/Passkey.yaml }
     PasskeyCreationOptions:                    { $ref: ./components/schemas/PasskeyCreationOptions.yaml }
     PasskeyAttestation:                        { $ref: ./components/schemas/PasskeyAttestation.yaml }

--- a/paths/fapi/organization-scim-attribute-mappings.yaml
+++ b/paths/fapi/organization-scim-attribute-mappings.yaml
@@ -1,0 +1,64 @@
+parameters:
+  - name: organization_id
+    in: path
+    required: true
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+get:
+  operationId: getOrganizationScimAttributeMapping
+  summary: Read the SCIM attribute mapping
+  description: |
+    Returns the per-org `ScimAttributeMapping` (server defaults
+    overridden by the operator).
+
+    **Access**: requires `org:sys_provisioning:read`.
+  tags: [Org SCIM]
+  responses:
+    "200":
+      description: The attribute mapping.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ScimAttributeMapping.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "403": { $ref: ../../components/responses/Forbidden.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+
+put:
+  operationId: replaceOrganizationScimAttributeMapping
+  summary: Replace the SCIM attribute mapping
+  description: |
+    Full-resource replace of the override map. Unsupplied keys revert
+    to the server defaults — there is no per-field PATCH.
+
+    **Access**: requires `org:sys_provisioning:manage`.
+  tags: [Org SCIM]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [mapping]
+          additionalProperties: false
+          properties:
+            mapping:
+              type: object
+              additionalProperties: { type: string }
+        examples:
+          okta:
+            value:
+              mapping:
+                userName: email_address
+                name.givenName: first_name
+                name.familyName: last_name
+                externalId: external_id
+  responses:
+    "200":
+      description: The replaced mapping.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ScimAttributeMapping.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "403": { $ref: ../../components/responses/Forbidden.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }

--- a/paths/fapi/organization-scim-endpoint.yaml
+++ b/paths/fapi/organization-scim-endpoint.yaml
@@ -1,0 +1,44 @@
+parameters:
+  - name: organization_id
+    in: path
+    required: true
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+get:
+  operationId: getOrganizationScimEndpoint
+  summary: Read the SCIM endpoint URL
+  description: |
+    Returns the SCIM base URL the IdP admin pastes into their
+    provisioning configuration. The shape is:
+
+    ```
+    https://<env_slug>.authn.sh/scim/v2/
+    ```
+
+    Per-org SCIM token authorisation scopes provisioning to this
+    organization — the IdP doesn't see a per-org URL.
+
+    **Access**: requires `org:sys_provisioning:read`.
+  tags: [Org SCIM]
+  responses:
+    "200":
+      description: The SCIM endpoint URL.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [endpoint_url]
+            additionalProperties: false
+            properties:
+              endpoint_url:
+                type: string
+                format: uri
+                examples:
+                  - https://acme.authn.sh/scim/v2/
+          examples:
+            production:
+              value:
+                endpoint_url: https://acme.authn.sh/scim/v2/
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "403": { $ref: ../../components/responses/Forbidden.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }

--- a/paths/fapi/organization-scim-token-revoke.yaml
+++ b/paths/fapi/organization-scim-token-revoke.yaml
@@ -1,0 +1,29 @@
+parameters:
+  - name: organization_id
+    in: path
+    required: true
+    schema: { $ref: ../../components/schemas/Id.yaml }
+  - name: scim_token_id
+    in: path
+    required: true
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+post:
+  operationId: revokeOrganizationScimToken
+  summary: Revoke a SCIM token
+  description: |
+    Stamp `revoked_at` on the row. Every subsequent `/scim/v2/*`
+    request authenticated with this token returns `401 invalidVers`.
+    Revocation is irreversible — issue a fresh token to replace it.
+
+    **Access**: requires `org:sys_provisioning:manage`.
+  tags: [Org SCIM]
+  responses:
+    "200":
+      description: The revoked token (no plaintext).
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ScimToken.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "403": { $ref: ../../components/responses/Forbidden.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }

--- a/paths/fapi/organization-scim-tokens.yaml
+++ b/paths/fapi/organization-scim-tokens.yaml
@@ -1,0 +1,84 @@
+parameters:
+  - name: organization_id
+    in: path
+    required: true
+    description: ID of the organization.
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+get:
+  operationId: listOrganizationScimTokens
+  summary: List SCIM tokens for an organization
+  description: |
+    Returns active and revoked `ScimToken` rows for this org. The
+    full plaintext token is never returned — only `prefix`.
+
+    **Access**: requires `org:sys_provisioning:read`.
+  tags: [Org SCIM]
+  parameters:
+    - $ref: ../../components/parameters/LimitParam.yaml
+    - $ref: ../../components/parameters/OffsetParam.yaml
+  responses:
+    "200":
+      description: A page of SCIM tokens (no plaintext).
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: ../../components/schemas/PaginatedList.yaml
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: ../../components/schemas/ScimToken.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "403": { $ref: ../../components/responses/Forbidden.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+
+post:
+  operationId: issueOrganizationScimToken
+  summary: Issue a SCIM token
+  description: |
+    Mint a fresh SCIM bearer token scoped to this organization. The
+    response is the **only** time the full plaintext (`token` field)
+    is returned — subsequent reads expose `prefix` only. Operators
+    must capture the value at issue time or rotate.
+
+    **Access**: requires `org:sys_provisioning:manage`.
+  tags: [Org SCIM]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [name]
+          additionalProperties: false
+          properties:
+            name:
+              type: string
+              minLength: 1
+              maxLength: 100
+        examples:
+          okta_prod:
+            value: { name: "Okta — Production" }
+  responses:
+    "201":
+      description: The issued SCIM token. `token` plaintext is included **only on this response**.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ScimToken.yaml }
+          examples:
+            issued:
+              value:
+                id: scimt_01HKX9SY9V7H7TF8C8K7J9X4ZA
+                object: scim_token
+                organization_id: org_01HKX9SY9V7H7TF8C8K7J9X4ZB
+                name: "Okta — Production"
+                prefix: "scim_01HKX9SY"
+                token: "scim_01HKX9SYABCDEFGHJKMNPQRSTVWXYZ234567"
+                created_at: 1714723000000
+                revoked_at: null
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "403": { $ref: ../../components/responses/Forbidden.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }

--- a/paths/fapi/scim-group.yaml
+++ b/paths/fapi/scim-group.yaml
@@ -1,0 +1,124 @@
+parameters:
+  - name: scim_group_id
+    in: path
+    required: true
+    schema: { type: string }
+
+get:
+  operationId: scimGetGroup
+  summary: Get a SCIM group
+  description: Fetch a single SCIM `Group` resource by id.
+  tags: [SCIM]
+  security:
+    - bearer_scim_token: []
+  responses:
+    "200":
+      description: The SCIM group.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimGroup.yaml }
+    "401":
+      description: SCIM-format unauthorized.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+    "404":
+      description: SCIM-format not found.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+
+put:
+  operationId: scimReplaceGroup
+  summary: Replace a SCIM group
+  description: |
+    SCIM 2.0 PUT (RFC 7644 §3.5.1) — full-resource replace.
+  tags: [SCIM]
+  security:
+    - bearer_scim_token: []
+  requestBody:
+    required: true
+    content:
+      application/scim+json:
+        schema: { $ref: ../../components/schemas/ScimGroup.yaml }
+  responses:
+    "200":
+      description: The replaced SCIM group.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimGroup.yaml }
+    "401":
+      description: SCIM-format unauthorized.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+    "404":
+      description: SCIM-format not found.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+
+patch:
+  operationId: scimPatchGroup
+  summary: Patch a SCIM group
+  description: |
+    SCIM 2.0 PATCH. The canonical group-membership-update flow is a
+    pair of `add` / `remove` ops against `members`.
+  tags: [SCIM]
+  security:
+    - bearer_scim_token: []
+  requestBody:
+    required: true
+    content:
+      application/scim+json:
+        schema: { $ref: ../../components/schemas/ScimPatchOp.yaml }
+        examples:
+          add_member:
+            summary: Add a user to the group
+            value:
+              schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]
+              Operations:
+                - op: add
+                  path: members
+                  value:
+                    - value: user_01HKX9SY9V7H7TF8C8K7J9X4ZA
+                      display: alice@acme.example
+  responses:
+    "200":
+      description: The patched SCIM group.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimGroup.yaml }
+    "401":
+      description: SCIM-format unauthorized.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+    "404":
+      description: SCIM-format not found.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+
+delete:
+  operationId: scimDeleteGroup
+  summary: Delete a SCIM group
+  description: |
+    Hard-delete the group and detach all `OrganizationMembership` rows
+    provisioned through it.
+  tags: [SCIM]
+  security:
+    - bearer_scim_token: []
+  responses:
+    "204":
+      description: Deleted.
+    "401":
+      description: SCIM-format unauthorized.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+    "404":
+      description: SCIM-format not found.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }

--- a/paths/fapi/scim-groups.yaml
+++ b/paths/fapi/scim-groups.yaml
@@ -1,0 +1,99 @@
+get:
+  operationId: scimListGroups
+  summary: List SCIM groups
+  description: |
+    SCIM 2.0 list of groups. Filter / pagination / sort grammar
+    mirrors `/scim/v2/Users`.
+  tags: [SCIM]
+  security:
+    - bearer_scim_token: []
+  parameters:
+    - name: filter
+      in: query
+      required: false
+      schema: { type: string }
+      examples:
+        eq:
+          summary: Match displayName
+          value: 'displayName eq "Engineering"'
+    - name: startIndex
+      in: query
+      required: false
+      schema: { type: integer, minimum: 1 }
+    - name: count
+      in: query
+      required: false
+      schema: { type: integer, minimum: 0, maximum: 200 }
+    - name: attributes
+      in: query
+      required: false
+      schema: { type: string }
+    - name: sortBy
+      in: query
+      required: false
+      schema: { type: string }
+    - name: sortOrder
+      in: query
+      required: false
+      schema: { type: string, enum: [ascending, descending] }
+  responses:
+    "200":
+      description: A page of SCIM groups.
+      content:
+        application/scim+json:
+          schema:
+            allOf:
+              - $ref: ../../components/schemas/ScimListResponse.yaml
+              - type: object
+                properties:
+                  Resources:
+                    type: array
+                    items: { $ref: ../../components/schemas/ScimGroup.yaml }
+    "401":
+      description: SCIM-format unauthorized.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+
+post:
+  operationId: scimCreateGroup
+  summary: Create a SCIM group
+  description: |
+    SCIM 2.0 create (RFC 7644 §3.3) for groups. The server materialises
+    the group as a `Role` or as a labelled cohort the IdP can later
+    sync `OrganizationMembership` rows into.
+  tags: [SCIM]
+  security:
+    - bearer_scim_token: []
+  requestBody:
+    required: true
+    content:
+      application/scim+json:
+        schema: { $ref: ../../components/schemas/ScimGroup.yaml }
+        examples:
+          engineering:
+            summary: New "Engineering" group
+            value:
+              schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"]
+              externalId: "okta-group-eng"
+              displayName: Engineering
+              members:
+                - value: user_01HKX9SY9V7H7TF8C8K7J9X4ZA
+                  display: alice@acme.example
+                  type: User
+  responses:
+    "201":
+      description: The created SCIM group.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimGroup.yaml }
+    "401":
+      description: SCIM-format unauthorized.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+    "409":
+      description: SCIM-format uniqueness conflict.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }

--- a/paths/fapi/scim-user.yaml
+++ b/paths/fapi/scim-user.yaml
@@ -1,0 +1,129 @@
+parameters:
+  - name: scim_user_id
+    in: path
+    required: true
+    description: SCIM resource id (the underlying `User.id`).
+    schema: { type: string }
+
+get:
+  operationId: scimGetUser
+  summary: Get a SCIM user
+  description: Fetch a single SCIM `User` resource by its server-assigned id.
+  tags: [SCIM]
+  security:
+    - bearer_scim_token: []
+  responses:
+    "200":
+      description: The SCIM user.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimUser.yaml }
+    "401":
+      description: SCIM-format unauthorized.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+    "404":
+      description: SCIM-format not found.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+
+put:
+  operationId: scimReplaceUser
+  summary: Replace a SCIM user
+  description: |
+    SCIM 2.0 PUT (RFC 7644 §3.5.1) — full-resource replace. Server
+    applies the body verbatim; any field omitted from the body
+    reverts to default. IdPs that drive provisioning via PUT (some
+    Okta + Azure AD variants) hit this; the more common pattern is
+    `PATCH`.
+  tags: [SCIM]
+  security:
+    - bearer_scim_token: []
+  requestBody:
+    required: true
+    content:
+      application/scim+json:
+        schema: { $ref: ../../components/schemas/ScimUser.yaml }
+  responses:
+    "200":
+      description: The replaced SCIM user.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimUser.yaml }
+    "401":
+      description: SCIM-format unauthorized.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+    "404":
+      description: SCIM-format not found.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+
+patch:
+  operationId: scimPatchUser
+  summary: Patch a SCIM user
+  description: |
+    SCIM 2.0 PATCH (RFC 7644 §3.5.2). Body is a `ScimPatchOp`. The
+    canonical deprovisioning flow is `replace active: false`.
+  tags: [SCIM]
+  security:
+    - bearer_scim_token: []
+  requestBody:
+    required: true
+    content:
+      application/scim+json:
+        schema: { $ref: ../../components/schemas/ScimPatchOp.yaml }
+        examples:
+          deactivate:
+            summary: SCIM-idiomatic deprovision
+            value:
+              schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]
+              Operations:
+                - op: replace
+                  path: active
+                  value: false
+  responses:
+    "200":
+      description: The patched SCIM user.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimUser.yaml }
+    "401":
+      description: SCIM-format unauthorized.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+    "404":
+      description: SCIM-format not found.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+
+delete:
+  operationId: scimDeleteUser
+  summary: Delete a SCIM user
+  description: |
+    Hard-delete via SCIM (RFC 7644 §3.6). Removes the underlying
+    `User` row and any `OrganizationMembership` provisioned by this
+    SCIM token. The SCIM-idiomatic alternative is to PATCH `active:
+    false`, which preserves the audit trail.
+  tags: [SCIM]
+  security:
+    - bearer_scim_token: []
+  responses:
+    "204":
+      description: Deleted.
+    "401":
+      description: SCIM-format unauthorized.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+    "404":
+      description: SCIM-format not found.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }

--- a/paths/fapi/scim-users.yaml
+++ b/paths/fapi/scim-users.yaml
@@ -1,0 +1,124 @@
+get:
+  operationId: scimListUsers
+  summary: List SCIM users
+  description: |
+    SCIM 2.0 list (RFC 7644 §3.4.2). Returns a paginated
+    `ScimListResponse` of `ScimUser` resources.
+
+    Query parameters follow the SCIM filter grammar. authn.sh
+    supports the `eq`, `co`, `sw` operators on `userName`,
+    `emails.value`, `externalId`, and `active`.
+  tags: [SCIM]
+  security:
+    - bearer_scim_token: []
+  parameters:
+    - name: filter
+      in: query
+      required: false
+      schema: { type: string }
+      examples:
+        eq:
+          summary: Exact match on userName
+          value: 'userName eq "alice@acme.example"'
+        co:
+          summary: Substring match on email
+          value: 'emails.value co "@acme.example"'
+        sw:
+          summary: Prefix match on userName
+          value: 'userName sw "alice"'
+    - name: startIndex
+      in: query
+      required: false
+      description: 1-based start index (SCIM convention).
+      schema: { type: integer, minimum: 1 }
+    - name: count
+      in: query
+      required: false
+      schema: { type: integer, minimum: 0, maximum: 200 }
+    - name: attributes
+      in: query
+      required: false
+      description: Comma-separated list of attribute paths to include in each resource.
+      schema: { type: string }
+    - name: sortBy
+      in: query
+      required: false
+      schema: { type: string }
+    - name: sortOrder
+      in: query
+      required: false
+      schema: { type: string, enum: [ascending, descending] }
+  responses:
+    "200":
+      description: A page of SCIM users.
+      content:
+        application/scim+json:
+          schema:
+            allOf:
+              - $ref: ../../components/schemas/ScimListResponse.yaml
+              - type: object
+                properties:
+                  Resources:
+                    type: array
+                    items: { $ref: ../../components/schemas/ScimUser.yaml }
+    "401":
+      description: SCIM-format unauthorized.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+    "400":
+      description: SCIM-format bad filter.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+
+post:
+  operationId: scimCreateUser
+  summary: Create a SCIM user
+  description: |
+    SCIM 2.0 create (RFC 7644 §3.3). Mints a `User` row on the
+    underlying environment, optionally creating an
+    `OrganizationMembership` against the token's org when the body
+    asserts a group membership the server can resolve.
+
+    Returns `201` with the full server-state `ScimUser` (now with the
+    server-assigned `id`).
+  tags: [SCIM]
+  security:
+    - bearer_scim_token: []
+  requestBody:
+    required: true
+    content:
+      application/scim+json:
+        schema: { $ref: ../../components/schemas/ScimUser.yaml }
+        examples:
+          alice:
+            summary: Provision a new user
+            value:
+              schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"]
+              externalId: "00uabcdEFGHIJKLM2x7"
+              userName: alice@acme.example
+              name:
+                givenName: Alice
+                familyName: Anderson
+              emails:
+                - value: alice@acme.example
+                  type: work
+                  primary: true
+              active: true
+  responses:
+    "201":
+      description: The created SCIM user.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimUser.yaml }
+    "401":
+      description: SCIM-format unauthorized.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }
+    "409":
+      description: SCIM-format uniqueness conflict.
+      content:
+        application/scim+json:
+          schema: { $ref: ../../components/schemas/ScimError.yaml }


### PR DESCRIPTION
Closes #80

## Summary

v0.6 SCIM 2.0 directory-sync surface — RFC 7643/7644. Per-org bearer tokens (`scim_*`) authenticate IdP-side provisioning agents; admins manage tokens and attribute mappings from `<OrganizationProfile />`.

## /scim/v2/*

New security scheme `bearer_scim_token` (FAPI-only, scoped to its issuing org).

- `GET|POST /scim/v2/Users` and `GET|PUT|PATCH|DELETE /scim/v2/Users/{id}`
- `GET|POST /scim/v2/Groups` and `GET|PUT|PATCH|DELETE /scim/v2/Groups/{id}`

Filter grammar: `eq`, `co`, `sw` against the standard attribute paths. `ListResponse` uses 1-based `startIndex` per the SCIM RFC, distinct from the authn.sh `PaginatedList`. Errors use the SCIM `Error` envelope with the standard `scimType` subtypes.

## Per-org admin CRUD

- `GET|POST /v1/organizations/{org_id}/scim/tokens` — list / issue. Plaintext `token` returned **only** by POST (single-shot, `writeOnly: true`); reads expose `prefix` only.
- `POST .../scim/tokens/{token_id}/revoke` — stamp `revoked_at`; subsequent calls return `401 invalidVers`.
- `GET|PUT .../scim/attribute-mappings` — read / replace the override map.
- `GET .../scim/endpoint` — returns the IdP-paste URL.

All admin routes gated by `org:sys_provisioning:read` / `org:sys_provisioning:manage`.

## New schemas

`ScimUser`, `ScimGroup`, `ScimListResponse`, `ScimPatchOp`, `ScimError` (RFC 7644 envelopes); `ScimToken` (id prefix `scimt_`, plaintext prefix `scim_`); `ScimAttributeMapping`.

## New tags

`SCIM` (IdP-facing) and `Org SCIM` (admin token / mapping CRUD).

## Validation

`npm run lint` pass; `npm run bundle` clean.