### PR TITLE
OA-2: OauthApplication resource + BAPI /v1/oauth-applications CRUD

### DIFF
--- a/bapi.yaml
+++ b/bapi.yaml
@@ -67,6 +67,8 @@ tags:
     description: Per-environment settings (`InstanceSetting`).
   - name: OAuth Providers
     description: Per-environment social-IdP configuration (`OauthProvider`).
+  - name: OAuth Applications
+    description: Third-party applications registered against authn.sh as an OAuth/OIDC IdP (`OauthApplication`).
   - name: Enterprise Connections
     description: Per-environment enterprise-IdP configuration (`EnterpriseConnection`).
   - name: SMS Templates
@@ -190,6 +192,12 @@ paths:
     $ref: ./paths/bapi/oauth-provider.yaml
   /v1/oauth-providers/{oauth_provider_id}/test:
     $ref: ./paths/bapi/oauth-provider-test.yaml
+  /v1/oauth-applications:
+    $ref: ./paths/bapi/oauth-applications.yaml
+  /v1/oauth-applications/{oauth_application_id}:
+    $ref: ./paths/bapi/oauth-application.yaml
+  /v1/oauth-applications/{oauth_application_id}/rotate-secret:
+    $ref: ./paths/bapi/oauth-application-rotate-secret.yaml
   /v1/enterprise-connections:
     $ref: ./paths/bapi/enterprise-connections.yaml
   /v1/enterprise-connections/{enterprise_connection_id}:
@@ -295,6 +303,10 @@ components:
     OauthProvider:                             { $ref: ./components/schemas/OauthProvider.yaml }
     OauthProviderRequest:                      { $ref: ./components/schemas/OauthProviderRequest.yaml }
     OauthProviderTestResult:                   { $ref: ./components/schemas/OauthProviderTestResult.yaml }
+    OauthApplication:                          { $ref: ./components/schemas/OauthApplication.yaml }
+    OauthApplicationWithSecret:                { $ref: ./components/schemas/OauthApplicationWithSecret.yaml }
+    OauthApplicationCreateRequest:             { $ref: ./components/schemas/OauthApplicationCreateRequest.yaml }
+    OauthApplicationUpdateRequest:             { $ref: ./components/schemas/OauthApplicationUpdateRequest.yaml }
     EnterpriseConnection:                      { $ref: ./components/schemas/EnterpriseConnection.yaml }
     EnterpriseConnectionRequest:               { $ref: ./components/schemas/EnterpriseConnectionRequest.yaml }
     EnterpriseConnectionTestResult:            { $ref: ./components/schemas/EnterpriseConnectionTestResult.yaml }

