### PR TITLE
OA-8: v0.6 webhook events (enterpriseConnection/Account, scimToken/User)

### DIFF
--- a/components/schemas/WebhookEvent.yaml
+++ b/components/schemas/WebhookEvent.yaml
@@ -55,10 +55,8 @@ properties:
       organization, role, and permission events. v0.4 adds the
       social-IdP, external-account, and phone-number events. v0.5
       adds passkey lifecycle, the appearance-config update event,
-      and the localization-config update event.
-
-      Future surfaces (enterprise SSO, SCIM) will be added additively
-      under their own milestones.
+      and the localization-config update event. v0.6 adds the
+      enterprise-SSO + SCIM events.
     enum:
       # v0.1
       - user.created
@@ -109,6 +107,16 @@ properties:
       - passkey.removed
       - instance.config.appearance_updated
       - localization.updated
+      # v0.6
+      - enterpriseConnection.created
+      - enterpriseConnection.updated
+      - enterpriseConnection.deleted
+      - enterpriseAccount.connected
+      - enterpriseAccount.unlinked
+      - scimToken.issued
+      - scimToken.revoked
+      - scimUser.provisioned
+      - scimUser.deprovisioned
   data:
     description: |
       The resource snapshot. Concrete shape depends on `type`:
@@ -134,6 +142,18 @@ properties:
         payload either)
       - `phoneNumber.*` → `PhoneNumber`
       - `passkey.*` → `Passkey`
+      - `enterpriseConnection.*` → `EnterpriseConnection`
+        (`oidc_client_secret` and `saml_signing_key` are never in the
+        payload — encrypted at rest, write-only)
+      - `enterpriseAccount.*` → `EnterpriseAccount`
+      - `scimToken.*` → `ScimToken` (plaintext `token` is never in
+        the payload — `writeOnly: true`, returned only on the
+        single-shot issue response)
+      - `scimUser.*` →
+        `{ user: User, enterprise_connection_id, organization_id }`
+        (carries the connection that drove provisioning + the
+        scoping org so handlers can route without a follow-up
+        lookup)
       - `instance.config.appearance_updated` →
         `{ previous: Appearance, current: Appearance,
            diff: Appearance }`. `diff` is the partial-shape blob
@@ -160,6 +180,29 @@ properties:
       - $ref: ./ExternalAccount.yaml
       - $ref: ./PhoneNumber.yaml
       - $ref: ./Passkey.yaml
