### PR TITLE
Spec: BAPI /v1/enterprise-accounts (list, get, delete)

### DIFF
--- a/bapi.yaml
+++ b/bapi.yaml
@@ -196,6 +196,10 @@ paths:
     $ref: ./paths/bapi/enterprise-connection.yaml
   /v1/enterprise-connections/{enterprise_connection_id}/test:
     $ref: ./paths/bapi/enterprise-connection-test.yaml
+  /v1/enterprise-accounts:
+    $ref: ./paths/bapi/enterprise-accounts.yaml
+  /v1/enterprise-accounts/{enterprise_account_id}:
+    $ref: ./paths/bapi/enterprise-account.yaml
   /v1/sms-templates:
     $ref: ./paths/bapi/sms-templates.yaml
   /v1/sms-templates/{sms_template_slug}:

--- a/paths/bapi/enterprise-account.yaml
+++ b/paths/bapi/enterprise-account.yaml
@@ -1,0 +1,36 @@
+parameters:
+  - name: enterprise_account_id
+    in: path
+    required: true
+    description: ID of the enterprise account.
+    schema: { $ref: "../../components/schemas/Id.yaml" }
+
+get:
+  operationId: getEnterpriseAccount
+  summary: Get an enterprise account
+  description: Fetch a single `EnterpriseAccount` by ID.
+  tags: [Enterprise Connections]
+  responses:
+    "200":
+      description: The enterprise account.
+      content:
+        application/json:
+          schema: { $ref: "../../components/schemas/EnterpriseAccount.yaml" }
+    "401": { $ref: "../../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../../components/responses/NotFound.yaml" }
+
+delete:
+  operationId: deleteEnterpriseAccount
+  summary: Delete an enterprise account
+  description: |
+    Admin unlink — drops the local `EnterpriseAccount` row. The
+    underlying `User` row is preserved; the next sign-in via the same
+    `EnterpriseConnection` will mint a fresh `EnterpriseAccount` if
+    the connection's policy allows JIT provisioning, or fail with
+    `enterprise_sso_no_user` if it doesn't.
+  tags: [Enterprise Connections]
+  responses:
+    "204":
+      description: Deleted.
+    "401": { $ref: "../../components/responses/Unauthorized.yaml" }
+    "404": { $ref: "../../components/responses/NotFound.yaml" }

--- a/paths/bapi/enterprise-accounts.yaml
+++ b/paths/bapi/enterprise-accounts.yaml
@@ -1,0 +1,40 @@
+get:
+  operationId: listEnterpriseAccounts
+  summary: List enterprise accounts
+  description: |
+    Every `EnterpriseAccount` row in the environment. Filterable by
+    `user_id` and `enterprise_connection_id` so admins can scope to a
+    single user or audit which users have signed in via a specific
+    enterprise connection.
+
+    No `POST` / `PATCH` on this resource — enterprise accounts are
+    provisioned through the SSO callback (`/v1/saml/{id}/acs` or
+    `/v1/enterprise-sso-callback`), not via BAPI.
+  tags: [Enterprise Connections]
+  parameters:
+    - name: user_id
+      in: query
+      required: false
+      description: Filter to enterprise accounts owned by this user.
+      schema: { $ref: "../../components/schemas/Id.yaml" }
+    - name: enterprise_connection_id
+      in: query
+      required: false
+      description: Filter to enterprise accounts created via this connection.
+      schema: { $ref: "../../components/schemas/Id.yaml" }
+    - $ref: "../../components/parameters/LimitParam.yaml"
+    - $ref: "../../components/parameters/OffsetParam.yaml"
+  responses:
+    "200":
+      description: Paginated list of enterprise accounts.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [data, total_count]
+            properties:
+              data:
+                type: array
+                items: { $ref: "../../components/schemas/EnterpriseAccount.yaml" }
+              total_count: { type: integer }
+    "401": { $ref: "../../components/responses/Unauthorized.yaml" }


### PR DESCRIPTION
## Summary

Mid-implementation spec gap flagged by php-impl on SP-1 (`EnterpriseAccountsManager`). OA-2 added the `EnterpriseAccount` resource schema but no BAPI path file, so SDK contract validators couldn't bind. Mirrors the v0.4 `/v1/external-accounts` shape for consistency.

Server-side routes already shipped on authn (#234).

## Operations

- `GET /v1/enterprise-accounts` — paginated list. Query: `user_id?`, `enterprise_connection_id?`, `limit?`, `offset?`. Returns `{ data: EnterpriseAccount[], total_count }`.
- `GET /v1/enterprise-accounts/{id}` — fetch by id.
- `DELETE /v1/enterprise-accounts/{id}` — admin unlink (preserves underlying `User`).

No POST / PATCH — provisioning happens through `/v1/saml/{id}/acs` and `/v1/enterprise-sso-callback`, not via BAPI write.

## Tag

Re-uses the existing v0.6 `Enterprise Connections` BAPI tag so the dashboard groups them with the connection CRUD.

## Validation

`npm run lint` pass; `npm run bundle` clean.