--- a/components/schemas/OauthApplication.yaml
+++ b/components/schemas/OauthApplication.yaml
@@ -1,0 +1,127 @@
+type: object
+description: |
+  Third-party application registered against the environment as an
+  OAuth 2.0 / OIDC client. `OauthApplication` rows drive the OAuth
+  provider mode endpoints (`/oauth/authorize`, `/oauth/token`,
+  `/oauth/userinfo`) — the application redirects the user to
+  `/oauth/authorize`, the user grants consent, and authn.sh hands
+  back tokens that the application can use to identify the user.
+
+  ### Client types
+
+  - **Confidential** (`is_public: false`) — server-side application
+    that holds a `client_secret` securely. The secret is required on
+    `POST /oauth/token`. Returned exactly once on create / rotate;
+    every subsequent read exposes only `client_id`.
+  - **Public** (`is_public: true`) — single-page app / mobile client
+    that cannot keep a secret. PKCE is required on every
+    `/oauth/authorize` request, and `/oauth/token` exchanges check
+    the verifier instead of a secret. No `client_secret` is ever
+    stored.
+
+  ### Identifier
+
+  Row id prefix `oac_` (e.g. `oac_01HKX9SY9V7H7TF8C8K7J9X4ZA`). The
+  public `client_id` is `oac_pub_<26-char-base32>`, deterministically
+  derived from `id` so it is stable across rotations.
+required:
+  - id
+  - object
+  - name
+  - client_id
+  - callback_urls
+  - scopes
+  - is_public
+  - created_at
+  - updated_at
+additionalProperties: false
+properties:
+  id:
+    $ref: ./Id.yaml
+  object:
+    type: string
+    const: oauth_application
+  name:
+    type: string
+    minLength: 1
+    maxLength: 100
+    description: |
+      Human-readable label rendered on the user-facing consent
+      screen and on the `<UserProfile />` authorized-apps list.
+  client_id:
+    type: string
+    pattern: "^oac_pub_[0-9A-HJKMNP-TV-Z]{26}$"
+    description: |
+      Public client identifier the application sends on every
+      `/oauth/authorize` request. Deterministic from `id` (the
+      same ULID body), prefixed `oac_pub_` so it is visually
+      distinguishable from the internal row id.
+    examples:
+      - oac_pub_01HKX9SY9V7H7TF8C8K7J9X4ZA
+  callback_urls:
+    type: array
+    minItems: 1
+    items:
+      type: string
+      format: uri
+    description: |
+      Allow-list of redirect URIs. Every `/oauth/authorize` request
+      must supply a `redirect_uri` that exactly matches one entry
+      (no wildcard, no path-prefix matching).
+    examples:
+      - ["https://app.acme.example/oauth/callback"]
+  scopes:
+    type: array
+    items:
+      type: string
+    description: |
+      Scope set the application is allowed to request. Standard
+      OIDC scopes (`openid`, `profile`, `email`) plus optional
+      custom scopes (`<env>.<name>`) registered on the
+      environment. `/oauth/authorize` requests narrowing or
+      matching this set succeed; supersets are rejected.
+    examples:
+      - ["openid", "profile", "email"]
+  is_public:
+    type: boolean
+    description: |
+      `true` means the client is public — PKCE-only, no
+      `client_secret` stored. `false` means confidential — a
+      `client_secret` is held server-side and required on token
+      exchange. Immutable after create.
+  client_secret:
+    type: [string, "null"]
+    writeOnly: true
+    description: |
+      Plaintext client secret. Populated only on the response to
+      `POST /v1/oauth-applications` (when `is_public: false`) and
+      on `POST /v1/oauth-applications/{id}/rotate-secret`. **Never
+      returned by any GET.** `null` on every list / read response.
+    examples:
+      - osec_01HKX9SYABCDEFGHJKMNPQRSTVWXYZ234567
+  created_at:
+    $ref: ./Timestamp.yaml
+  updated_at:
+    $ref: ./Timestamp.yaml
+examples:
+  - id: oac_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    object: oauth_application
+    name: Acme Dashboard
+    client_id: oac_pub_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    callback_urls:
+      - https://app.acme.example/oauth/callback
+    scopes: [openid, profile, email]
+    is_public: false
+    created_at: 1714723000000
+    updated_at: 1714723000000
+  - id: oac_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    object: oauth_application
+    name: Acme Mobile
+    client_id: oac_pub_01HKX9SY9V7H7TF8C8K7J9X4ZB
+    callback_urls:
+      - com.acme.app://oauth/callback
+      - https://app.acme.example/oauth/mobile-callback
+    scopes: [openid, profile, email, acme.read_billing]
+    is_public: true
+    created_at: 1714724000000
+    updated_at: 1714724000000

