### PR TITLE
Add display_config.redirects to FAPI Environment (#286)

### DIFF
--- a/components/schemas/Environment.yaml
+++ b/components/schemas/Environment.yaml
@@ -148,6 +148,30 @@ properties:
         type: object
         description: Hex colors / radii. Free-form in v0.1.
         additionalProperties: true
+      redirects:
+        type: object
+        description: |
+          Per-environment SDK fallback URLs. The SDK uses these when the
+          tenant app doesn't supply an override at runtime (afterSignInUrl,
+          afterSignUpUrl, etc). Each field is nullable; `null` means
+          "no fallback set — fall back to the SDK-level default."
+        additionalProperties: false
+        properties:
+          after_sign_up:
+            type: [string, "null"]
+            format: uri
+          after_sign_in:
+            type: [string, "null"]
+            format: uri
+          home:
+            type: [string, "null"]
+            format: uri
+          after_create_organization:
+            type: [string, "null"]
+            format: uri
+          after_leave_organization:
+            type: [string, "null"]
+            format: uri
   user_settings:
     type: object
     description: |


### PR DESCRIPTION
## Summary

Allows the new \`redirects\` block under \`display_config\` on the FAPI Environment schema.

The dashboard now persists 5 SDK fallback URLs under \`user_settings.redirects\` (authn-sh/authn#286). \`EnvironmentResource\` surfaces them under \`display_config.redirects\` so the SDK can pick them up at boot. \`display_config\` had \`additionalProperties: false\`, so the contract validator (Pest fixture) refused the new field until this lands.

## Fields

- \`after_sign_up\` — fallback for successful sign-up
- \`after_sign_in\` — fallback for successful sign-in
- \`home\` — destination behind the brand logo on hosted pages
- \`after_create_organization\` — destination after creating an org
- \`after_leave_organization\` — destination after leaving an org

All five are nullable (\`null\` = no fallback set).

## Test plan
- [x] Bundle validates (\`npx @redocly/cli bundle fapi.yaml\` clean)
- [ ] authn-sh/authn#295 (the consumer PR) flips from red to green once this merges