### PR TITLE
OA-6: BAPI SCIM admin endpoints (carryover from v0.6)

### DIFF
--- a/bapi.yaml
+++ b/bapi.yaml
@@ -77,6 +77,8 @@ tags:
     description: Webhook endpoints, deliveries, and the event envelope.
   - name: JWT Templates
     description: Named JWT templates rendered by `Session.getToken({template})` (`JwtTemplate`).
+  - name: Org SCIM Admin
+    description: Operator-scoped (bearer-secret) SCIM token and attribute-mapping admin for any organization (`ScimToken`, `ScimAttributeMapping`).
 
 security:
   - bearer_secret_key: []
@@ -214,6 +216,14 @@ paths:
     $ref: ./paths/bapi/jwt-templates.yaml
   /v1/jwt-templates/{jwt_template_id}:
     $ref: ./paths/bapi/jwt-template.yaml
+  /v1/organizations/{organization_id}/scim/tokens:
+    $ref: ./paths/bapi/organization-scim-tokens.yaml
+  /v1/organizations/{organization_id}/scim/tokens/{scim_token_id}/revoke:
+    $ref: ./paths/bapi/organization-scim-token-revoke.yaml
+  /v1/organizations/{organization_id}/scim/attribute-mappings:
+    $ref: ./paths/bapi/organization-scim-attribute-mappings.yaml
+  /v1/organizations/{organization_id}/scim/endpoint:
+    $ref: ./paths/bapi/organization-scim-endpoint.yaml
   /v1/sms-templates:
     $ref: ./paths/bapi/sms-templates.yaml
   /v1/sms-templates/{sms_template_slug}:
@@ -322,6 +332,8 @@ components:
     JwtTemplate:                               { $ref: ./components/schemas/JwtTemplate.yaml }
     JwtTemplateCreateRequest:                  { $ref: ./components/schemas/JwtTemplateCreateRequest.yaml }
     JwtTemplateUpdateRequest:                  { $ref: ./components/schemas/JwtTemplateUpdateRequest.yaml }
+    ScimToken:                                 { $ref: ./components/schemas/ScimToken.yaml }
+    ScimAttributeMapping:                      { $ref: ./components/schemas/ScimAttributeMapping.yaml }
 
   responses:
     BadRequest:           { $ref: ./components/responses/BadRequest.yaml }

--- a/paths/bapi/organization-scim-attribute-mappings.yaml
+++ b/paths/bapi/organization-scim-attribute-mappings.yaml
@@ -1,0 +1,58 @@
+parameters:
+  - name: organization_id
+    in: path
+    required: true
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+get:
+  operationId: adminGetOrganizationScimAttributeMapping
+  summary: Read the SCIM attribute mapping (BAPI)
+  description: |
+    Operator-scoped read of the per-org `ScimAttributeMapping`
+    (server defaults overridden by the operator).
+  tags: [Org SCIM Admin]
+  responses:
+    "200":
+      description: The attribute mapping.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ScimAttributeMapping.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+
+put:
+  operationId: adminReplaceOrganizationScimAttributeMapping
+  summary: Replace the SCIM attribute mapping (BAPI)
+  description: |
+    Full-resource replace of the override map. Unsupplied keys revert
+    to the server defaults — there is no per-field PATCH.
+  tags: [Org SCIM Admin]
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [mapping]
+          additionalProperties: false
+          properties:
+            mapping:
+              type: object
+              additionalProperties: { type: string }
+        examples:
+          okta:
+            value:
+              mapping:
+                userName: email_address
+                name.givenName: first_name
+                name.familyName: last_name
+                externalId: external_id
+  responses:
+    "200":
+      description: The replaced mapping.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ScimAttributeMapping.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }

--- a/paths/bapi/organization-scim-endpoint.yaml
+++ b/paths/bapi/organization-scim-endpoint.yaml
@@ -1,0 +1,41 @@
+parameters:
+  - name: organization_id
+    in: path
+    required: true
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+get:
+  operationId: adminGetOrganizationScimEndpoint
+  summary: Read the SCIM endpoint URL (BAPI)
+  description: |
+    Operator-scoped read of the SCIM base URL the IdP admin pastes
+    into their provisioning configuration. The shape is:
+
+    ```
+    https://<env_slug>.authn.sh/scim/v2/
+    ```
+
+    Per-org SCIM token authorisation scopes provisioning to this
+    organization — the IdP doesn't see a per-org URL.
+  tags: [Org SCIM Admin]
+  responses:
+    "200":
+      description: The SCIM endpoint URL.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [endpoint_url]
+            additionalProperties: false
+            properties:
+              endpoint_url:
+                type: string
+                format: uri
+                examples:
+                  - https://acme.authn.sh/scim/v2/
+          examples:
+            production:
+              value:
+                endpoint_url: https://acme.authn.sh/scim/v2/
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }

--- a/paths/bapi/organization-scim-token-revoke.yaml
+++ b/paths/bapi/organization-scim-token-revoke.yaml
@@ -1,0 +1,26 @@
+parameters:
+  - name: organization_id
+    in: path
+    required: true
+    schema: { $ref: ../../components/schemas/Id.yaml }
+  - name: scim_token_id
+    in: path
+    required: true
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+post:
+  operationId: adminRevokeOrganizationScimToken
+  summary: Revoke a SCIM token (BAPI)
+  description: |
+    Stamp `revoked_at` on the row. Every subsequent `/scim/v2/*`
+    request authenticated with this token returns `401 invalidVers`.
+    Revocation is irreversible — issue a fresh token to replace it.
+  tags: [Org SCIM Admin]
+  responses:
+    "200":
+      description: The revoked token (no plaintext).
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ScimToken.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }

--- a/paths/bapi/organization-scim-tokens.yaml
+++ b/paths/bapi/organization-scim-tokens.yaml
@@ -1,0 +1,81 @@
+parameters:
+  - name: organization_id
+    in: path
+    required: true
+    description: ID of the organization the SCIM tokens are scoped to.
+    schema: { $ref: ../../components/schemas/Id.yaml }
+
+get:
+  operationId: adminListOrganizationScimTokens
+  summary: List SCIM tokens for an organization (BAPI)
+  description: |
+    Operator-scoped mirror of the FAPI surface — no per-user
+    permission check, bearer-secret authenticated. Returns active
+    and revoked `ScimToken` rows. The full plaintext token is never
+    returned — only `prefix`.
+  tags: [Org SCIM Admin]
+  parameters:
+    - $ref: ../../components/parameters/LimitParam.yaml
+    - $ref: ../../components/parameters/OffsetParam.yaml
+  responses:
+    "200":
+      description: A page of SCIM tokens (no plaintext).
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: ../../components/schemas/PaginatedList.yaml
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: ../../components/schemas/ScimToken.yaml }
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+
+post:
+  operationId: adminIssueOrganizationScimToken
+  summary: Issue a SCIM token (BAPI)
+  description: |
+    Mint a fresh SCIM bearer token scoped to this organization. The
+    response is the **only** time the full plaintext (`token` field)
+    is returned — subsequent reads expose `prefix` only.
+  tags: [Org SCIM Admin]
+  parameters:
+    - $ref: ../../components/parameters/IdempotencyKeyHeader.yaml
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [name]
+          additionalProperties: false
+          properties:
+            name:
+              type: string
+              minLength: 1
+              maxLength: 100
+        examples:
+          okta_prod:
+            value: { name: "Okta — Production" }
+  responses:
+    "201":
+      description: The issued SCIM token. `token` plaintext is included **only on this response**.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ScimToken.yaml }
+          examples:
+            issued:
+              value:
+                id: scimt_01HKX9SY9V7H7TF8C8K7J9X4ZA
+                object: scim_token
+                organization_id: org_01HKX9SY9V7H7TF8C8K7J9X4ZB
+                name: "Okta — Production"
+                prefix: "scim_01HKX9SY"
+                token: "scim_01HKX9SYABCDEFGHJKMNPQRSTVWXYZ234567"
+                created_at: 1714723000000
+                revoked_at: null
+    "401": { $ref: ../../components/responses/Unauthorized.yaml }
+    "404": { $ref: ../../components/responses/NotFound.yaml }
+    "422": { $ref: ../../components/responses/UnprocessableEntity.yaml }


### PR DESCRIPTION
Closes #99

## Summary

- BAPI mirror of v0.6 AU-10's FAPI SCIM surface, operator-scoped (no per-user permission check; bearer-secret authenticated).
- `GET|POST /v1/organizations/{org_id}/scim/tokens` (list / issue with single-shot plaintext).
- `POST /v1/organizations/{org_id}/scim/tokens/{token_id}/revoke`.
- `GET|PUT /v1/organizations/{org_id}/scim/attribute-mappings` (read / full replace).
- `GET /v1/organizations/{org_id}/scim/endpoint` (read-only URL).
- New tag `Org SCIM Admin`. Reuses v0.6 `ScimToken` + `ScimAttributeMapping` schemas (now registered on the BAPI root).

## Test plan

- [x] `npm run lint:bapi` passes (only the pre-existing `instance.yaml` warning remains).
- [x] `npm run bundle:bapi` succeeds.
- [x] Example payloads cover issue + revoke + attribute-mapping replace.