### PR TITLE
OA-5: FAPI /oauth/userinfo + /.well-known/{openid-configuration,jwks.json}

### DIFF
--- a/fapi.yaml
+++ b/fapi.yaml
@@ -232,6 +232,12 @@ paths:
     $ref: ./paths/fapi/oauth-token.yaml
   /oauth/token_info:
     $ref: ./paths/fapi/oauth-token-info.yaml
+  /oauth/userinfo:
+    $ref: ./paths/fapi/oauth-userinfo.yaml
+  /.well-known/openid-configuration:
+    $ref: ./paths/fapi/well-known-openid-configuration.yaml
+  /.well-known/jwks.json:
+    $ref: ./paths/fapi/well-known-jwks.yaml
 
 components:
   securitySchemes:

--- a/paths/fapi/oauth-userinfo.yaml
+++ b/paths/fapi/oauth-userinfo.yaml
@@ -1,0 +1,133 @@
+get:
+  operationId: oauthUserinfo
+  summary: OIDC UserInfo endpoint
+  description: |
+    OpenID Connect Core §5.3 UserInfo endpoint. Bearer-authenticated
+    by an access token issued by `/oauth/token`. Returns the subset
+    of `User` claims authorised by the access token's granted scope
+    set.
+
+    ### Scope → claim mapping
+
+    - `openid` — always returns `sub` (the user's `id`).
+    - `profile` — adds `name` (composed from `first_name` +
+      `last_name` when both are present), `given_name`,
+      `family_name`, `preferred_username`, `picture`, `updated_at`.
+    - `email` — adds `email` (`User.primary_email_address`) and
+      `email_verified` (`true` iff the primary email is verified).
+    - `phone` — adds `phone_number` and `phone_number_verified`.
+    - `address` — adds `address` per OIDC §5.1.1 when the env exposes
+      a user-address attribute (post-v0.7; absent otherwise).
+    - Custom (`<env>.<name>`) scopes — surfaced under
+      `<env>.<name>` keys at the top level. Each custom scope is
+      mapped to a `User` field (or a static value) by the operator
+      via the JWT-template-style configuration.
+
+    Claims for scopes not on the access token's granted set are
+    silently omitted (per OIDC §5.4) rather than rejected with an
+    error.
+
+    ### Caching
+
+    Responses are uncacheable per OIDC §5.3.3 (`Cache-Control:
+    no-store`). The SDK calls this on demand when reading
+    `User`-shaped claims it didn't already get from the ID token.
+  tags: [OAuth]
+  security: []
+  responses:
+    "200":
+      description: |
+        UserInfo response. `sub` is always present; every other claim
+        is conditional on scope.
+      headers:
+        Cache-Control:
+          description: Always `no-store` per OIDC §5.3.3.
+          schema:
+            type: string
+            const: no-store
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [sub]
+            additionalProperties: true
+            properties:
+              sub:
+                description: User's `id`. Always present.
+                $ref: ../../components/schemas/Id.yaml
+              name:
+                type: string
+                description: |
+                  Composed display name. Surfaced when `profile`
+                  is granted and either `first_name` or `last_name`
+                  is set on the `User`.
+              given_name:
+                type: string
+                description: From `User.first_name`. `profile` scope.
+              family_name:
+                type: string
+                description: From `User.last_name`. `profile` scope.
+              preferred_username:
+                type: string
+                description: From `User.username`. `profile` scope.
+              picture:
+                type: string
+                format: uri
+                description: From `User.image_url`. `profile` scope.
+              updated_at:
+                type: integer
+                description: |
+                  Unix-second `User.updated_at`. OIDC §5.1 specifies
+                  this field as seconds, **not** the millisecond
+                  `Timestamp` used elsewhere in the surface.
+              email:
+                type: string
+                format: email
+                description: From `User.primary_email_address`. `email` scope.
+              email_verified:
+                type: boolean
+                description: |
+                  `true` when the primary email's verification
+                  state is `verified`. `email` scope.
+              phone_number:
+                type: string
+                description: |
+                  From `User.primary_phone_number` (E.164).
+                  `phone` scope.
+              phone_number_verified:
+                type: boolean
+                description: |
+                  `true` when the primary phone is verified.
+                  `phone` scope.
+          examples:
+            full_profile:
+              summary: openid + profile + email granted
+              value:
+                sub: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+                name: Alice Anderson
+                given_name: Alice
+                family_name: Anderson
+                preferred_username: alice
+                picture: https://acme.authn.sh/storage/u/user_01HKX9SY9V7H7TF8C8K7J9X4ZB.jpg
+                updated_at: 1714723000
+                email: alice@acme.example
+                email_verified: true
+            sub_only:
+              summary: openid only — nothing leaked beyond `sub`
+              value:
+                sub: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+            custom_scope:
+              summary: Custom scope `acme.read_billing` surfaced at the top level
+              value:
+                sub: user_01HKX9SY9V7H7TF8C8K7J9X4ZB
+                email: alice@acme.example
+                email_verified: true
+                "acme.read_billing": true
+    "401":
+      description: |
+        Missing / invalid / expired access token. Returns
+        `WWW-Authenticate: Bearer realm="oauth", error="…"` per
+        OIDC §5.3.5.
+      content:
+        application/json:
+          schema: { $ref: ../../components/schemas/ErrorResponse.yaml }

--- a/paths/fapi/well-known-jwks.yaml
+++ b/paths/fapi/well-known-jwks.yaml
@@ -1,0 +1,104 @@
+get:
+  operationId: getJwks
+  summary: JSON Web Key Set
+  description: |
+    RFC 7517 JWKS document for the calling environment. Public,
+    unauthenticated. Cached for one hour.
+
+    Surfaces every public verifying key the environment may have
+    signed a token with — the standard session-signing key, plus
+    any rotated predecessors still inside their grace window. As
+    of v0.7 the same JWKS covers IdP-mode tokens (access /
+    `id_token` from `/oauth/token`) by default. Envs that wire a
+    separate IdP signing key surface it here as an additional
+    entry, distinguished by `use` / `kid`.
+
+    Verifiers should match by `kid`, never assume a single-key
+    JWKS.
+  tags: [JWKS / OIDC]
+  security: []
+  responses:
+    "200":
+      description: The JSON Web Key Set.
+      headers:
+        Cache-Control:
+          description: Always `public, max-age=3600`.
+          schema:
+            type: string
+            const: public, max-age=3600
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [keys]
+            additionalProperties: false
+            properties:
+              keys:
+                type: array
+                items:
+                  type: object
+                  required: [kty, kid, use, alg]
+                  additionalProperties: true
+                  properties:
+                    kty:
+                      type: string
+                      enum: [RSA, EC, oct]
+                      description: Key type per RFC 7518.
+                    kid:
+                      type: string
+                      description: |
+                        Stable key id matching the `kid` header
+                        on tokens signed with this key.
+                    use:
+                      type: string
+                      enum: [sig]
+                      description: |
+                        Always `sig` — JWKS only surfaces signing
+                        keys (no encryption keys in v0.7).
+                    alg:
+                      type: string
+                      enum: [RS256, ES256, HS256]
+                      description: Signing algorithm.
+                    "n":
+                      type: string
+                      description: RSA modulus (base64url). RSA keys only.
+                    "e":
+                      type: string
+                      description: RSA exponent (base64url). RSA keys only.
+                    crv:
+                      type: string
+                      description: EC curve name. EC keys only.
+                    x:
+                      type: string
+                      description: EC public X coord (base64url). EC keys only.
+                    y:
+                      type: string
+                      description: EC public Y coord (base64url). EC keys only.
+          examples:
+            single_rsa_key:
+              summary: One active RSA key (most common shape)
+              value:
+                keys:
+                  - kty: RSA
+                    kid: env_acme_test_1
+                    use: sig
+                    alg: RS256
+                    n: 0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw
+                    e: AQAB
+            ec_plus_rotated_rsa:
+              summary: Active EC key + rotated RSA still in grace
+              value:
+                keys:
+                  - kty: EC
+                    kid: env_acme_test_2
+                    use: sig
+                    alg: ES256
+                    crv: P-256
+                    x: f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU
+                    y: x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0
+                  - kty: RSA
+                    kid: env_acme_test_1
+                    use: sig
+                    alg: RS256
+                    n: 0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw
+                    e: AQAB

--- a/paths/fapi/well-known-openid-configuration.yaml
+++ b/paths/fapi/well-known-openid-configuration.yaml
@@ -1,0 +1,168 @@
+get:
+  operationId: getOpenidConfiguration
+  summary: OIDC discovery document
+  description: |
+    OpenID Connect Discovery 1.0 §4 metadata document. Public,
+    unauthenticated. Cached for one hour (`Cache-Control: public,
+    max-age=3600`).
+
+    The document is per-environment — its `issuer` and endpoint
+    URLs all point at the calling env's FAPI host
+    (`https://<env_slug>.authn.sh`). Clients can resolve the full
+    OAuth provider mode surface from this single document.
+  tags: [JWKS / OIDC]
+  security: []
+  responses:
+    "200":
+      description: The discovery document.
+      headers:
+        Cache-Control:
+          description: Always `public, max-age=3600`.
+          schema:
+            type: string
+            const: public, max-age=3600
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - issuer
+              - authorization_endpoint
+              - token_endpoint
+              - userinfo_endpoint
+              - jwks_uri
+              - scopes_supported
+              - response_types_supported
+              - grant_types_supported
+              - subject_types_supported
+              - id_token_signing_alg_values_supported
+              - token_endpoint_auth_methods_supported
+              - code_challenge_methods_supported
+            additionalProperties: true
+            properties:
+              issuer:
+                type: string
+                format: uri
+                description: |
+                  Environment-scoped issuer URL —
+                  `https://<env_slug>.authn.sh`. Matches the `iss`
+                  claim on every ID token.
+              authorization_endpoint:
+                type: string
+                format: uri
+                description: |
+                  Always `<issuer>/oauth/authorize` (OA-3).
+              token_endpoint:
+                type: string
+                format: uri
+                description: |
+                  Always `<issuer>/oauth/token` (OA-4).
+              userinfo_endpoint:
+                type: string
+                format: uri
+                description: |
+                  Always `<issuer>/oauth/userinfo`.
+              jwks_uri:
+                type: string
+                format: uri
+                description: |
+                  Always `<issuer>/.well-known/jwks.json`. The same
+                  JWKS surfaces both the env's session-signing
+                  keys and the IdP-mode signing keys (default:
+                  same key set; operators that want a separate
+                  IdP-mode key configure it per env post-v0.7).
+              introspection_endpoint:
+                type: string
+                format: uri
+                description: |
+                  RFC 7662 token introspection endpoint —
+                  `<issuer>/oauth/token_info` (OA-4). Not part of
+                  OIDC core but advertised for discovery
+                  convenience.
+              scopes_supported:
+                type: array
+                items:
+                  type: string
+                description: |
+                  Standard OIDC scopes plus any env-registered
+                  custom scopes (`<env>.<name>`).
+                examples:
+                  - ["openid", "profile", "email", "phone", "address", "offline_access"]
+              response_types_supported:
+                type: array
+                items:
+                  type: string
+                description: Only `code` is supported in v0.7.
+                examples:
+                  - ["code"]
+              grant_types_supported:
+                type: array
+                items:
+                  type: string
+                description: Authorization-code + refresh-token.
+                examples:
+                  - ["authorization_code", "refresh_token"]
+              subject_types_supported:
+                type: array
+                items:
+                  type: string
+                description: Only `public` (one `sub` per user across all apps).
+                examples:
+                  - ["public"]
+              id_token_signing_alg_values_supported:
+                type: array
+                items:
+                  type: string
+                description: |
+                  Algorithms surfaced on the JWKS. Default
+                  `[RS256]`; envs with custom signing keys may
+                  surface additional algorithms.
+                examples:
+                  - ["RS256"]
+              token_endpoint_auth_methods_supported:
+                type: array
+                items:
+                  type: string
+                examples:
+                  - ["client_secret_basic", "client_secret_post", "none"]
+              code_challenge_methods_supported:
+                type: array
+                items:
+                  type: string
+                description: Only `S256` per RFC 7636 best practice.
+                examples:
+                  - ["S256"]
+              claims_supported:
+                type: array
+                items:
+                  type: string
+                description: |
+                  Claim names that may appear in an ID token or
+                  `/oauth/userinfo` response.
+                examples:
+                  - ["sub", "name", "given_name", "family_name", "preferred_username", "picture", "updated_at", "email", "email_verified", "phone_number", "phone_number_verified", "nonce", "aud", "iss", "iat", "exp"]
+              service_documentation:
+                type: string
+                format: uri
+                description: |
+                  Link to the human-readable docs for authn.sh's
+                  OAuth provider mode.
+          examples:
+            production:
+              summary: Production env discovery document
+              value:
+                issuer: https://acme.authn.sh
+                authorization_endpoint: https://acme.authn.sh/oauth/authorize
+                token_endpoint: https://acme.authn.sh/oauth/token
+                userinfo_endpoint: https://acme.authn.sh/oauth/userinfo
+                jwks_uri: https://acme.authn.sh/.well-known/jwks.json
+                introspection_endpoint: https://acme.authn.sh/oauth/token_info
+                scopes_supported: [openid, profile, email, phone, address, offline_access]
+                response_types_supported: [code]
+                grant_types_supported: [authorization_code, refresh_token]
+                subject_types_supported: [public]
+                id_token_signing_alg_values_supported: [RS256]
+                token_endpoint_auth_methods_supported: [client_secret_basic, client_secret_post, none]
+                code_challenge_methods_supported: [S256]
+                claims_supported: [sub, name, given_name, family_name, preferred_username, picture, updated_at, email, email_verified, phone_number, phone_number_verified, nonce, aud, iss, iat, exp]
+                service_documentation: https://authn.sh/docs/oauth-provider-mode


### PR DESCRIPTION
Closes #98

## Summary

- `GET /oauth/userinfo` (OIDC Core §5.3) — bearer-authenticated UserInfo. Scope → claim mapping documented inline: `openid` → `sub`; `profile` → `name`/`given_name`/`family_name`/`preferred_username`/`picture`/`updated_at`; `email` → `email`/`email_verified`; `phone` → `phone_number`/`phone_number_verified`; custom (`<env>.<name>`) scopes surfaced at the top level. `Cache-Control: no-store` per §5.3.3.
- `GET /.well-known/openid-configuration` — OIDC Discovery 1.0 §4 document. Per-env `issuer` + endpoints (`authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, `introspection_endpoint`, `jwks_uri`). `scopes_supported`, `response_types_supported: [code]`, `grant_types_supported: [authorization_code, refresh_token]`, `code_challenge_methods_supported: [S256]`, `subject_types_supported: [public]`. `Cache-Control: public, max-age=3600`.
- `GET /.well-known/jwks.json` — RFC 7517 JWKS for the env (active + rotated-in-grace keys). Documented as the surface for both session-signing and IdP-mode signing keys; verifiers must match by `kid`. `Cache-Control: public, max-age=3600`.

## Test plan

- [x] `npm run lint:fapi` passes.
- [x] `npm run bundle:fapi` succeeds.
- [x] Discovery document example matches the OIDC discovery spec (issuer + endpoint + metadata fields).