+      - $ref: ./EnterpriseConnection.yaml
+      - $ref: ./EnterpriseAccount.yaml
+      - $ref: ./ScimToken.yaml
+      - type: object
+        description: |
+          `scimUser.*` payload.
+        required: [user, enterprise_connection_id, organization_id]
+        additionalProperties: false
+        properties:
+          user:
+            $ref: ./User.yaml
+          enterprise_connection_id:
+            oneOf:
+              - $ref: ./Id.yaml
+              - type: "null"
+            description: |
+              Source connection. `null` for SCIM-only provisioning
+              when no `EnterpriseConnection` was involved (token
+              issued for direct directory sync against a workspace
+              IdP that doesn't drive SSO).
+          organization_id:
+            $ref: ./Id.yaml
+            description: Scoping organization.
       - type: object
         description: |
           `instance.config.appearance_updated` payload.
@@ -466,6 +509,117 @@ examples:
         overrides:
           pt-BR:
             signIn.start.title: "Bem-vindo de volta"
+  - id: whd_01HKX9SY9V7H7TF8C8K7J9X4ZE
+    object: event
+    type: enterpriseConnection.created
+    timestamp: 1714897800000
+    instance_id: env_acme_test
+    was_test: false
+    data:
+      id: entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA
+      object: enterprise_connection
+      protocol: saml
+      name: Acme Okta
+      enabled: true
+      organization_id: org_01HKX9SY9V7H7TF8C8K7J9X4ZH
+      domains: ["acme.com"]
+      default_role: org:member
+      attribute_mapping:
+        email_address: "urn:oid:0.9.2342.19200300.100.1.3"
+        first_name: "urn:oid:2.5.4.42"
+        last_name: "urn:oid:2.5.4.4"
+        provider_user_id: nameid
+      saml_idp_entity_id: https://idp.acme.example/saml/metadata
+      saml_sso_url: https://idp.acme.example/saml/sso
+      saml_idp_certificate: "-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----"
+      saml_signing_algorithm: RSA_SHA256
+      saml_audience_uri: https://acme.authn.sh/v1/saml/entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA/metadata
+      saml_acs_url: https://acme.authn.sh/v1/saml/entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA/acs
+      saml_sp_entity_id: https://acme.authn.sh/v1/saml/entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA/metadata
+      oidc_issuer: null
+      oidc_discovery_endpoint: null
+      oidc_client_id: null
+      oidc_scopes: []
+      oidc_redirect_uri: null
+      created_at: 1714897800000
+      updated_at: 1714897800000
+  - id: whd_01HKX9SY9V7H7TF8C8K7J9X4ZF
+    object: event
+    type: enterpriseAccount.connected
+    timestamp: 1714897900000
+    instance_id: env_acme_test
+    was_test: false
+    data:
+      id: entacc_01HKX9SY9V7H7TF8C8K7J9X4ZA
+      object: enterprise_account
+      enterprise_connection_id: entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA
+      provider_user_id: alice@acme.example
+      email_address: alice@acme.example
+      verified: true
+      public_metadata:
+        groups: [engineering]
+      linked_at: 1714897900000
+      last_signed_in_at: null
+      created_at: 1714897900000
+      updated_at: 1714897900000
+  - id: whd_01HKX9SY9V7H7TF8C8K7J9X4ZG
+    object: event
+    type: scimToken.issued
+    timestamp: 1714898000000
+    instance_id: env_acme_test
+    was_test: false
+    data:
+      id: scimt_01HKX9SY9V7H7TF8C8K7J9X4ZA
+      object: scim_token
+      organization_id: org_01HKX9SY9V7H7TF8C8K7J9X4ZH
+      name: "Okta — Production"
+      prefix: "scim_01HKX9SY"
+      created_at: 1714898000000
+      revoked_at: null
+  - id: whd_01HKX9SY9V7H7TF8C8K7J9X4ZH
+    object: event
+    type: scimUser.provisioned
+    timestamp: 1714898100000
+    instance_id: env_acme_test
+    was_test: false
+    data:
+      enterprise_connection_id: entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA
+      organization_id: org_01HKX9SY9V7H7TF8C8K7J9X4ZH
+      user:
+        id: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+        object: user
+        external_id: "00uabcdEFGHIJKLM2x7"
+        username: null
+        first_name: Alice
+        last_name: Anderson
+        image_url: null
+        has_image: false
+        primary_email_address_id: idn_01HKX9SY9V7H7TF8C8K7J9X4ZE
+        primary_phone_number_id: null
+        email_addresses: []
+        phone_numbers: []
+        external_accounts: []
+        enterprise_accounts: []
+        passkeys: []
+        passkey_count: 0
+        password_enabled: false
+        two_factor_enabled: false
+        totp_enabled: false
+        backup_code_enabled: false
+        mfa_enabled_at: null
+        mfa_disabled_at: null
+        banned: false
+        locked: false
+        lockout_expires_at: null
+        last_sign_in_at: null
+        last_active_at: null
+        delete_self_enabled: true
+        locale: null
+        public_metadata: {}
+        private_metadata: {}
+        unsafe_metadata: {}
+        created_at: 1714898100000
+        updated_at: 1714898100000
   - id: whd_01HKX9SY9V7H7TF8C8K7J9X4Z9
     object: event
     type: session.created

--- a/paths/bapi/webhook-deliveries.yaml
+++ b/paths/bapi/webhook-deliveries.yaml
@@ -64,4 +64,68 @@ get:
                     succeeded: false
                     created_at: 1714896500000
                 total_count: 1
+            enterprise_connection_created:
+              summary: enterpriseConnection.created delivery
+              value:
+                data:
+                  - id: whd_01HKX9SY9V7H7TF8C8K7J9X4ZQ
+                    object: webhook_delivery
+                    endpoint_id: whe_01HKX9SY9V7H7TF8C8K7J9X4ZH
+                    event_id: evt_01HKX9SY9V7H7TF8C8K7J9X4ZN
+                    event_type: enterpriseConnection.created
+                    attempt: 1
+                    response_status: 200
+                    response_body: '{"ok":true}'
+                    next_retry_at: null
+                    succeeded: true
+                    created_at: 1714896500000
+                total_count: 1
+            enterprise_account_connected:
+              summary: enterpriseAccount.connected delivery
+              value:
+                data:
+                  - id: whd_01HKX9SY9V7H7TF8C8K7J9X4ZR
+                    object: webhook_delivery
+                    endpoint_id: whe_01HKX9SY9V7H7TF8C8K7J9X4ZH
+                    event_id: evt_01HKX9SY9V7H7TF8C8K7J9X4ZP
+                    event_type: enterpriseAccount.connected
+                    attempt: 1
+                    response_status: 200
+                    response_body: '{"ok":true}'
+                    next_retry_at: null
+                    succeeded: true
+                    created_at: 1714896600000
+                total_count: 1
+            scim_token_issued:
+              summary: scimToken.issued delivery
+              value:
+                data:
+                  - id: whd_01HKX9SY9V7H7TF8C8K7J9X4ZS
+                    object: webhook_delivery
+                    endpoint_id: whe_01HKX9SY9V7H7TF8C8K7J9X4ZH
+                    event_id: evt_01HKX9SY9V7H7TF8C8K7J9X4ZQ
+                    event_type: scimToken.issued
+                    attempt: 1
+                    response_status: 200
+                    response_body: '{"ok":true}'
+                    next_retry_at: null
+                    succeeded: true
+                    created_at: 1714896700000
+                total_count: 1
+            scim_user_provisioned:
+              summary: scimUser.provisioned delivery
+              value:
+                data:
+                  - id: whd_01HKX9SY9V7H7TF8C8K7J9X4ZT
+                    object: webhook_delivery
+                    endpoint_id: whe_01HKX9SY9V7H7TF8C8K7J9X4ZH
+                    event_id: evt_01HKX9SY9V7H7TF8C8K7J9X4ZR
+                    event_type: scimUser.provisioned
+                    attempt: 1
+                    response_status: 200
+                    response_body: '{"ok":true}'
+                    next_retry_at: null
+                    succeeded: true
+                    created_at: 1714896800000
+                total_count: 1
     "401": { $ref: ../../components/responses/Unauthorized.yaml }


### PR DESCRIPTION
Closes #81

## Summary

Adds the v0.6 webhook events that pair with the new `EnterpriseConnection` / `EnterpriseAccount` / `ScimToken` / SCIM provisioning surface.

## Event types added

- `enterpriseConnection.created` / `updated` / `deleted` — payload: `EnterpriseConnection`. `oidc_client_secret` and `saml_signing_key` never appear (write-only, encrypted at rest).
- `enterpriseAccount.connected` / `unlinked` — payload: `EnterpriseAccount`.
- `scimToken.issued` / `revoked` — payload: `ScimToken` (plaintext `token` is `writeOnly: true` and never in the payload — operators captured it on the single-shot issue response).
- `scimUser.provisioned` / `deprovisioned` — payload: `{ user: User, enterprise_connection_id, organization_id }`. The connection id + org are carried explicitly so handlers can route without a follow-up lookup.

## Schema changes

- `WebhookEvent.yaml` — `type` enum extended (9 new values); `data` discriminator extended with the new payload shapes; description updated; four full example events appended.
- `paths/bapi/webhook-deliveries.yaml` — four new example deliveries on the list endpoint (one per event family).

## Validation

`npm run lint` pass; `npm run bundle` clean.