### PR TITLE
OA-1: JwtTemplate resource + BAPI /v1/jwt-templates CRUD

### DIFF
--- a/bapi.yaml
+++ b/bapi.yaml
@@ -73,6 +73,8 @@ tags:
     description: Per-environment outbound SMS body customization (`SmsTemplate`).
   - name: Webhooks
     description: Webhook endpoints, deliveries, and the event envelope.
+  - name: JWT Templates
+    description: Named JWT templates rendered by `Session.getToken({template})` (`JwtTemplate`).
 
 security:
   - bearer_secret_key: []
@@ -200,6 +202,10 @@ paths:
     $ref: ./paths/bapi/enterprise-accounts.yaml
   /v1/enterprise-accounts/{enterprise_account_id}:
     $ref: ./paths/bapi/enterprise-account.yaml
+  /v1/jwt-templates:
+    $ref: ./paths/bapi/jwt-templates.yaml
+  /v1/jwt-templates/{jwt_template_id}:
+    $ref: ./paths/bapi/jwt-template.yaml
   /v1/sms-templates:
     $ref: ./paths/bapi/sms-templates.yaml
   /v1/sms-templates/{sms_template_slug}:
@@ -301,6 +307,9 @@ components:
     EnterpriseAccount:                         { $ref: ./components/schemas/EnterpriseAccount.yaml }
     SmsTemplate:                               { $ref: ./components/schemas/SmsTemplate.yaml }
     SmsTemplateRequest:                        { $ref: ./components/schemas/SmsTemplateRequest.yaml }
+    JwtTemplate:                               { $ref: ./components/schemas/JwtTemplate.yaml }
+    JwtTemplateCreateRequest:                  { $ref: ./components/schemas/JwtTemplateCreateRequest.yaml }
+    JwtTemplateUpdateRequest:                  { $ref: ./components/schemas/JwtTemplateUpdateRequest.yaml }
 
   responses:
     BadRequest:           { $ref: ./components/responses/BadRequest.yaml }

