### PR TITLE
OA-4: FAPI /oauth/token + /oauth/token_info introspection

### DIFF
--- a/fapi.yaml
+++ b/fapi.yaml
@@ -228,6 +228,10 @@ paths:
     $ref: ./paths/fapi/me-active-organization.yaml
   /oauth/authorize:
     $ref: ./paths/fapi/oauth-authorize.yaml
+  /oauth/token:
+    $ref: ./paths/fapi/oauth-token.yaml
+  /oauth/token_info:
+    $ref: ./paths/fapi/oauth-token-info.yaml
 
 components:
   securitySchemes:

--- a/paths/fapi/oauth-token-info.yaml
+++ b/paths/fapi/oauth-token-info.yaml
@@ -1,0 +1,151 @@
+post:
+  operationId: oauthTokenInfo
+  summary: OAuth 2.0 token introspection
+  description: |
+    RFC 7662 token introspection. Lets a resource server validate a
+    bearer token it received from a client without re-implementing
+    the JWT verification logic (or in cases where the token is opaque
+    rather than a JWT).
+
+    ### Authentication
+
+    Two schemes are accepted:
+
+    - `client_secret_basic` — the `OauthApplication` itself
+      introspects tokens minted against it. Useful for a confidential
+      client's resource server when it shares the same client_id /
+      secret pair.
+    - `bearer_secret_key` — the env's BAPI secret key
+      (`sk_test_…` / `sk_live_…`). Lets server-side admin tooling
+      introspect tokens for any application in the env (e.g. for
+      audit logs or anomaly detection).
+
+    Anonymous calls are refused with `401`.
+
+    ### Response
+
+    Per RFC 7662 §2.2, an inactive / unknown token returns
+    `{ "active": false }` with no further detail. Active tokens
+    return the introspection metadata documented below.
+  tags: [OAuth]
+  security: []
+  requestBody:
+    required: true
+    content:
+      application/x-www-form-urlencoded:
+        schema:
+          type: object
+          required: [token]
+          additionalProperties: false
+          properties:
+            token:
+              type: string
+              description: |
+                The token to introspect. May be an `access_token`
+                (`oat_…`) or a `refresh_token` (`oartt_…`). The
+                introspected token's kind is reflected in the
+                `token_type_hint` field of the response.
+              maxLength: 4096
+            token_type_hint:
+              type: string
+              enum: [access_token, refresh_token]
+              description: |
+                Optimization hint per RFC 7662 §2.1. The server may
+                ignore it. authn.sh uses the prefix on the token
+                itself (`oat_` vs `oartt_`) as authoritative.
+        examples:
+          introspect_access:
+            value:
+              token: oat_01HKX9SYABCDEFGHJKMNPQRSTVWXYZ234567
+              token_type_hint: access_token
+          introspect_refresh:
+            value:
+              token: oartt_01HKX9SY9V7H7TF8C8K7J9X4ZC
+              token_type_hint: refresh_token
+  responses:
+    "200":
+      description: |
+        Introspection result. `active: false` carries no further
+        detail; `active: true` carries the documented metadata.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [active]
+            additionalProperties: false
+            properties:
+              active:
+                type: boolean
+                description: |
+                  `true` iff the token is currently valid (not
+                  expired, not revoked, rooted at a non-revoked
+                  `AuthorizationGrant`).
+              scope:
+                type: string
+                description: Space-separated granted scope set.
+              client_id:
+                type: string
+                description: |
+                  `OauthApplication.client_id` the token was issued
+                  to.
+                pattern: "^oac_pub_[0-9A-HJKMNP-TV-Z]{26}$"
+              username:
+                type: string
+                description: |
+                  Human-readable user identifier — primary email
+                  address or username, whichever the env primarily
+                  identifies users by.
+              token_type:
+                type: string
+                const: Bearer
+              exp:
+                type: integer
+                description: Unix-second expiry timestamp.
+              iat:
+                type: integer
+                description: Unix-second issuance timestamp.
+              nbf:
+                type: integer
+                description: Unix-second "not before" timestamp.
+              sub:
+                description: User the token represents.
+                $ref: ../../components/schemas/Id.yaml
+              aud:
+                type: string
+                description: |
+                  Same as `client_id`. Surfaced for tooling that
+                  expects the JWT-style claim name.
+              iss:
+                type: string
+                format: uri
+                description: |
+                  Environment-scoped issuer URL —
+                  `https://<env_slug>.authn.sh`.
+              jti:
+                type: string
+                description: Token ID — same as the access/refresh token suffix.
+          examples:
+            active_access:
+              summary: Live access token
+              value:
+                active: true
+                scope: "openid profile email"
+                client_id: oac_pub_01HKX9SY9V7H7TF8C8K7J9X4ZA
+                username: alice@acme.example
+                token_type: Bearer
+                exp: 1714726600
+                iat: 1714723000
+                nbf: 1714723000
+                sub: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+                aud: oac_pub_01HKX9SY9V7H7TF8C8K7J9X4ZA
+                iss: https://acme.authn.sh
+                jti: oat_01HKX9SYABCDEFGHJKMNPQRSTVWXYZ234567
+            inactive:
+              summary: Expired / revoked / unknown
+              value:
+                active: false
+    "401":
+      description: Anonymous call — neither client credentials nor BAPI secret presented.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ErrorResponse.yaml }