--- a/components/schemas/OauthApplicationCreateRequest.yaml
+++ b/components/schemas/OauthApplicationCreateRequest.yaml
@@ -1,0 +1,47 @@
+type: object
+description: |
+  Request body for `POST /v1/oauth-applications`.
+required:
+  - name
+  - callback_urls
+additionalProperties: false
+properties:
+  name:
+    type: string
+    minLength: 1
+    maxLength: 100
+  callback_urls:
+    type: array
+    minItems: 1
+    items:
+      type: string
+      format: uri
+    description: |
+      Exact-match redirect URI allow-list. At least one entry
+      required.
+  scopes:
+    type: array
+    items:
+      type: string
+    description: |
+      Scope allow-list. Defaults to `[openid, profile, email]` when
+      omitted.
+    default: [openid, profile, email]
+  is_public:
+    type: boolean
+    description: |
+      `true` for a public (PKCE-only) client; `false` for a
+      confidential client with a server-side `client_secret`.
+      Immutable after create.
+    default: false
+examples:
+  - name: Acme Dashboard
+    callback_urls:
+      - https://app.acme.example/oauth/callback
+    scopes: [openid, profile, email]
+  - name: Acme Mobile
+    callback_urls:
+      - com.acme.app://oauth/callback
+      - https://app.acme.example/oauth/mobile-callback
+    scopes: [openid, profile, email, acme.read_billing]
+    is_public: true

--- a/components/schemas/OauthApplicationUpdateRequest.yaml
+++ b/components/schemas/OauthApplicationUpdateRequest.yaml
@@ -1,0 +1,28 @@
+type: object
+description: |
+  Request body for `PATCH /v1/oauth-applications/{oauth_application_id}`.
+  Every field is optional; omitted keys are left untouched.
+  `client_id` and `is_public` are immutable — sending a different
+  value returns `422`.
+additionalProperties: false
+properties:
+  name:
+    type: string
+    minLength: 1
+    maxLength: 100
+  callback_urls:
+    type: array
+    minItems: 1
+    items:
+      type: string
+      format: uri
+  scopes:
+    type: array
+    items:
+      type: string
+examples:
+  - name: Acme Dashboard (renamed)
+  - callback_urls:
+      - https://app.acme.example/oauth/callback
+      - https://staging.acme.example/oauth/callback
+  - scopes: [openid, profile, email, acme.read_billing]

--- a/components/schemas/OauthApplicationWithSecret.yaml
+++ b/components/schemas/OauthApplicationWithSecret.yaml
@@ -1,0 +1,32 @@
+allOf:
+  - $ref: ./OauthApplication.yaml
+  - type: object
+    description: |
+      `OauthApplication` augmented with the plaintext `client_secret`.
+      Returned **only** on `POST /v1/oauth-applications` (when
+      `is_public: false`) and on
+      `POST /v1/oauth-applications/{id}/rotate-secret`. Operators must
+      capture the value at this moment or rotate — there is no way to
+      recover the plaintext afterwards.
+    required:
+      - client_secret
+    properties:
+      client_secret:
+        type: string
+        writeOnly: true
+        description: |
+          Plaintext client secret. Prefix `osec_` + 32-char base32.
+        examples:
+          - osec_01HKX9SYABCDEFGHJKMNPQRSTVWXYZ234567
+examples:
+  - id: oac_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    object: oauth_application
+    name: Acme Dashboard
+    client_id: oac_pub_01HKX9SY9V7H7TF8C8K7J9X4ZA
+    client_secret: osec_01HKX9SYABCDEFGHJKMNPQRSTVWXYZ234567
+    callback_urls:
+      - https://app.acme.example/oauth/callback
+    scopes: [openid, profile, email]
+    is_public: false
+    created_at: 1714723000000
+    updated_at: 1714723000000