--- a/components/schemas/JwtTemplate.yaml
+++ b/components/schemas/JwtTemplate.yaml
@@ -1,0 +1,179 @@
+type: object
+description: |
+  Named JWT template used by `Session.getToken({template})` to mint
+  custom-shaped session tokens. Each environment can define an
+  unbounded number of templates, looked up by `name` at render time.
+
+  Templates exist so consumers can issue tokens whose claim set is
+  tailored to a specific downstream verifier (e.g. a third-party
+  RPC service that expects `sub` to be the user's `external_id`
+  instead of the authn.sh `user.id`, or a backend that wants the
+  active org slug in `org_slug`). The `claims` object is a JSON
+  template with Liquid-style placeholders resolved against a
+  `{user, session, organization}` snapshot at render time. Reserved
+  JWT registered claim names (`iss`, `sub`, `aud`, `exp`, `nbf`,
+  `iat`, `jti`) supplied by the operator are merged on top of the
+  server-generated values, so operators can override `sub` /
+  `aud` / `iss` without losing the time-bound claims.
+
+  ### Lifetime + clock skew
+
+  `lifetime` (seconds) is the `exp - iat` window stamped on each
+  rendered token. `allowed_clock_skew` (seconds) is the leeway
+  verifiers should grant when comparing `exp` / `nbf` / `iat` —
+  the field is surfaced for verifier-side use and is not enforced
+  by the renderer itself.
+
+  ### Signing key
+
+  By default, rendered tokens are signed with the environment's
+  session-signing key (the same key surfaced at
+  `/.well-known/jwks.json`). Operators that need to sign with a
+  different key (e.g. an HS256 shared-secret with a legacy
+  consumer) can supply `custom_signing_key` as a PEM-encoded
+  private key (or a base64 secret for `HS256`). The field is
+  **write-only**, encrypted at rest, and never returned by any
+  read response.
+
+  ### Identifier
+
+  ID prefix `jtmpl_` (e.g. `jtmpl_01HKX9SY9V7H7TF8C8K7J9X4ZA`).
+required:
+  - id
+  - object
+  - name
+  - claims
+  - lifetime
+  - allowed_clock_skew
+  - signing_algorithm
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: jwt_template
+  name:
+    type: string
+    pattern: "^[a-z][a-z0-9_-]{0,63}$"
+    maxLength: 64
+    description: |
+      Slug used to look the template up from
+      `Session.getToken({template: <name>})`. Unique within the
+      environment.
+    examples:
+      - supabase
+      - acme_rpc
+      - billing_backend
+  claims:
+    type: object
+    description: |
+      JSON template rendered against a `{user, session,
+      organization}` snapshot. Values may be plain JSON (string /
+      number / boolean / nested object / array) or strings
+      containing Liquid-style placeholders. Supported expressions:
+
+      - `{{user.id}}`, `{{user.primary_email_address}}`,
+        `{{user.first_name}}`, `{{user.last_name}}`,
+        `{{user.external_id}}`, `{{user.public_metadata.<key>}}`
+      - `{{session.id}}`, `{{session.actor.id}}`
+      - `{{organization.id}}`, `{{organization.slug}}`,
+        `{{organization.role}}`,
+        `{{organization.public_metadata.<key>}}`
+
+      Reserved registered-claim keys (`iss`, `sub`, `aud`, `exp`,
+      `nbf`, `iat`, `jti`) override the server-generated defaults
+      when present. Unresolved placeholders render as the empty
+      string.
+    additionalProperties: true
+    examples:
+      - sub: "{{user.id}}"
+        email: "{{user.primary_email_address}}"
+        org_slug: "{{organization.slug}}"
+        tier: "{{user.public_metadata.tier}}"
+  lifetime:
+    type: integer
+    minimum: 1
+    maximum: 86400
+    default: 60
+    description: |
+      `exp - iat` window in seconds. Defaults to 60s (matches the
+      v0.1 short-lived session token); bump for verifiers that
+      need a longer-lived token, but keep it short to limit blast
+      radius if a rendered token leaks.
+  allowed_clock_skew:
+    type: integer
+    minimum: 0
+    maximum: 300
+    default: 5
+    description: |
+      Leeway, in seconds, that verifiers should grant on `exp` /
+      `nbf` / `iat` comparisons. Surfaced for verifier-side use;
+      authn.sh does not enforce it during rendering.
+  signing_algorithm:
+    type: string
+    enum: [RS256, ES256, HS256]
+    default: RS256
+    description: |
+      JWS algorithm used to sign rendered tokens. Immutable after
+      create — flipping the algorithm would invalidate any cached
+      `kid` on downstream verifiers. Re-create the template with
+      a new name to migrate.
+  custom_signing_key:
+    type: [string, "null"]
+    writeOnly: true
+    description: |
+      PEM-encoded private key (or base64-encoded secret for
+      `HS256`). When `null`, rendered tokens are signed with the
+      environment's session-signing key (surfaced at
+      `/.well-known/jwks.json`). Encrypted at rest, never
+      returned by any read response.
+  created_at:
+    $ref: ./Timestamp.yaml
+  updated_at:
+    $ref: ./Timestamp.yaml
+examples:
+  - id: jtmpl_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    object: jwt_template
+    name: supabase
+    claims:
+      sub: "{{user.id}}"
+      email: "{{user.primary_email_address}}"
+      role: authenticated
+    lifetime: 60
+    allowed_clock_skew: 5
+    signing_algorithm: RS256
+    created_at: 1714723000000
+    updated_at: 1714723000000
+  - id: jtmpl_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    object: jwt_template
+    name: acme_rpc
+    claims:
+      sub: "{{user.external_id}}"
+      email: "{{user.primary_email_address}}"
+      first_name: "{{user.first_name}}"
+      last_name: "{{user.last_name}}"
+      org_id: "{{organization.id}}"
+      org_slug: "{{organization.slug}}"
+      org_role: "{{organization.role}}"
+      tier: "{{user.public_metadata.tier}}"
+      session_id: "{{session.id}}"
+    lifetime: 300
+    allowed_clock_skew: 10
+    signing_algorithm: ES256
+    created_at: 1714724000000
+    updated_at: 1714724000000
+  - id: jtmpl_01HKX9SY9V7H7TF8C8K7J9X4ZC
+    object: jwt_template
+    name: legacy_hs256
+    claims:
+      sub: "{{user.id}}"
+      iss: https://acme.example
+      aud: legacy-rpc
+    lifetime: 60
+    allowed_clock_skew: 5
+    signing_algorithm: HS256
+    created_at: 1714725000000
+    updated_at: 1714725000000

