### PR TITLE
OA-9: Extend SignIn + SignUp schemas for transferable handoff

### DIFF
--- a/components/schemas/SignIn.yaml
+++ b/components/schemas/SignIn.yaml
@@ -144,6 +144,8 @@ required:
   - identifier
   - user_data
   - created_session_id
+  - transferable_to_signup
+  - target_flow
   - abandon_at
 additionalProperties: false
 properties:
@@ -160,6 +162,7 @@ properties:
       - needs_second_factor
       - needs_new_password
       - needs_client_trust
+      - transferable
       - complete
       - abandoned
     description: |
@@ -177,6 +180,20 @@ properties:
         to `complete`.
       - `needs_client_trust` — environment requires the device pass an
         out-of-band trust check (geolocation/WAF/captcha).
+      - `transferable` — the SignIn succeeded the IdP / magic-link
+        side of authentication but the resolved identity has no
+        matching `User`, so the flow must hand off to sign-up. The
+        SDK reads `target_flow: "sign_up"` and posts
+        `POST /v1/client/sign-ups { transfer: true }` to mint a
+        SignUp that completes synchronously off the same upstream
+        identity. Surfaces in three cases:
+          - **OAuth** — IdP returned an unknown identity and the
+            parent `OauthProvider.allow_sign_up` is `true`.
+          - **Magic-link** — `email_link` was answered against an
+            address with no `User`.
+          - **Enterprise SSO** — IdP-asserted identity has no
+            matching `User`; subject to the connection's
+            org-scoped provisioning policy.
       - `complete` — `created_session_id` is set; SDK can stop driving.
       - `abandoned` — `abandon_at` passed; create a new sign-in.
   supported_identifiers:
@@ -240,6 +257,30 @@ properties:
     oneOf:
       - $ref: ./Id.yaml
       - type: "null"
+  transferable_to_signup:
+    type: boolean
+    default: false
+    description: |
+      `true` when `status == "transferable"` and `target_flow ==
+      "sign_up"` — the SDK should bounce to sign-up via
+      `POST /v1/client/sign-ups { transfer: true }`. Convenience
+      flag so consumers don't have to string-compare `target_flow`.
+      `false` otherwise.
+  target_flow:
+    type: [string, "null"]
+    enum: [sign_in, sign_up, null]
+    description: |
+      Populated when `status == "transferable"`. Indicates which
+      flow the SDK should hand the upstream identity off to:
+
+      - `sign_up` — the resolved identity has no matching `User`;
+        SDK posts `POST /v1/client/sign-ups { transfer: true }`.
+      - `sign_in` — reserved for cross-direction handoffs (a SignIn
+        that resolved an identity which should retry a different
+        sign-in path); not used by v0.6's transferable cases but
+        kept in the enum so consumers handle both directions.
+
+      `null` for every other `status` value.
   current_challenge_id:
     description: |
       Pointer to the live `Challenge` if one's in flight. `null` when
@@ -266,3 +307,17 @@ properties:
       visible in the enclosing `Client.sessions[]`.
   abandon_at:
     $ref: ./Timestamp.yaml
+examples:
+  - id: sia_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    object: sign_in_attempt
+    status: transferable
+    supported_identifiers: [email_address]
+    supported_strategies: []
+    enterprise_connection_id: entcon_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    transferable_to_signup: true
+    target_flow: sign_up
+    current_challenge_id: null
+    identifier: alice@acme.example
+    user_data: {}
+    created_session_id: null
+    abandon_at: 1714724000000

--- a/components/schemas/SignUp.yaml
+++ b/components/schemas/SignUp.yaml
@@ -61,6 +61,8 @@ required:
   - unverified_fields
   - supported_strategies
   - current_challenge_id
+  - transferable_to_signin
+  - target_flow
   - password_enabled
   - unsafe_metadata
   - public_metadata
@@ -92,7 +94,12 @@ properties:
         that already has a `User` — the SDK should bounce to sign-in
         with `POST /v1/client/sign-ins { transfer: true }`. v0.4: a
         sign-up via `oauth_<provider_key>` returned an IdP identity