--- a/paths/fapi/oauth-token.yaml
+++ b/paths/fapi/oauth-token.yaml
@@ -1,0 +1,239 @@
+post:
+  operationId: oauthToken
+  summary: OAuth 2.0 token endpoint
+  description: |
+    RFC 6749 §3.2 / OIDC Core §3.1.3 token endpoint. Exchanges an
+    authorization code minted by `/oauth/authorize` for an
+    `access_token` + `id_token` (+ optional `refresh_token`), or
+    rotates an existing `refresh_token`.
+
+    ### Client authentication
+
+    Confidential clients (`OauthApplication.is_public: false`)
+    authenticate one of two ways (RFC 6749 §2.3.1):
+
+    - `client_secret_basic` — HTTP Basic auth header carrying
+      `<client_id>:<client_secret>`.
+    - `client_secret_post` — `client_id` + `client_secret` in the
+      form body.
+
+    Public clients (`is_public: true`) omit the secret entirely and
+    must supply `code_verifier` matching the `code_challenge` they
+    sent to `/oauth/authorize`. The verifier check replaces the
+    secret check (RFC 7636 §4.6).
+
+    ### Refresh-token rotation
+
+    On `grant_type=refresh_token`, the previous refresh token is
+    invalidated and a fresh one is returned. Clients that mishandle
+    the rotation (e.g. retry with the old token) trip
+    refresh-token-reuse detection — every token rooted at the
+    `AuthorizationGrant` is invalidated and the user must re-consent.
+    This matches OAuth 2.1 §6.1.
+
+    ### ID token
+
+    Issued when the granted scope set includes `openid`. Signed with
+    the env's session-signing key (the same `kid` surfaced at
+    `/.well-known/jwks.json`). Claims:
+
+    - `iss` — `https://<env_slug>.authn.sh`
+    - `sub` — the user's `id` (`user_…`)
+    - `aud` — the requesting `client_id`
+    - `iat` / `exp` / `nbf` — per `lifetime`
+    - `nonce` — verbatim from `/oauth/authorize` when provided
+    - `email` / `email_verified` — when `profile` and `email` scopes
+      are granted
+    - `name` / `given_name` / `family_name` / `picture` — when
+      `profile` scope is granted
+    - Org-aware claims (`org_id`, `org_slug`, `org_role`) when the
+      session has an active organization
+  tags: [OAuth]
+  security: []
+  requestBody:
+    required: true
+    content:
+      application/x-www-form-urlencoded:
+        schema:
+          type: object
+          required: [grant_type]
+          additionalProperties: false
+          properties:
+            grant_type:
+              type: string
+              enum: [authorization_code, refresh_token]
+              description: |
+                Which grant flow to run.
+            code:
+              type: string
+              description: |
+                Authorization code minted by `/oauth/authorize`.
+                Required when `grant_type=authorization_code`. Single
+                use; expires 60 seconds after issue.
+              maxLength: 2048
+            redirect_uri:
+              type: string
+              format: uri
+              description: |
+                Must match the `redirect_uri` originally sent to
+                `/oauth/authorize` (per RFC 6749 §4.1.3 — guards
+                against authorization-code injection).
+              maxLength: 2048
+            refresh_token:
+              type: string
+              description: |
+                Required when `grant_type=refresh_token`. Single use;
+                replaced on every successful exchange.
+              maxLength: 4096
+            client_id:
+              type: string
+              description: |
+                Required for public clients and for confidential
+                clients using `client_secret_post`. Omitted (or
+                ignored) when authentication rides the
+                `Authorization` header (`client_secret_basic`).
+              pattern: "^oac_pub_[0-9A-HJKMNP-TV-Z]{26}$"
+            client_secret:
+              type: string
+              description: |
+                Required for confidential clients using
+                `client_secret_post`. Never sent by public clients.
+              maxLength: 2048
+            code_verifier:
+              type: string
+              description: |
+                PKCE verifier (RFC 7636 §4.1). Required when the
+                application is `is_public: true` or when
+                `code_challenge` was sent to `/oauth/authorize`.
+              pattern: "^[A-Za-z0-9._~-]{43,128}$"
+            scope:
+              type: string
+              description: |
+                Optional on `grant_type=refresh_token` — narrow the
+                granted scope set on rotation (cannot widen). Ignored
+                on `grant_type=authorization_code` (scope comes from
+                the `AuthorizationGrant`).
+              maxLength: 1024
+        examples:
+          authorization_code_confidential:
+            summary: Confidential client redeeming an authorization code
+            value:
+              grant_type: authorization_code
+              code: oacode_01HKX9SY9V7H7TF8C8K7J9X4ZA
+              redirect_uri: https://app.acme.example/oauth/callback
+              client_id: oac_pub_01HKX9SY9V7H7TF8C8K7J9X4ZA
+              client_secret: osec_01HKX9SYABCDEFGHJKMNPQRSTVWXYZ234567
+          authorization_code_pkce:
+            summary: Public client redeeming with PKCE verifier
+            value:
+              grant_type: authorization_code
+              code: oacode_01HKX9SY9V7H7TF8C8K7J9X4ZB
+              redirect_uri: com.acme.app://oauth/callback
+              client_id: oac_pub_01HKX9SY9V7H7TF8C8K7J9X4ZB
+              code_verifier: dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
+          refresh_token:
+            summary: Refresh-token rotation
+            value:
+              grant_type: refresh_token
+              refresh_token: oartt_01HKX9SY9V7H7TF8C8K7J9X4ZC
+              client_id: oac_pub_01HKX9SY9V7H7TF8C8K7J9X4ZA
+              client_secret: osec_01HKX9SYABCDEFGHJKMNPQRSTVWXYZ234567
+  responses:
+    "200":
+      description: The minted token bundle.
+      headers:
+        Cache-Control:
+          description: Always `no-store` per RFC 6749 §5.1.
+          schema:
+            type: string
+            const: no-store
+        Pragma:
+          description: Always `no-cache` per RFC 6749 §5.1.
+          schema:
+            type: string
+            const: no-cache
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [access_token, token_type, expires_in, scope]
+            additionalProperties: false
+            properties:
+              access_token:
+                type: string
+                description: |
+                  Bearer access token. Format `oat_<base32-ULID-bytes>`.
+                  Verified at `/oauth/userinfo` and `/oauth/token_info`.
+              token_type:
+                type: string
+                const: Bearer
+              expires_in:
+                type: integer
+                minimum: 1
+                description: |
+                  Access token lifetime in seconds. Default 3600
+                  (1 hour); operator-overridable per
+                  `OauthApplication` post-v0.7.
+              refresh_token:
+                type: string
+                description: |
+                  Refresh token (`oartt_<base32-ULID-bytes>`).
+                  Returned when the granted scope set includes
+                  `offline_access`, and on every
+                  `grant_type=refresh_token` exchange. Single use.
+              id_token:
+                type: string
+                description: |
+                  Signed OIDC ID token (JWT). Returned when the
+                  granted scope set includes `openid`. Claims documented
+                  in the operation description.
+              scope:
+                type: string
+                description: |
+                  Space-separated final scope set granted on this
+                  token (may be a subset of the requested set when
+                  the user denied individual scopes on the consent
+                  screen).
+          examples:
+            full:
+              summary: Full bundle with id_token + refresh_token
+              value:
+                access_token: oat_01HKX9SYABCDEFGHJKMNPQRSTVWXYZ234567
+                token_type: Bearer
+                expires_in: 3600
+                refresh_token: oartt_01HKX9SY9V7H7TF8C8K7J9X4ZC
+                id_token: eyJhbGciOiJSUzI1NiIsImtpZCI6ImVudl9hY21lX3Rlc3RfMSJ9.eyJpc3MiOiJodHRwczovL2FjbWUuYXV0aG4uc2giLCJzdWIiOiJ1c2VyXzAxSEtYOVNZOVY3SDdUR…
+                scope: "openid profile email"
+            minimal:
+              summary: Bearer-only (no OIDC, no refresh)
+              value:
+                access_token: oat_01HKX9SYABCDEFGHJKMNPQRSTVWXYZ234567
+                token_type: Bearer
+                expires_in: 3600
+                scope: "acme.read_billing"
+    "400":
+      description: |
+        Grant validation failed. Error codes (RFC 6749 §5.2 + OIDC):
+
+        - `oauth_invalid_grant` — code expired, already redeemed,
+          or doesn't match the supplied `redirect_uri` /
+          `code_verifier`.
+        - `oauth_invalid_request` — required parameter missing.
+        - `oauth_invalid_client` — bad credentials.
+        - `oauth_unsupported_grant_type` — `grant_type` not in the
+          enum.
+        - `oauth_invalid_pkce` — `code_verifier` doesn't hash to
+          the prior `code_challenge`.
+        - `oauth_invalid_scope` — refresh-rotation requested a
+          scope outside the original grant.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ErrorResponse.yaml }
+    "401":
+      description: |
+        Client authentication failed (`client_secret_basic` /
+        `client_secret_post` mismatch). Returns
+        `WWW-Authenticate: Basic realm="oauth"` per RFC 6749 §5.2.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ErrorResponse.yaml }