--- a/paths/bapi/oauth-application-rotate-secret.yaml
+++ b/paths/bapi/oauth-application-rotate-secret.yaml
@@ -1,0 +1,45 @@
+parameters:
+  - name: oauth_application_id
+    in: path
+    required: true
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+post:
+  operationId: rotateOauthApplicationSecret
+  summary: Rotate the OAuth application's client secret
+  description: |
+    Mint a fresh `client_secret` and invalidate the previous one.
+    Refused with `409 oauth_application_public_client` when the
+    application has `is_public: true` (public clients have no secret
+    to rotate). The response is the **only** time the new plaintext
+    is returned.
+
+    There is no rotation overlap — the previous secret is invalidated
+    immediately. Coordinate the rotation with the consumer to avoid a
+    flap.
+  tags: [OAuth Applications]
+  parameters:
+    - $ref: ../../components/parameters/IdempotencyKeyHeader.yaml
+  responses:
+    "200":
+      description: The rotated application with the fresh plaintext secret.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/OauthApplicationWithSecret.yaml }
+          examples:
+            rotated:
+              value:
+                id: oac_01HKX9SY9V7H7TF8C8K7J9X4ZA
+                object: oauth_application
+                name: Acme Dashboard
+                client_id: oac_pub_01HKX9SY9V7H7TF8C8K7J9X4ZA
+                client_secret: osec_01HKX9TTABCDEFGHJKMNPQRSTVWXYZ234567
+                callback_urls:
+                  - https://app.acme.example/oauth/callback
+                scopes: [openid, profile, email]
+                is_public: false
+                created_at: 1714723000000
+                updated_at: 1714724000000
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "409": { $ref: ../../components/responses/Conflict.yaml }

--- a/paths/bapi/oauth-application.yaml
+++ b/paths/bapi/oauth-application.yaml
@@ -1,0 +1,81 @@
+parameters:
+  - name: oauth_application_id
+    in: path
+    required: true
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+get:
+  operationId: getOauthApplication
+  summary: Get an OAuth application
+  description: |
+    Fetch a single `OauthApplication` row. `client_secret` is never
+    included on a read — it is only ever surfaced on create or
+    `/rotate-secret`.
+  tags: [OAuth Applications]
+  responses:
+    "200":
+      description: The OAuth application.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/OauthApplication.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+
+patch:
+  operationId: updateOauthApplication
+  summary: Update an OAuth application
+  description: |
+    Partial update. `client_id` and `is_public` are immutable —
+    sending a different value returns `422`. Every other field is
+    optional; omitted keys are left untouched.
+
+    Shrinking `callback_urls` or `scopes` does not invalidate already
+    issued tokens; subsequent `/oauth/authorize` requests are evaluated
+    against the new set.
+  tags: [OAuth Applications]
+  parameters:
+    - $ref: ../../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../../components/schemas/OauthApplicationUpdateRequest.yaml }
+        examples:
+          rename:
+            summary: Rename the application
+            value: { name: Acme Dashboard (renamed) }
+          add_callback:
+            summary: Add a staging redirect URI
+            value:
+              callback_urls:
+                - https://app.acme.example/oauth/callback
+                - https://staging.acme.example/oauth/callback
+          widen_scopes:
+            summary: Grant a custom scope
+            value:
+              scopes: [openid, profile, email, acme.read_billing]
+  responses:
+    "200":
+      description: The updated OAuth application.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/OauthApplication.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }
+
+delete:
+  operationId: deleteOauthApplication
+  summary: Delete an OAuth application
+  description: |
+    Soft delete. Revokes every outstanding `AuthorizationGrant` rooted
+    at this application (no opt-out) and rejects subsequent
+    `/oauth/authorize` requests with `400 invalid_client`. Existing
+    access / refresh tokens are invalidated at the next introspection
+    or refresh attempt.
+  tags: [OAuth Applications]
+  responses:
+    "204":
+      description: Deleted.
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }

--- a/paths/bapi/oauth-applications.yaml
+++ b/paths/bapi/oauth-applications.yaml
@@ -1,0 +1,109 @@
+get:
+  operationId: listOauthApplications
+  summary: List OAuth applications
+  description: |
+    Paginated list of every `OauthApplication` row registered against
+    the environment. Confidential applications never expose
+    `client_secret` on read.
+  tags: [OAuth Applications]
+  parameters:
+    - $ref: ../../components/parameters/LimitParam.yaml
+    - $ref: ../../components/parameters/OffsetParam.yaml
+  responses:
+    "200":
+      description: A page of OAuth applications.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: ../../components/schemas/PaginatedList.yaml
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: ../../components/schemas/OauthApplication.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+
+post:
+  operationId: createOauthApplication
+  summary: Create an OAuth application
+  description: |
+    Register a third-party application that can authenticate users
+    against this environment's `/oauth/authorize` + `/oauth/token`
+    endpoints.
+
+    When `is_public: false`, the response carries the freshly minted
+    plaintext `client_secret` exactly once (`OauthApplicationWithSecret`).
+    Capture it at this moment or rotate via
+    `POST /v1/oauth-applications/{id}/rotate-secret` — there is no way
+    to recover the plaintext afterwards.
+
+    When `is_public: true`, no secret is stored; the response is the
+    plain `OauthApplication` shape (no `client_secret` field).
+  tags: [OAuth Applications]
+  parameters:
+    - $ref: ../../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema: { $ref: ../../components/schemas/OauthApplicationCreateRequest.yaml }
+        examples:
+          confidential:
+            summary: Confidential client (server-side app)
+            value:
+              name: Acme Dashboard
+              callback_urls:
+                - https://app.acme.example/oauth/callback
+              scopes: [openid, profile, email]
+          public_pkce:
+            summary: Public client (PKCE-only mobile / SPA)
+            value:
+              name: Acme Mobile
+              callback_urls:
+                - com.acme.app://oauth/callback
+                - https://app.acme.example/oauth/mobile-callback
+              scopes: [openid, profile, email, acme.read_billing]
+              is_public: true
+  responses:
+    "201":
+      description: |
+        The created application. The plaintext `client_secret` is
+        included only when `is_public: false` — this is the **only**
+        response that ever surfaces it. Public clients have no secret
+        and the field is omitted.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/OauthApplication.yaml }
+          examples:
+            confidential:
+              summary: Confidential — plaintext secret returned once
+              value:
+                id: oac_01HKX9SY9V7H7TF8C8K7J9X4ZA
+                object: oauth_application
+                name: Acme Dashboard
+                client_id: oac_pub_01HKX9SY9V7H7TF8C8K7J9X4ZA
+                client_secret: osec_01HKX9SYABCDEFGHJKMNPQRSTVWXYZ234567
+                callback_urls:
+                  - https://app.acme.example/oauth/callback
+                scopes: [openid, profile, email]
+                is_public: false
+                created_at: 1714723000000
+                updated_at: 1714723000000
+            public:
+              summary: Public — no secret
+              value:
+                id: oac_01HKX9SY9V7H7TF8C8K7J9X4ZB
+                object: oauth_application
+                name: Acme Mobile
+                client_id: oac_pub_01HKX9SY9V7H7TF8C8K7J9X4ZB
+                callback_urls:
+                  - com.acme.app://oauth/callback
+                  - https://app.acme.example/oauth/mobile-callback
+                scopes: [openid, profile, email, acme.read_billing]
+                is_public: true
+                created_at: 1714724000000
+                updated_at: 1714724000000
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "409": { $ref: ../../components/responses/Conflict.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }


### PR DESCRIPTION
Closes #95

## Summary

- New `OauthApplication` schema (`oac_` ID prefix) — `client_id` (public `oac_pub_…`), `callback_urls[]` (exact-match allow-list, min 1), `scopes[]`, `is_public` toggle.
- `OauthApplicationWithSecret` for the once-per-secret return shape (`client_secret` written only on create/rotate, never on GET).
- `OauthApplicationCreateRequest` + `OauthApplicationUpdateRequest`.
- BAPI `/v1/oauth-applications` (list / create), `/v1/oauth-applications/{id}` (get / update / delete), and `POST /v1/oauth-applications/{id}/rotate-secret` (refused for public clients with `409 oauth_application_public_client`).
- `client_id` + `is_public` immutable on PATCH; delete revokes any outstanding `AuthorizationGrant` rows.

## Test plan

- [x] `npm run lint:bapi` passes (the pre-existing `instance.yaml` warning is unrelated).
- [x] `npm run bundle:bapi` succeeds.
- [x] Examples cover confidential vs public client creation and the rotate-secret response.