--- a/components/schemas/JwtTemplateCreateRequest.yaml
+++ b/components/schemas/JwtTemplateCreateRequest.yaml
@@ -1,0 +1,66 @@
+type: object
+description: |
+  Request body for `POST /v1/jwt-templates`.
+required:
+  - name
+  - claims
+additionalProperties: false
+properties:
+  name:
+    type: string
+    pattern: "^[a-z][a-z0-9_-]{0,63}$"
+    maxLength: 64
+    description: |
+      Slug used by `Session.getToken({template: <name>})`. Must be
+      unique within the environment. Immutable after create.
+  claims:
+    type: object
+    description: |
+      JSON template with Liquid-style placeholders. See
+      `JwtTemplate.claims` for the supported expression set.
+    additionalProperties: true
+  lifetime:
+    type: integer
+    minimum: 1
+    maximum: 86400
+    default: 60
+  allowed_clock_skew:
+    type: integer
+    minimum: 0
+    maximum: 300
+    default: 5
+  signing_algorithm:
+    type: string
+    enum: [RS256, ES256, HS256]
+    default: RS256
+    description: |
+      Immutable after create. Re-create the template under a new
+      `name` to migrate to a different algorithm.
+  custom_signing_key:
+    type: [string, "null"]
+    writeOnly: true
+    description: |
+      PEM-encoded private key (or base64-encoded secret for
+      `HS256`). When `null`, rendered tokens are signed with the
+      environment's session-signing key.
+examples:
+  - name: supabase
+    claims:
+      sub: "{{user.id}}"
+      email: "{{user.primary_email_address}}"
+      role: authenticated
+  - name: acme_rpc
+    claims:
+      sub: "{{user.external_id}}"
+      org_id: "{{organization.id}}"
+      org_role: "{{organization.role}}"
+    lifetime: 300
+    allowed_clock_skew: 10
+    signing_algorithm: ES256
+  - name: legacy_hs256
+    claims:
+      sub: "{{user.id}}"
+      iss: https://acme.example
+      aud: legacy-rpc
+    signing_algorithm: HS256
+    custom_signing_key: c2VjcmV0LWJhc2U2NA==

--- a/components/schemas/JwtTemplateUpdateRequest.yaml
+++ b/components/schemas/JwtTemplateUpdateRequest.yaml
@@ -1,0 +1,33 @@
+type: object
+description: |
+  Request body for `PATCH /v1/jwt-templates/{jwt_template_id}`.
+  Every field is optional; omitted keys are left untouched.
+  `signing_algorithm` is immutable — sending a different value
+  returns `422`.
+additionalProperties: false
+properties:
+  claims:
+    type: object
+    additionalProperties: true
+  lifetime:
+    type: integer
+    minimum: 1
+    maximum: 86400
+  allowed_clock_skew:
+    type: integer
+    minimum: 0
+    maximum: 300
+  custom_signing_key:
+    type: [string, "null"]
+    writeOnly: true
+    description: |
+      Send `null` to revert to the environment's session-signing
+      key; send a new PEM / base64 secret to rotate.
+examples:
+  - claims:
+      sub: "{{user.id}}"
+      email: "{{user.primary_email_address}}"
+      role: authenticated
+      tenant: "{{user.public_metadata.tenant}}"
+  - lifetime: 600
+  - custom_signing_key: null

--- a/paths/bapi/jwt-template.yaml
+++ b/paths/bapi/jwt-template.yaml
@@ -1,0 +1,81 @@
+parameters:
+  - name: jwt_template_id
+    in: path
+    required: true
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+get:
+  operationId: getJwtTemplate
+  summary: Get a JWT template
+  description: |
+    Fetch a single `JwtTemplate` row. `custom_signing_key` is never
+    included.
+  tags: [JWT Templates]
+  responses:
+    "200":
+      description: The JWT template.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/JwtTemplate.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+
+patch:
+  operationId: updateJwtTemplate
+  summary: Update a JWT template
+  description: |
+    Partial update. `name` and `signing_algorithm` are immutable —
+    sending a different value returns `422`. Every other field is
+    optional; omitted keys are left untouched. Send
+    `custom_signing_key: null` to revert to the environment's
+    default session-signing key.
+  tags: [JWT Templates]
+  parameters:
+    - $ref: ../../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../../components/schemas/JwtTemplateUpdateRequest.yaml }
+        examples:
+          add_claim:
+            summary: Add a tenant claim
+            value:
+              claims:
+                sub: "{{user.id}}"
+                email: "{{user.primary_email_address}}"
+                role: authenticated
+                tenant: "{{user.public_metadata.tenant}}"
+          bump_lifetime:
+            summary: Bump lifetime to 10 minutes
+            value: { lifetime: 600 }
+          rotate_signing_key:
+            summary: Revert to the environment's default signing key
+            value: { custom_signing_key: null }
+  responses:
+    "200":
+      description: The updated JWT template.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/JwtTemplate.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }
+
+delete:
+  operationId: deleteJwtTemplate
+  summary: Delete a JWT template
+  description: |
+    Soft delete. Refuses (`409 jwt_template_in_use`) when the
+    template was used to mint a token within the last `lifetime +
+    allowed_clock_skew` seconds (40h grace floor) — verifiers may
+    still be carrying tokens with this `name` in their cache. Once
+    deleted, `Session.getToken({template: <name>})` returns
+    `404 jwt_template_not_found`.
+  tags: [JWT Templates]
+  responses:
+    "204":
+      description: Deleted.
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "409": { $ref: ../../components/responses/Conflict.yaml }