### PR DESCRIPTION
Closes #97

## Summary

- `POST /oauth/token` (RFC 6749 §3.2 + OIDC Core §3.1.3) — exchanges the authorization code minted by OA-3 for `access_token` + `id_token` (when `openid` granted) + optional `refresh_token` (`oat_` / `oartt_` prefixes). Documents `grant_type=authorization_code` and `grant_type=refresh_token`, confidential vs public client auth, PKCE verifier handling, and refresh-token-reuse detection per OAuth 2.1 §6.1.
- `POST /oauth/token_info` (RFC 7662) — introspection. `{active: false}` for unknown/expired/revoked; full metadata (`scope`, `client_id`, `sub`, `iss`, `exp`, `iat`, `jti`, …) otherwise.
- ID-token claim contract documented inline — `iss`, `sub`, `aud`, `iat/exp/nbf`, `nonce`, `email/email_verified` + `name/given_name/family_name/picture` (per granted scope), org-aware claims (`org_id`, `org_slug`, `org_role`).
- `Cache-Control: no-store` + `Pragma: no-cache` headers documented per RFC 6749 §5.1.

## Test plan

- [x] `npm run lint:fapi` passes.
- [x] `npm run bundle:fapi` succeeds.
- [x] Examples cover authorization_code (confidential + PKCE), refresh_token rotation, and introspection (active access token + inactive fallback).