-        that already has an `ExternalAccount` — same bounce.
+        that already has an `ExternalAccount` — same bounce. v0.6: a
+        sign-up via `enterprise_sso` / `saml` returned an IdP-asserted
+        identity that already has a `User` — same bounce. In every
+        case, `target_flow` is set to `sign_in` and
+        `transferable_to_signin` is `true` so consumers can branch
+        without re-parsing the cause.
       - `abandoned` — `abandon_at` passed.
   required_fields:
     type: array
@@ -139,6 +146,30 @@ properties:
     oneOf:
       - $ref: ./Id.yaml
       - type: "null"
+  transferable_to_signin:
+    type: boolean
+    default: false
+    description: |
+      `true` when `status == "transferable"` and `target_flow ==
+      "sign_in"` — the SDK should bounce to sign-in via
+      `POST /v1/client/sign-ins { transfer: true }`. Convenience
+      flag so consumers don't have to string-compare `target_flow`.
+      `false` otherwise.
+  target_flow:
+    type: [string, "null"]
+    enum: [sign_in, sign_up, null]
+    description: |
+      Populated when `status == "transferable"`. Indicates which flow
+      the SDK should hand the upstream identity off to:
+
+      - `sign_in` — the resolved identity already has a `User`; SDK
+        posts `POST /v1/client/sign-ins { transfer: true }`. This is
+        the only direction v0.6 emits on a SignUp.
+      - `sign_up` — reserved for the mirror direction (kept in the
+        enum so consumers handle both `SignIn` and `SignUp` snapshots
+        uniformly).
+
+      `null` for every other `status` value.
   username:
     type: [string, "null"]
   email_address:
@@ -163,3 +194,26 @@ properties:
     type: [string, "null"]
   abandon_at:
     $ref: ./Timestamp.yaml
+examples:
+  - id: sua_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    object: sign_up_attempt
+    status: transferable
+    required_fields: []
+    optional_fields: []
+    missing_fields: []
+    unverified_fields: []
+    supported_strategies: []
+    current_challenge_id: null
+    transferable_to_signin: true
+    target_flow: sign_in
+    username: null
+    email_address: alice@acme.example
+    phone_number: null
+    first_name: Alice
+    last_name: Anderson
+    password_enabled: false
+    unsafe_metadata: {}
+    public_metadata: {}
+    created_session_id: null
+    created_user_id: null
+    abandon_at: 1714724000000


### PR DESCRIPTION
Closes #90

## Summary

Mid-implementation spec gap caught during authn AU-11. The `transferable` handoff between `SignIn` and `SignUp` was documented in PLAN but not on the wire — consumers had no way to branch on the bounce direction without re-deriving cause from the live `Challenge`. This PR adds an explicit `target_flow` plus a boolean convenience flag to both snapshots.

## SignIn.yaml

- `status` enum: added `transferable` with prose covering the three v0.6 cases (unknown OAuth identity, magic-link unknown address, enterprise-SSO unknown identity).
- `transferable_to_signup: boolean` — `true` when `status == "transferable"` and `target_flow == "sign_up"`.
- `target_flow: string | null` — enum `[sign_in, sign_up, null]`. Populated when `status == "transferable"`.
- Both fields added to `required:` for snapshot stability.
- New top-level `examples:` block with a transferable-to-signup snapshot (enterprise SSO).

## SignUp.yaml

- `status` enum already has `transferable`; description extended to cover the v0.6 enterprise-SSO case + cross-reference the new fields.
- `transferable_to_signin: boolean` — mirror flag.
- `target_flow: string | null` — same enum.
- Both fields added to `required:`.
- New top-level `examples:` block with a transferable-to-signin snapshot.

## Validation

`npm run lint` pass; `npm run bundle` clean.

## Out of scope

Server implementation lives in authn AU-11. No new endpoints — existing `POST /v1/client/sign-ins` and `POST /v1/client/sign-ups` produce the new shapes.