--- a/paths/bapi/jwt-templates.yaml
+++ b/paths/bapi/jwt-templates.yaml
@@ -1,0 +1,93 @@
+get:
+  operationId: listJwtTemplates
+  summary: List JWT templates
+  description: |
+    Paginated list of every `JwtTemplate` row configured on the
+    environment. The dashboard renders the rows in this order;
+    reorder by re-creating with a different `created_at` (no
+    separate `position` column).
+  tags: [JWT Templates]
+  parameters:
+    - $ref: ../../components/parameters/LimitParam.yaml
+    - $ref: ../../components/parameters/OffsetParam.yaml
+  responses:
+    "200":
+      description: A page of JWT templates.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: ../../components/schemas/PaginatedList.yaml
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: ../../components/schemas/JwtTemplate.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+
+post:
+  operationId: createJwtTemplate
+  summary: Create a JWT template
+  description: |
+    Register a named JWT template. `name` is the slug consumers pass to
+    `Session.getToken({template})`. `claims` is a JSON template with
+    Liquid-style placeholders rendered against the active
+    `{user, session, organization}` snapshot at mint time.
+
+    `custom_signing_key` is optional. When omitted, the environment's
+    default session-signing key is used (the same key surfaced at
+    `/.well-known/jwks.json`). When supplied, it is encrypted at rest
+    and never returned by any GET.
+  tags: [JWT Templates]
+  parameters:
+    - $ref: ../../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../../components/schemas/JwtTemplateCreateRequest.yaml }
+        examples:
+          minimal:
+            summary: Minimal template (defaults for lifetime / skew / algorithm)
+            value:
+              name: supabase
+              claims:
+                sub: "{{user.id}}"
+                email: "{{user.primary_email_address}}"
+                role: authenticated
+          full_claims:
+            summary: Larger claim set with organization context
+            value:
+              name: acme_rpc
+              claims:
+                sub: "{{user.external_id}}"
+                email: "{{user.primary_email_address}}"
+                first_name: "{{user.first_name}}"
+                last_name: "{{user.last_name}}"
+                org_id: "{{organization.id}}"
+                org_slug: "{{organization.slug}}"
+                org_role: "{{organization.role}}"
+                tier: "{{user.public_metadata.tier}}"
+                session_id: "{{session.id}}"
+              lifetime: 300
+              allowed_clock_skew: 10
+              signing_algorithm: ES256
+          custom_signing_key:
+            summary: HS256 with a custom shared secret
+            value:
+              name: legacy_hs256
+              claims:
+                sub: "{{user.id}}"
+                iss: https://acme.example
+                aud: legacy-rpc
+              signing_algorithm: HS256
+              custom_signing_key: c2VjcmV0LWJhc2U2NA==
+  responses:
+    "201":
+      description: The created JWT template.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/JwtTemplate.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "409": { $ref: ../../components/responses/Conflict.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }


### PR DESCRIPTION
Closes #94

## Summary

- New `JwtTemplate` schema (`jtmpl_` ID prefix) — `name` slug, Liquid-templated `claims`, `lifetime`, `allowed_clock_skew`, `signing_algorithm` (`RS256` / `ES256` / `HS256`), optional write-only `custom_signing_key`.
- `JwtTemplateCreateRequest` + `JwtTemplateUpdateRequest` for `POST` / `PATCH` bodies.
- BAPI `/v1/jwt-templates` (list / create) + `/v1/jwt-templates/{id}` (get / update / delete).
- `signing_algorithm` immutable on `PATCH`; delete refuses with `409 jwt_template_in_use` while recently-minted tokens may still be cached downstream.
- `custom_signing_key` documented `writeOnly: true` so encoded SDKs strip it from response types.

## Test plan

- [x] `npm run lint:bapi` passes (the pre-existing `instance.yaml` warning is unrelated).
- [x] `npm run bundle:bapi` produces `dist/bapi.bundled.{yaml,json}` without errors.
- [x] Example payloads cover the three shapes called out in the issue (minimal, full claims, custom signing key).